### PR TITLE
Don't urldecode the output from http_build_query

### DIFF
--- a/library/Imbo/Http/ParameterContainer.php
+++ b/library/Imbo/Http/ParameterContainer.php
@@ -114,6 +114,7 @@ class ParameterContainer implements ParameterContainerInterface {
      * @see Imbo\Http\ParameterContainerInterface::asString()
      */
     public function asString() {
-        return preg_replace('/\[\d+\]/', '[]', urldecode(http_build_query($this->parameters)));
+        // Translate %5B and %5D back to [] as the client uses [] when generating the access token
+        return preg_replace('/%5B\d+%5D/', '[]', http_build_query($this->parameters));
     }
 }

--- a/tests/Imbo/Http/ParameterContainerTest.php
+++ b/tests/Imbo/Http/ParameterContainerTest.php
@@ -96,6 +96,7 @@ class ParameterContainerTest extends \PHPUnit_Framework_TestCase {
 
     public function getParameters() {
         return array(
+            array(array('foo' => '', 'bar' => 'foo'), 'foo=&bar=foo'),
             array(array('foo' => 'bar', 'bar' => 'foo'), 'foo=bar&bar=foo'),
             array(array('key' => 'value', 'keys' => array(1, 2, 3, 'four'), 'foo' => 'bar'), 'key=value&keys[]=1&keys[]=2&keys[]=3&keys[]=four&foo=bar'),
         );


### PR DESCRIPTION
When running urldecode on the output from http_build_query Imbo ends up generating the access token in a different fashion than the client. We also need to translate the brackets correctly.
