### PR TITLE
Alternate way of specifying event listeners in the configuration

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -97,7 +97,8 @@ return array(
     /**
      * Event listeners
      *
-     * Each element in this array is another array with the following keys:
+     * Each element in this array is either an instance of an event listener, or another array with
+     * the following keys:
      *
      * - listener
      * - events
@@ -117,6 +118,7 @@ return array(
      * Example of how to add different listeners:
      *
      * 'eventListeners' => array(
+     *   new EventListener\Authenticate(),
      *   array(
      *     'listener' => new Imbo\EventListener\AccessToken(),
      *   ),
@@ -138,12 +140,8 @@ return array(
      * @var array
      */
     'eventListeners' => array(
-        array(
-            'listener' => new EventListener\Authenticate(),
-        ),
-        array(
-            'listener' => new EventListener\AccessToken(),
-        ),
+        new EventListener\Authenticate(),
+        new EventListener\AccessToken(),
     ),
 
     /**


### PR DESCRIPTION
This PR implements support for specifying instances of event listeners in the configuration without having to wrap them in another array with a listener key.

Both these examples will now do the same:

``` php
<?php
namespace Imbo;

return array(
    // ...
    'eventListeners' => array(
        array(
            'listener' => new EventListener\Authenticate(),
        ),
    ),
);
```

and

``` php
<?php
namespace Imbo;

return array(
    // ...
    'eventListeners' => array(
        new EventListener\Authenticate(),
    ),
);
```
