### PR TITLE
Replace an image that exists when adding

### DIFF
--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -303,7 +303,7 @@ When using this driver you need to create a table in the `DBMS`_ you choose to u
         publicKey TEXT NOT NULL,
         imageIdentifier TEXT NOT NULL,
         data BLOB NOT NULL,
-        created INTEGER NOT NULL,
+        updated INTEGER NOT NULL,
         PRIMARY KEY (publicKey,imageIdentifier)
     )
 

--- a/library/Imbo/Database/DatabaseInterface.php
+++ b/library/Imbo/Database/DatabaseInterface.php
@@ -52,7 +52,8 @@ interface DatabaseInterface {
     /**
      * Insert a new image
      *
-     * This method will insert a new image into the database
+     * This method will insert a new image into the database. If the same image already exists,
+     * just update the "updated" information.
      *
      * @param string $publicKey The public key of the user
      * @param string $imageIdentifier Image identifier
@@ -165,4 +166,14 @@ interface DatabaseInterface {
      * @throws DatabaseException
      */
     function getImageMimeType($publicKey, $imageIdentifier);
+
+    /**
+     * Check if an image already exists
+     *
+     * @param string $publicKey The public key of the user who owns the image
+     * @param string $imageIdentifier The image identifier
+     * @return boolean Returns true of the image exists, false otherwise
+     * @throws DatabaseException
+     */
+    function imageExists($publicKey, $imageIdentifier);
 }

--- a/library/Imbo/EventListener/StorageOperations.php
+++ b/library/Imbo/EventListener/StorageOperations.php
@@ -113,6 +113,7 @@ class StorageOperations implements ContainerAware, ListenerInterface {
         $blob = $image->getBlob();
 
         try {
+            $exists = $event->getStorage()->imageExists($publicKey, $imageIdentifier);
             $event->getStorage()->store(
                 $publicKey,
                 $imageIdentifier,
@@ -126,5 +127,7 @@ class StorageOperations implements ContainerAware, ListenerInterface {
 
             throw $e;
         }
+
+        $event->getResponse()->setStatusCode($exists ? 200 : 201);
     }
 }

--- a/library/Imbo/Resource/Image.php
+++ b/library/Imbo/Resource/Image.php
@@ -83,8 +83,7 @@ class Image implements ResourceInterface, ListenerInterface {
         $request = $event->getRequest();
         $response = $event->getResponse();
 
-        $response->setStatusCode(201)
-                 ->setBody(array('imageIdentifier' => $request->getImage()->getChecksum()));
+        $response->setBody(array('imageIdentifier' => $request->getImage()->getChecksum()));
     }
 
     /**

--- a/library/Imbo/Storage/StorageInterface.php
+++ b/library/Imbo/Storage/StorageInterface.php
@@ -55,6 +55,8 @@ interface StorageInterface {
      * actual storage driver. If an error occurs the driver should throw an
      * Imbo\Exception\StorageException exception.
      *
+     * If the image already exists, simply overwrite it.
+     *
      * @param string $publicKey The public key of the user
      * @param string $imageIdentifier The image identifier
      * @param string $imageData The image data to store
@@ -103,4 +105,14 @@ interface StorageInterface {
      * @return boolean
      */
     function getStatus();
+
+    /**
+     * See if the image already exists
+     *
+     * @param string $publicKey The public key of the user
+     * @param string $imageIdentifier Image identifier
+     * @return DateTime Returns an instance of DateTime
+     * @throws StorageException
+     */
+    function imageExists($publicKey, $imageIdentifier);
 }

--- a/tests/Imbo/IntegrationTest/Database/DatabaseTests.php
+++ b/tests/Imbo/IntegrationTest/Database/DatabaseTests.php
@@ -112,14 +112,13 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($this->driver->load($this->publicKey, $this->imageIdentifier, $image));
     }
 
-    /**
-     * @expectedException Imbo\Exception\DatabaseException
-     * @expectedExceptionCode 400
-     * @expectedExceptionMessage Image already exists
-     */
     public function testStoreSameImageTwice() {
         $this->assertTrue($this->driver->insertImage($this->publicKey, $this->imageIdentifier, $this->image));
-        $this->driver->insertImage($this->publicKey, $this->imageIdentifier, $this->image);
+        $lastModified1 = $this->driver->getLastModified($this->publicKey, $this->imageIdentifier);
+        sleep(1);
+        $this->assertTrue($this->driver->insertImage($this->publicKey, $this->imageIdentifier, $this->image));
+        $lastModified2 = $this->driver->getLastModified($this->publicKey, $this->imageIdentifier);
+        $this->assertTrue($lastModified2 > $lastModified1);
     }
 
     /**
@@ -370,5 +369,11 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
      */
     public function testGetMimeTypeWhenImageDoesNotExist() {
         $this->driver->getImageMimeType($this->publicKey, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    }
+
+    public function testCanCheckIfImageAlreadyExists() {
+        $this->assertFalse($this->driver->imageExists($this->publicKey, $this->imageIdentifier));
+        $this->driver->insertImage($this->publicKey, $this->imageIdentifier, $this->image);
+        $this->assertTrue($this->driver->imageExists($this->publicKey, $this->imageIdentifier));
     }
 }

