### PR TITLE
Specify extensions for the resources

### DIFF
--- a/library/Imbo/EventListener/ImageTransformationCache.php
+++ b/library/Imbo/EventListener/ImageTransformationCache.php
@@ -111,7 +111,7 @@ class ImageTransformationCache extends Listener implements ListenerInterface {
 
         $publicKey          = $request->getPublicKey();
         $imageIdentifier    = $request->getImageIdentifier();
-        $imageExtension     = $request->getImageExtension();
+        $imageExtension     = $request->getExtension();
         $hasTransformations = $request->getQuery()->has('t') || $imageExtension;
         $url                = $request->getUrl();
 

--- a/library/Imbo/FrontController.php
+++ b/library/Imbo/FrontController.php
@@ -107,10 +107,10 @@ class FrontController {
         // Possible patterns to match where the most accessed match is placed first
         $routes = array(
             ResourceInterface::IMAGE    => '#^/users/(?<publicKey>[a-zA-Z0-9]{3,})/images/(?<imageIdentifier>[a-f0-9]{32})(/|.(?<extension>gif|jpg|png))?$#',
-            ResourceInterface::STATUS   => '#^/status/?$#',
-            ResourceInterface::IMAGES   => '#^/users/(?<publicKey>[a-zA-Z0-9]{3,})/images/?$#',
-            ResourceInterface::METADATA => '#^/users/(?<publicKey>[a-zA-Z0-9]{3,})/images/(?<imageIdentifier>[a-f0-9]{32})(/|.(?<extension>gif|jpg|png)/)meta/?$#',
-            ResourceInterface::USER     => '#^/users/(?<publicKey>[a-zA-Z0-9]{3,})/?$#',
+            ResourceInterface::STATUS   => '#^/status(/|(\.(?<extension>json|html|xml)))?$#',
+            ResourceInterface::IMAGES   => '#^/users/(?<publicKey>[a-zA-Z0-9]{3,})/images(/|(\.(?<extension>json|html|xml)))?$#',
+            ResourceInterface::METADATA => '#^/users/(?<publicKey>[a-zA-Z0-9]{3,})/images/(?<imageIdentifier>[a-f0-9]{32})/meta(/|\.(?<extension>json|html|xml))?$#',
+            ResourceInterface::USER     => '#^/users/(?<publicKey>[a-zA-Z0-9]{3,})(/|\.(?<extension>json|html|xml))?$#',
         );
 
         // Initialize matches
@@ -140,7 +140,7 @@ class FrontController {
         }
 
         if (isset($matches['extension'])) {
-            $request->setImageExtension($matches['extension']);
+            $request->setExtension($matches['extension']);
         }
 
         // Append "Resource" to the resource name to match the entry in the container

--- a/library/Imbo/Http/Request/Request.php
+++ b/library/Imbo/Http/Request/Request.php
@@ -112,11 +112,11 @@ class Request implements RequestInterface {
     private $rawData;
 
     /**
-     * The current image extension (if any)
+     * The current extension (if any)
      *
      * @var string
      */
-    private $imageExtension;
+    private $extension;
 
     /**
      * The currently requested resorce name (as defined by the constants in
@@ -350,17 +350,17 @@ class Request implements RequestInterface {
     }
 
     /**
-     * @see Imbo\Http\Request\RequestInterface::getImageExtension()
+     * @see Imbo\Http\Request\RequestInterface::getExtension()
      */
-    public function getImageExtension() {
-        return $this->imageExtension;
+    public function getExtension() {
+        return $this->extension;
     }
 
     /**
-     * @see Imbo\Http\Request\RequestInterface::setImageExtension()
+     * @see Imbo\Http\Request\RequestInterface::setExtension()
      */
-    public function setImageExtension($extension) {
-        $this->imageExtension = $extension;
+    public function setExtension($extension) {
+        $this->extension = $extension;
 
         return $this;
     }

--- a/library/Imbo/Http/Request/RequestInterface.php
+++ b/library/Imbo/Http/Request/RequestInterface.php
@@ -175,19 +175,19 @@ interface RequestInterface {
     function getRealImageIdentifier();
 
     /**
-     * Get the current image extension (if any)
+     * Get the current requested extension (if any)
      *
      * @return string|null
      */
-    function getImageExtension();
+    function getExtension();
 
     /**
-     * Set the image extension
+     * Set the extension requested
      *
-     * @param string $extension The image extension to set
+     * @param string $extension The extension to set
      * @return Imbo\Http\Request\RequestInterface
      */
-    function setImageExtension($extension);
+    function setExtension($extension);
 
     /**
      * Get the current HTTP method

--- a/tests/Imbo/UnitTest/FrontControllerTest.php
+++ b/tests/Imbo/UnitTest/FrontControllerTest.php
@@ -135,7 +135,7 @@ class FrontControllerTest extends \PHPUnit_Framework_TestCase {
         $request->expects($this->once())->method('getPath')->will($this->returnValue($path));
         $request->expects($this->once())->method('setPublicKey')->with($publicKey);
         $request->expects($this->once())->method('setImageIdentifier')->with($imageIdentifier);
-        $request->expects($this->once())->method('setImageExtension')->with('jpg');
+        $request->expects($this->once())->method('setExtension')->with('jpg');
 
         $this->assertInstanceOf('Imbo\Resource\Image', $method->invoke($this->controller, $request));
     }

--- a/tests/Imbo/UnitTest/Http/Request/RequestTest.php
+++ b/tests/Imbo/UnitTest/Http/Request/RequestTest.php
@@ -118,15 +118,15 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @covers Imbo\Http\Request\Request::__construct
-     * @covers Imbo\Http\Request\Request::getImageExtension
-     * @covers Imbo\Http\Request\Request::setImageExtension
+     * @covers Imbo\Http\Request\Request::getExtension
+     * @covers Imbo\Http\Request\Request::setExtension
      */
-    public function testSetGetImageExtension() {
+    public function testSetGetExtension() {
         $request = new Request();
         $extension = 'gif';
-        $this->assertNull($request->getImageExtension());
-        $this->assertSame($request, $request->setImageExtension($extension));
-        $this->assertSame($extension, $request->getImageExtension());
+        $this->assertNull($request->getExtension());
+        $this->assertSame($request, $request->setExtension($extension));
+        $this->assertSame($extension, $request->getExtension());
     }
 
     /**


### PR DESCRIPTION
Implemented support for specifying extensions to all resources. The current available extensions are:
- html
- json
- xml

If no extensions is specified Imbo will try to find the best match based in the Accept headers from the client.
