### PR TITLE
Imagick::newImage() does not support null as background parameter.

### DIFF
--- a/library/Imbo/Image/Transformation/Canvas.php
+++ b/library/Imbo/Image/Transformation/Canvas.php
@@ -94,11 +94,11 @@ class Canvas extends Transformation implements TransformationInterface {
     private $y = 0;
 
     /**
-     * Background color of the canvas
+     * Background color of the canvas. Defaults to white.
      *
      * @var string
      */
-    private $bg;
+    private $bg = '#fff';
 
     /**
      * Class constructor
@@ -136,11 +136,9 @@ class Canvas extends Transformation implements TransformationInterface {
      */
     public function applyToImage(ImageInterface $image) {
         try {
-            $background = $this->bg ?: '#fff';
-
             // Create a new canvas
             $canvas = new Imagick();
-            $canvas->newImage($this->width, $this->height, $background);
+            $canvas->newImage($this->width, $this->height, $this->bg);
             $canvas->setImageFormat($image->getExtension());
 
             // Load existing image


### PR DESCRIPTION
Defaults to white(#fff) if it's not explicitly set.