--- a/tests/Imbo/IntegrationTest/Storage/DoctrineTest.php
+++ b/tests/Imbo/IntegrationTest/Storage/DoctrineTest.php
@@ -77,7 +77,7 @@ class DoctrineTest extends StorageTests {
                 publicKey TEXT NOT NULL,
                 imageIdentifier TEXT NOT NULL,
                 data BLOB NOT NULL,
-                created INTEGER NOT NULL,
+                updated INTEGER NOT NULL,
                 PRIMARY KEY (publicKey,imageIdentifier)
             )
         ");

--- a/tests/Imbo/IntegrationTest/Storage/StorageTests.php
+++ b/tests/Imbo/IntegrationTest/Storage/StorageTests.php
@@ -88,14 +88,15 @@ abstract class StorageTests extends \PHPUnit_Framework_TestCase {
         $this->assertSame($this->imageData, $this->driver->getImage($this->publicKey, $this->imageIdentifier));
     }
 
-    /**
-     * @expectedException Imbo\Exception\StorageException
-     * @expectedExceptionCode 400
-     * @expectedExceptionMessage Image already exists
-     */
     public function testStoreSameImageTwice() {
         $this->assertTrue($this->driver->store($this->publicKey, $this->imageIdentifier, $this->imageData));
-        $this->driver->store($this->publicKey, $this->imageIdentifier, $this->imageData);
+        $lastModified1 = $this->driver->getLastModified($this->publicKey, $this->imageIdentifier);
+        clearstatcache();
+        sleep(1);
+        $this->assertTrue($this->driver->store($this->publicKey, $this->imageIdentifier, $this->imageData));
+        $lastModified2 = $this->driver->getLastModified($this->publicKey, $this->imageIdentifier);
+
+        $this->assertTrue($lastModified2 > $lastModified1);
     }
 
     /**
@@ -135,5 +136,11 @@ abstract class StorageTests extends \PHPUnit_Framework_TestCase {
     public function testGetLastModified() {
         $this->assertTrue($this->driver->store($this->publicKey, $this->imageIdentifier, $this->imageData));
         $this->assertInstanceOf('DateTime', $this->driver->getLastModified($this->publicKey, $this->imageIdentifier));
+    }
+
+    public function testCanCheckIfImageAlreadyExists() {
+        $this->assertFalse($this->driver->imageExists($this->publicKey, $this->imageIdentifier));
+        $this->driver->store($this->publicKey, $this->imageIdentifier, $this->imageData);
+        $this->assertTrue($this->driver->imageExists($this->publicKey, $this->imageIdentifier));
     }
 }

--- a/tests/Imbo/UnitTest/Database/MongoDBTest.php
+++ b/tests/Imbo/UnitTest/Database/MongoDBTest.php
@@ -135,6 +135,26 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
     public function testThrowsExceptionWhenMongoFailsDuringInsertImage() {
         $this->collection->expects($this->once())
                          ->method('findOne')
+                         ->will($this->returnValue(null));
+        $this->collection->expects($this->once())
+                         ->method('insert')
+                         ->will($this->throwException(new MongoException()));
+
+        $this->driver->insertImage('key', 'identifier', $this->getMock('Imbo\Image\Image'));
+    }
+
+    /**
+     * @covers Imbo\Database\MongoDB::insertImage
+     * @expectedException Imbo\Exception\DatabaseException
+     * @expectedExceptionMessage Unable to save image data
+     * @expectedExceptionCode 500
+     */
+    public function testThrowsExceptionWhenMongoFailsDuringInsertImageAndImageAlreadyExists() {
+        $this->collection->expects($this->once())
+                         ->method('findOne')
+                         ->will($this->returnValue(array('some' => 'data')));
+        $this->collection->expects($this->once())
+                         ->method('update')
                          ->will($this->throwException(new MongoException()));
 
         $this->driver->insertImage('key', 'identifier', $this->getMock('Imbo\Image\Image'));

--- a/tests/Imbo/UnitTest/EventListener/StorageOperationsTest.php
+++ b/tests/Imbo/UnitTest/EventListener/StorageOperationsTest.php
@@ -51,6 +51,7 @@ class StorageOperationsTest extends ListenerTests {
     private $container;
     private $event;
     private $request;
+    private $response;
     private $publicKey = 'key';
     private $imageIdentifier = 'id';
     private $storage;
@@ -62,12 +63,14 @@ class StorageOperationsTest extends ListenerTests {
      */
     public function setUp() {
         $this->container = $this->getMock('Imbo\Container');
+        $this->response = $this->getMock('Imbo\Http\Response\ResponseInterface');
         $this->request = $this->getMock('Imbo\Http\Request\RequestInterface');
         $this->request->expects($this->any())->method('getPublicKey')->will($this->returnValue($this->publicKey));
         $this->request->expects($this->any())->method('getImageIdentifier')->will($this->returnValue($this->imageIdentifier));
         $this->storage = $this->getMock('Imbo\Storage\StorageInterface');
         $this->event = $this->getMock('Imbo\EventManager\EventInterface');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
+        $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getStorage')->will($this->returnValue($this->storage));
 
         $this->listener = new StorageOperations();
@@ -81,6 +84,7 @@ class StorageOperationsTest extends ListenerTests {
         $this->container = null;
         $this->listener = null;
         $this->request = null;
+        $this->response = null;
         $this->storage = null;
         $this->event = null;
     }
@@ -110,14 +114,12 @@ class StorageOperationsTest extends ListenerTests {
         $formatter = $this->getMock('Imbo\Helpers\DateFormatter');
         $formatter->expects($this->once())->method('formatDate')->with($datetime)->will($this->returnValue('some date'));
         $this->container->expects($this->once())->method('get')->with('dateFormatter')->will($this->returnValue($formatter));
-        $response = $this->getMock('Imbo\Http\Response\ResponseInterface');
         $responseHeaders = $this->getMock('Imbo\Http\HeaderContainer');
         $responseHeaders->expects($this->once())->method('set')->with('Last-Modified', 'some date');
-        $response->expects($this->once())->method('getHeaders')->will($this->returnValue($responseHeaders));
+        $this->response->expects($this->once())->method('getHeaders')->will($this->returnValue($responseHeaders));
         $image = $this->getMock('Imbo\Image\Image');
         $image->expects($this->once())->method('setBlob')->with('image data');
-        $response->expects($this->once())->method('getImage')->will($this->returnValue($image));
-        $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
+        $this->response->expects($this->once())->method('getImage')->will($this->returnValue($image));
 
         $this->listener->loadImage($this->event);
     }
@@ -130,7 +132,24 @@ class StorageOperationsTest extends ListenerTests {
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image data'));
         $image->expects($this->once())->method('getChecksum')->will($this->returnValue('checksum'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
+        $this->response->expects($this->once())->method('setStatusCode')->with(201);
         $this->storage->expects($this->once())->method('store')->with($this->publicKey, 'checksum', 'image data');
+        $this->storage->expects($this->once())->method('imageExists')->with($this->publicKey, 'checksum')->will($this->returnValue(false));
+
+        $this->listener->insertImage($this->event);
+    }
+
+    /**
+     * @covers Imbo\EventListener\StorageOperations::insertImage
+     */
+    public function testCanInsertImageThatAlreadyExists() {
+        $image = $this->getMock('Imbo\Image\Image');
+        $image->expects($this->once())->method('getBlob')->will($this->returnValue('image data'));
+        $image->expects($this->once())->method('getChecksum')->will($this->returnValue('checksum'));
+        $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
+        $this->response->expects($this->once())->method('setStatusCode')->with(200);
+        $this->storage->expects($this->once())->method('store')->with($this->publicKey, 'checksum', 'image data');
+        $this->storage->expects($this->once())->method('imageExists')->with($this->publicKey, 'checksum')->will($this->returnValue(true));
 
         $this->listener->insertImage($this->event);
     }

--- a/tests/Imbo/UnitTest/Resource/ImageTest.php
+++ b/tests/Imbo/UnitTest/Resource/ImageTest.php
@@ -98,7 +98,6 @@ class ImageTest extends ResourceTests {
     public function testSupportsHttpPut() {
         $this->manager->expects($this->at(0))->method('trigger')->with('db.image.insert');
         $this->manager->expects($this->at(1))->method('trigger')->with('storage.image.insert');
-        $this->response->expects($this->once())->method('setStatusCode')->with(201)->will($this->returnSelf());
         $image = $this->getMock('Imbo\Image\Image');
         $image->expects($this->once())->method('getChecksum')->will($this->returnValue('id'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));

--- a/tests/Imbo/UnitTest/Storage/FilesystemTest.php
+++ b/tests/Imbo/UnitTest/Storage/FilesystemTest.php
@@ -127,24 +127,6 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Imbo\Exception\StorageException
-     * @expectedExceptionMessage Image already exists
-     * @expectedExceptionCode 400
-     * @covers Imbo\Storage\Filesystem::store
-     */
-    public function testStoreFileTwice() {
-        $imageData = file_get_contents(FIXTURES_DIR . '/image.png');
-        $baseDir = 'someDir';
-
-        // Create the virtual directory
-        vfsStream::setup($baseDir);
-
-        $driver = new Filesystem(array('dataDir' => vfsStream::url($baseDir)));
-        $this->assertTrue($driver->store($this->publicKey, $this->imageIdentifier, $imageData));
-        $driver->store($this->publicKey, $this->imageIdentifier, $imageData);
-    }
-
-    /**
      * @covers Imbo\Storage\Filesystem::store
      */
     public function testStore() {

--- a/tests/Imbo/UnitTest/Storage/GridFSTest.php
+++ b/tests/Imbo/UnitTest/Storage/GridFSTest.php
@@ -98,24 +98,6 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @expectedException Imbo\Exception\StorageException
-     * @expectedExceptionCode 400
-     * @covers Imbo\Storage\GridFS::store
-     * @covers Imbo\Storage\GridFS::imageExists
-     */
-    public function testStoreWhenImageExists() {
-        $file = $this->getMockBuilder('MongoGridFSFile')->disableOriginalConstructor()->getMock();
-
-        $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
-        $cursor->expects($this->once())->method('count')->will($this->returnValue(1));
-        $cursor->expects($this->once())->method('getNext')->will($this->returnValue($file));
-
-        $this->grid->expects($this->once())->method('find')->will($this->returnValue($cursor));
-
-        $this->driver->store($this->publicKey, $this->imageIdentifier, $this->getMock('Imbo\Image\ImageInterface'));
-    }
-
-    /**
      * @covers Imbo\Storage\GridFS::store
      * @covers Imbo\Storage\GridFS::imageExists
      */
@@ -125,26 +107,14 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
         $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
         $cursor->expects($this->once())->method('count')->will($this->returnValue(0));
 
-        $this->grid->expects($this->once())->method('find')->will($this->returnValue($cursor));
-        $this->grid->expects($this->once())->method('storeBytes')->with($data, $this->isType('array'), $this->isType('array'))->will($this->returnValue($cursor));
-
-        $this->assertTrue($this->driver->store($this->publicKey, $this->imageIdentifier, $data));
-    }
-
-    /**
-     * @expectedException Imbo\Exception\StorageException
-     * @expectedExceptionCode 500
-     * @covers Imbo\Storage\GridFS::store
-     * @covers Imbo\Storage\GridFS::imageExists
-     */
-    public function testStoreWhenMongoThrowsException() {
-        $data = 'some content';
-
-        $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
-        $cursor->expects($this->once())->method('count')->will($this->returnValue(0));
-
-        $this->grid->expects($this->once())->method('find')->will($this->returnValue($cursor));
-        $this->grid->expects($this->once())->method('storeBytes')->will($this->throwException($this->getMock('MongoCursorException')));
+        $this->grid->expects($this->at(0))
+                   ->method('find')
+                   ->with(array(
+                       'publicKey' => $this->publicKey,
+                       'imageIdentifier' => $this->imageIdentifier
+                   ))
+                   ->will($this->returnValue($cursor));
+        $this->grid->expects($this->once())->method('storeBytes')->with($data, $this->isType('array'));
 
         $this->assertTrue($this->driver->store($this->publicKey, $this->imageIdentifier, $data));
     }
@@ -268,7 +238,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
 if (class_exists('MongoGridFSFile')) {
     class TestFile extends MongoGridFSFile {
         public $file = array(
-            'created' => 1334579830,
+            'updated' => 1334579830,
         );
 
         public function __construct() {}


### PR DESCRIPTION
With this PR Imbo will no longer respond with 400 Bad Request if a client tries to add an image that already exists. Instead it will respond with 200 OK with a similar response body as when the image does not exist.

Also added a new method to both the database and storage interfaces that
can be used to check if an image already exists. Closes #109
