### PR TITLE
Use call_user_func so Imbo works on php-5.3 again

### DIFF
--- a/library/Imbo/EventManager/EventManager.php
+++ b/library/Imbo/EventManager/EventManager.php
@@ -151,7 +151,7 @@ class EventManager implements ContainerAware {
                     continue;
                 }
 
-                $callback($event);
+                call_user_func($callback, $event);
 
                 if ($event->propagationIsStopped()) {
                     break;

--- a/tests/Imbo/UnitTest/EventManager/EventManagerTest.php
+++ b/tests/Imbo/UnitTest/EventManager/EventManagerTest.php
@@ -77,13 +77,20 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Callback used in the method below
+     */
+    public function someCallback($event) {
+        echo 3;
+    }
+
+    /**
      * @covers Imbo\EventManager\EventManager::attach
      * @covers Imbo\EventManager\EventManager::trigger
      */
     public function testCanAttachAndExecuteRegularCallbacksInAPrioritizedFashion() {
         $callback1 = function ($event) { echo 1; };
         $callback2 = function ($event) { echo 2; };
-        $callback3 = function ($event) { echo 3; };
+        $callback3 = array($this, 'someCallback');
 
         $this->assertSame(
             $this->manager,


### PR DESCRIPTION
Use `call_user_func($callback, $event);` instead of `$callback($event);` since the latter won't work on PHP <= 5.4 if `$callback` is `array($obj, 'method')`.
