### PR TITLE
Fix XML and HTML formatter with regards to the status resource

### DIFF
--- a/library/Imbo/Http/Response/Formatter/HTML.php
+++ b/library/Imbo/Http/Response/Formatter/HTML.php
@@ -105,6 +105,12 @@ DOCUMENT;
      * @return string Returns an HTML string
      */
     private function formatError(array $data) {
+        if (!isset($data['error'])) {
+            // If the $data array does not have an error key, this is simply the status resource
+            // reporting that the system is not stable, which is not a regular error
+            return $this->formatStatus($data);
+        }
+
         $title = 'Error';
         $body = <<<ERROR
 <dl>
@@ -129,15 +135,18 @@ ERROR;
      * @return string Returns an HTML string
      */
     private function formatStatus(array $data) {
+        $database = (int) $data['database'];
+        $storage = (int) $data['storage'];
+
         $title = 'Status';
         $body = <<<STATUS
 <dl>
   <dt>Date</dt>
   <dd>{$data['date']}</dd>
   <dt>Database</dt>
-  <dd>{$data['database']}</dd>
+  <dd>$database</dd>
   <dt>Storage</dt>
-  <dd>{$data['storage']}</dd>
+  <dd>$storage</dd>
 </dl>
 STATUS;
 

--- a/library/Imbo/Http/Response/Formatter/XML.php
+++ b/library/Imbo/Http/Response/Formatter/XML.php
@@ -126,6 +126,12 @@ class XML implements FormatterInterface {
      * @return string Returns an XML string
      */
     private function formatError(array $data) {
+        if (!isset($data['error'])) {
+            // If the $data array does not have an error key, this is simply the status resource
+            // reporting that the system is not stable, which is not a regular error
+            return $this->formatStatus($data);
+        }
+
         $writer = $this->getWriter();
         $this->writeSimpleDocument($writer, 'error', $data['error']);
 
@@ -139,6 +145,9 @@ class XML implements FormatterInterface {
      * @return string Returns an XML string
      */
     private function formatStatus(array $data) {
+        $data['database'] = (int) $data['database'];
+        $data['storage'] = (int) $data['storage'];
+
         $writer = $this->getWriter();
         $this->writeSimpleDocument($writer, 'status', $data);
 


### PR DESCRIPTION
This PR fixes a bug in the XML and HTML formatters that occurs when the status resource reports that either the database or the storage is down. Fixes #90.
