### PR TITLE
Errors on an image resource with explicit content type provided fails to render

### DIFF
--- a/library/Imbo/Http/Response/ResponseWriter.php
+++ b/library/Imbo/Http/Response/ResponseWriter.php
@@ -107,6 +107,7 @@ class ResponseWriter implements ResponseWriterInterface {
         if ($extension = $request->getExtension()) {
             // The user agent wants a specific type. Skip content negotiation completely
             $mime = $this->defaultMimeType;
+
             if (isset($this->extensionsToMimeType[$extension])) {
                 $mime = $this->extensionsToMimeType[$extension];
             }


### PR DESCRIPTION
This fix simply uses the default mime type response writer if the explicit file type used does not have an associated response writer.

On the image resource, it makes more sense this way, as providing a .jpg or .png format is common, and it makes debugging easier to actually see the error message generated when something goes wrong (incorrect access token, for example).

On resources other than an image, it might make more sense to throw a 406 to let the user know that the explicit content type provided does not have an associated formatter.

Not sure if there is a more optimal solution to the problem - feel free to reject if a better solution is found.
