### PR TITLE
Use MongoClient instead of the Mongo class

### DIFF
--- a/library/Imbo/Database/MongoDB.php
+++ b/library/Imbo/Database/MongoDB.php
@@ -34,7 +34,7 @@ namespace Imbo\Database;
 use Imbo\Image\Image,
     Imbo\Resource\Images\Query,
     Imbo\Exception\DatabaseException,
-    Mongo,
+    MongoClient,
     MongoCollection,
     MongoException,
     DateTime;
@@ -50,7 +50,7 @@ use Imbo\Image\Image,
  * - (string) collectionName Name of the collection to store data in. Defaults to 'images'
  * - (string) server The server string to use when connecting to MongoDB. Defaults to
  *                              'mongodb://localhost:27017'
- * - (array) options Options to use when creating the Mongo instance. Defaults to
+ * - (array) options Options to use when creating the MongoClient instance. Defaults to
  *                              array('connect' => true, 'timeout' => 1000).
  *
  * @package Database
@@ -61,16 +61,16 @@ use Imbo\Image\Image,
  */
 class MongoDB implements DatabaseInterface {
     /**
-     * Mongo instance
+     * Mongo client instance
      *
-     * @var \Mongo
+     * @var MongoClient
      */
-    private $mongo;
+    private $mongoClient;
 
     /**
      * The collection instance used by the driver
      *
-     * @var \MongoCollection
+     * @var MongoCollection
      */
     private $collection;
 
@@ -93,16 +93,16 @@ class MongoDB implements DatabaseInterface {
      * Class constructor
      *
      * @param array $params Parameters for the driver
-     * @param \Mongo $mongo Mongo instance
-     * @param \MongoCollection $collection MongoCollection instance
+     * @param MongoClient $client MongoClient instance
+     * @param MongoCollection $collection MongoCollection instance
      */
-    public function __construct(array $params = null, Mongo $mongo = null, MongoCollection $collection = null) {
+    public function __construct(array $params = null, MongoClient $client = null, MongoCollection $collection = null) {
         if ($params !== null) {
             $this->params = array_replace_recursive($this->params, $params);
         }
 
-        if ($mongo !== null) {
-            $this->mongo = $mongo;
+        if ($client !== null) {
+            $this->mongoClient = $client;
         }
 
         if ($collection !== null) {
@@ -394,7 +394,7 @@ class MongoDB implements DatabaseInterface {
      * {@inheritdoc}
      */
     public function getStatus() {
-        return $this->getMongo()->connect();
+        return $this->getMongoClient()->connect();
     }
 
     /**
@@ -432,12 +432,12 @@ class MongoDB implements DatabaseInterface {
     /**
      * Get the mongo collection instance
      *
-     * @return \MongoCollection
+     * @return MongoCollection
      */
     protected function getCollection() {
         if ($this->collection === null) {
             try {
-                $this->collection = $this->getMongo()->selectCollection(
+                $this->collection = $this->getMongoClient()->selectCollection(
                     $this->params['databaseName'],
                     $this->params['collectionName']
                 );
@@ -450,19 +450,19 @@ class MongoDB implements DatabaseInterface {
     }
 
     /**
-     * Get the mongo instance
+     * Get the mongo client instance
      *
-     * @return \Mongo
+     * @return MongoClient
      */
-    protected function getMongo() {
-        if ($this->mongo === null) {
+    protected function getMongoClient() {
+        if ($this->mongoClient === null) {
             try {
-                $this->mongo = new Mongo($this->params['server'], $this->params['options']);
+                $this->mongoClient = new MongoClient($this->params['server'], $this->params['options']);
             } catch (MongoException $e) {
                 throw new DatabaseException('Could not connect to database', 500, $e);
             }
         }
 
-        return $this->mongo;
+        return $this->mongoClient;
     }
 }

--- a/library/Imbo/Storage/GridFS.php
+++ b/library/Imbo/Storage/GridFS.php
@@ -34,6 +34,7 @@ namespace Imbo\Storage;
 use Imbo\Image\Image,
     Imbo\Exception\StorageException,
     Mongo,
+    MongoClient,
     MongoGridFS,
     MongoException,
     DateTime;
@@ -48,7 +49,7 @@ use Imbo\Image\Image,
  * - <pre>(string) databaseName</pre> Name of the database. Defaults to 'imbo_storage'
  * - <pre>(string) server</pre> The server string to use when connecting to MongoDB. Defaults to
  *                              'mongodb://localhost:27017'
- * - <pre>(array) options</pre> Options to use when creating the Mongo instance. Defaults to
+ * - <pre>(array) options</pre> Options to use when creating the Mongo client instance. Defaults to
  *                              array('connect' => true, 'timeout' => 1000).
  *
  * @package Storage
@@ -59,11 +60,11 @@ use Imbo\Image\Image,
  */
 class GridFS implements StorageInterface {
     /**
-     * Mongo instance
+     * Mongo client instance
      *
-     * @var Mongo
+     * @var MongoClient
      */
-    private $mongo;
+    private $mongoClient;
 
     /**
      * The grid instance
@@ -90,16 +91,16 @@ class GridFS implements StorageInterface {
      * Class constructor
      *
      * @param array $params Parameters for the driver
-     * @param Mongo $mongo Mongo instance
+     * @param MongoClient $client Mongo client instance
      * @param MongoGridFS $grid MongoGridFS instance
      */
-    public function __construct(array $params = null, Mongo $mongo = null, MongoGridFS $grid = null) {
+    public function __construct(array $params = null, MongoClient $client = null, MongoGridFS $grid = null) {
         if ($params !== null) {
             $this->params = array_replace_recursive($this->params, $params);
         }
 
-        if ($mongo !== null) {
-            $this->mongo = $mongo;
+        if ($client !== null) {
+            $this->mongoClient = $client;
         }
 
         if ($grid !== null) {
@@ -141,7 +142,9 @@ class GridFS implements StorageInterface {
             throw new StorageException('File not found', 404);
         }
 
-        return $this->getGrid()->delete($file->file['_id']);
+        $this->getGrid()->delete($file->file['_id']);
+
+        return true;
     }
 
     /**
@@ -172,7 +175,7 @@ class GridFS implements StorageInterface {
      * {@inheritdoc}
      */
     public function getStatus() {
-        return $this->getMongo()->connect();
+        return $this->getMongoClient()->connect();
     }
 
     /**
@@ -195,7 +198,7 @@ class GridFS implements StorageInterface {
     protected function getGrid() {
         if ($this->grid === null) {
             try {
-                $database = $this->getMongo()->selectDB($this->params['databaseName']);
+                $database = $this->getMongoClient()->selectDB($this->params['databaseName']);
                 $this->grid = $database->getGridFS();
             } catch (MongoException $e) {
                 throw new StorageException('Could not connect to database', 500, $e);
@@ -206,20 +209,20 @@ class GridFS implements StorageInterface {
     }
 
     /**
-     * Get the mongo instance
+     * Get the mongo client instance
      *
-     * @return Mongo
+     * @return MongoClient
      */
-    protected function getMongo() {
-        if ($this->mongo === null) {
+    protected function getMongoClient() {
+        if ($this->mongoClient === null) {
             try {
-                $this->mongo = new Mongo($this->params['server'], $this->params['options']);
+                $this->mongoClient = new MongoClient($this->params['server'], $this->params['options']);
             } catch (MongoException $e) {
                 throw new StorageException('Could not connect to database', 500, $e);
             }
         }
 
-        return $this->mongo;
+        return $this->mongoClient;
     }
 
     /**

--- a/tests/Imbo/IntegrationTest/Database/MongoDBTest.php
+++ b/tests/Imbo/IntegrationTest/Database/MongoDBTest.php
@@ -32,7 +32,7 @@
 namespace Imbo\IntegrationTest\Database;
 
 use Imbo\Database\MongoDB,
-    Mongo;
+    MongoClient;
 
 /**
  * @package TestSuite\IntegrationTests
@@ -67,12 +67,12 @@ class MongoDBTest extends DatabaseTests {
      * Make sure we have the mongo extension available and drop the test database just in case
      */
     public function setUp() {
-        if (!extension_loaded('mongo')) {
-            $this->markTestSkipped('pecl/mongo is required to run this test');
+        if (!extension_loaded('mongo') || !class_exists('MongoClient')) {
+            $this->markTestSkipped('pecl/mongo >= 1.3.0 is required to run this test');
         }
 
-        $mongo = new Mongo();
-        $mongo->selectDB($this->testDbName)->drop();
+        $client = new MongoClient();
+        $client->selectDB($this->testDbName)->drop();
 
         parent::setUp();
     }
@@ -81,16 +81,16 @@ class MongoDBTest extends DatabaseTests {
      * Drop the test database after each test
      */
     public function tearDown() {
-        if (extension_loaded('mongo')) {
-            $mongo = new Mongo();
-            $mongo->selectDB($this->testDbName)->drop();
+        if (extension_loaded('mongo') && class_exists('MongoClient')) {
+            $client = new MongoClient();
+            $client->selectDB($this->testDbName)->drop();
         }
 
         parent::tearDown();
     }
 
     /**
-     * @covers Imbo\Database\MongoDB::getMongo
+     * @covers Imbo\Database\MongoDB::getMongoClient
      * @expectedException Imbo\Exception\DatabaseException
      * @expectedExceptionMessage Could not connect to database
      * @expectedExceptionCode 500

--- a/tests/Imbo/IntegrationTest/Storage/GridFSTest.php
+++ b/tests/Imbo/IntegrationTest/Storage/GridFSTest.php
@@ -32,7 +32,7 @@
 namespace Imbo\IntegrationTest\Storage;
 
 use Imbo\Storage\GridFS,
-    Mongo;
+    MongoClient;
 
 /**
  * @package TestSuite\IntegrationTests
@@ -60,20 +60,20 @@ class GridFSTest extends StorageTests {
     }
 
     public function setUp() {
-        if (!extension_loaded('mongo')) {
-            $this->markTestSkipped('pecl/mongo is required to run this test');
+        if (!extension_loaded('mongo') || !class_exists('MongoClient')) {
+            $this->markTestSkipped('pecl/mongo >= 1.3.0 is required to run this test');
         }
 
-        $mongo = new Mongo();
-        $mongo->selectDB($this->testDbName)->drop();
+        $client = new MongoClient();
+        $client->selectDB($this->testDbName)->drop();
 
         parent::setUp();
     }
 
     public function tearDown() {
-        if (extension_loaded('mongo')) {
-            $mongo = new Mongo();
-            $mongo->selectDB($this->testDbName)->drop();
+        if (extension_loaded('mongo') && class_exists('MongoClient')) {
+            $client = new MongoClient();
+            $client->selectDB($this->testDbName)->drop();
         }
 
         parent::tearDown();

--- a/tests/Imbo/UnitTest/Storage/GridFSTest.php
+++ b/tests/Imbo/UnitTest/Storage/GridFSTest.php
@@ -33,7 +33,7 @@ namespace Imbo\UnitTest\Storage;
 
 use Imbo\Storage\GridFS,
     DateTime,
-    Mongo,
+    MongoClient,
     MongoGridFS,
     MongoGridFSFile;
 
@@ -57,9 +57,9 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
     private $grid;
 
     /**
-     * @var Mongo
+     * @var MongoClient
      */
-    private $mongo;
+    private $mongoClient;
 
     /**
      * Public key that can be used in tests
@@ -79,13 +79,13 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      * Set up the driver
      */
     public function setUp() {
-        if (!extension_loaded('mongo')) {
-            $this->markTestSkipped('pecl/mongo is required to run this test');
+        if (!extension_loaded('mongo') || !class_exists('MongoClient')) {
+            $this->markTestSkipped('pecl/mongo >= 1.3.0 is required to run this test');
         }
 
         $this->grid = $this->getMockBuilder('MongoGridFS')->disableOriginalConstructor()->getMock();
-        $this->mongo = $this->getMockBuilder('Mongo')->disableOriginalConstructor()->getMock();
-        $this->driver = new GridFS(array(), $this->mongo, $this->grid);
+        $this->mongoClient = $this->getMockBuilder('MongoClient')->disableOriginalConstructor()->getMock();
+        $this->driver = new GridFS(array(), $this->mongoClient, $this->grid);
     }
 
     /**
@@ -93,7 +93,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      */
     public function tearDown() {
         $this->grid = null;
-        $this->mongo = null;
+        $this->mongoClient = null;
         $this->driver = null;
     }
 
@@ -222,7 +222,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Storage\GridFS::getStatus
      */
     public function testGetStatusWhenMongoIsNotConnectable() {
-        $this->mongo->expects($this->once())->method('connect')->will($this->returnValue(false));
+        $this->mongoClient->expects($this->once())->method('connect')->will($this->returnValue(false));
         $this->assertFalse($this->driver->getStatus());
     }
 
@@ -230,7 +230,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Storage\GridFS::getStatus
      */
     public function testGetStatusWhenMongoIsConnectable() {
-        $this->mongo->expects($this->once())->method('connect')->will($this->returnValue(true));
+        $this->mongoClient->expects($this->once())->method('connect')->will($this->returnValue(true));
         $this->assertTrue($this->driver->getStatus());
     }
 }


### PR DESCRIPTION
This PR replaces usage of the Mongo class with MongoClient. After applying this PR Imbo will only work with pecl/mongo >= 1.3.0 if any of the Mongo-related adapters are used.
