### PR TITLE
Drop content negotiation if a specific type has been requested

### DIFF
--- a/library/Imbo/FrontController.php
+++ b/library/Imbo/FrontController.php
@@ -61,12 +61,12 @@ class FrontController {
      * @var array
      */
     static private $supportedHttpMethods = array(
-        RequestInterface::METHOD_GET     => true,
-        RequestInterface::METHOD_POST    => true,
-        RequestInterface::METHOD_PUT     => true,
-        RequestInterface::METHOD_HEAD    => true,
-        RequestInterface::METHOD_DELETE  => true,
-        RequestInterface::METHOD_BREW    => true,
+        RequestInterface::METHOD_GET    => true,
+        RequestInterface::METHOD_POST   => true,
+        RequestInterface::METHOD_PUT    => true,
+        RequestInterface::METHOD_HEAD   => true,
+        RequestInterface::METHOD_DELETE => true,
+        RequestInterface::METHOD_BREW   => true,
     );
 
     /**
@@ -182,12 +182,16 @@ class FrontController {
         $resource = $this->resolveResource($request);
 
         // Add some response headers
-        $response->getHeaders()
-            // Inform the user agent of which methods are allowed against this resource
-            ->set('Allow', implode(', ', $resource->getAllowedMethods()))
+        $responseHeaders = $response->getHeaders();
 
-            // Vary on the Accept header as Imbo supports several content types
-            ->set('Vary', 'Accept');
+        // Inform the user agent of which methods are allowed against this resource
+        $responseHeaders->set('Allow', implode(', ', $resource->getAllowedMethods()));
+
+        // Add Accept to Vary if the client has not specified a specific extension, in which we
+        // won't do any content negotiation at all.
+        if (!$request->getExtension()) {
+            $responseHeaders->set('Vary', 'Accept');
+        }
 
         // Fetch the real image identifier (PUT only) or the one from the URL (if present)
         if (($identifier = $request->getRealImageIdentifier()) || ($identifier = $request->getImageIdentifier())) {


### PR DESCRIPTION
If the user agent specifies a specific content type in the URI (for instance `GET /users/<user>/images/<image>.jpg` or `GET /status.json`) Imbo will skip the content negotiation part completely. It will also remove `Accept` from the `Vary` response header if this is the case.

If the user agent specifies a resource without a specific extension (for instance `GET /users/<user>/images/<image>` or `GET /status`) Imbo will pick the best match based on the `Accept` headers found in the request.
