### PR TITLE
Skip Behat tests on php < 5.4

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -2,11 +2,10 @@ default:
   context:
     class: ImboContext
     parameters:
-      # URL to use for the functional tests
+      # URL to use for the functional tests with the built in httpd in php-5.4
       url: http://localhost:8888
 
-      # Document root and router used by the built in httpd in php-5.4 if the above URL does not
-      # answer
+      # Document root and router used by the httpd
       documentRoot: public
       router: tests/router.php
   paths:

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -10,9 +10,7 @@
 
 namespace Imbo;
 
-/**
- * Require composer autoloader
- */
+// Require composer autoloader
 require __DIR__ . '/../vendor/autoload.php';
 
 $config = array(

--- a/config/config.testing.php
+++ b/config/config.testing.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo;
+
+// Require composer autoloader
+require __DIR__ . '/../vendor/autoload.php';
+
+return array(
+    'auth' => array('publickey' => 'privatekey'),
+
+    'database' => function() {
+        return new Database\MongoDB(array(
+            'databaseName'   => 'imbo_testing',
+        ));
+    },
+
+    'storage' => function() {
+        return new Storage\GridFS(array(
+            'databaseName' => 'imbo_testing',
+        ));
+    },
+
+    'eventListeners' => array(
+        'auth' => function() {
+            return new EventListener\Authenticate();
+        },
+        'accessToken' => function() {
+            return new EventListener\AccessToken();
+        }
+    ),
+
+    'imageTransformations' => array(
+        'border' => function (array $params) {
+            return new Image\Transformation\Border($params);
+        },
+        'canvas' => function (array $params) {
+            return new Image\Transformation\Canvas($params);
+        },
+        'compress' => function (array $params) {
+            return new Image\Transformation\Compress($params);
+        },
+        'convert' => function (array $params) {
+            return new Image\Transformation\Convert($params);
+        },
+        'crop' => function (array $params) {
+            return new Image\Transformation\Crop($params);
+        },
+        'desaturate' => function (array $params) {
+            return new Image\Transformation\Desaturate();
+        },
+        'flipHorizontally' => function (array $params) {
+            return new Image\Transformation\FlipHorizontally();
+        },
+        'flipVertically' => function (array $params) {
+            return new Image\Transformation\FlipVertically();
+        },
+        'maxSize' => function (array $params) {
+            return new Image\Transformation\MaxSize($params);
+        },
+        'resize' => function (array $params) {
+            return new Image\Transformation\Resize($params);
+        },
+        'rotate' => function (array $params) {
+            return new Image\Transformation\Rotate($params);
+        },
+        'sepia' => function (array $params) {
+            return new Image\Transformation\Sepia($params);
+        },
+        'thumbnail' => function (array $params) {
+            return new Image\Transformation\Thumbnail($params);
+        },
+        'transpose' => function (array $params) {
+            return new Image\Transformation\Transpose();
+        },
+        'transverse' => function (array $params) {
+            return new Image\Transformation\Transverse();
+        },
+    ),
+);

--- a/features/bootstrap/RESTContext.php
+++ b/features/bootstrap/RESTContext.php
@@ -26,7 +26,7 @@ require 'PHPUnit/Framework/Assert/Functions.php';
  */
 class RESTContext extends BehatContext {
     /**
-     * Pid for the optional built-in httpd in php-5.4 that will be used if no other httpd responds
+     * Pid for the built-in httpd in php-5.4
      *
      * @var int
      */
@@ -63,8 +63,7 @@ class RESTContext extends BehatContext {
     }
 
     /**
-     * Try to connect to the url specified in behat.yml. If not successful, start up the built in
-     * httpd in php-5.4 and try to connect to that instead.
+     * Start up the built in httpd in php-5.4
      *
      * @BeforeSuite
      */
@@ -73,20 +72,17 @@ class RESTContext extends BehatContext {
         $url = parse_url($params['url']);
         $port = !empty($url['port']) ? $url['port'] : 80;
 
+        self::$pid = self::startBuiltInHttpd(
+            $url['host'],
+            $port,
+            $params['documentRoot'],
+            $params['router']
+        );
+
+        sleep(1);
+
         if (!self::canConnectToHttpd($url['host'], $port)) {
-            // No connection. Let's try and fire up the built in httpd (requires php-5.4)
-            self::$pid = self::startBuiltInHttpd(
-                $url['host'],
-                $url['port'],
-                $params['documentRoot'],
-                $params['router']
-            );
-
-            sleep(1);
-
-            if (!self::canConnectToHttpd($url['host'], $port)) {
-                throw new RuntimeException('Could not start the built in httpd');
-            }
+            throw new RuntimeException('Could not start the built in httpd');
         }
     }
 

--- a/features/user.feature
+++ b/features/user.feature
@@ -4,15 +4,15 @@ Feature: Imbo provides a user endpoint
     I want to make requests against the user endpoint
 
     Scenario: Request user information using a valid access token
-        Given the user "username" exists with private key "key"
+        Given the user "publickey" exists with private key "privatekey"
         And I include an access token in the query
-        When I request "/users/username.json"
+        When I request "/users/publickey.json"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
 
     Scenario: Request user information without a valid access token
-        Given the user "username" exists with private key "key"
-        When I request "/users/username.json"
+        Given the user "publickey" exists with private key "privatekey"
+        When I request "/users/publickey.json"
         Then I should get a response with "400 Bad Request"
         And the "Content-Type" response header is "application/json"
         And the Imbo error message is "Missing access token" and the error code is "0"

--- a/public/index.php
+++ b/public/index.php
@@ -14,7 +14,7 @@ use Exception as BaseException;
 
 try {
     // Fetch the configuration
-    $configPath = __DIR__ . '/../config/config.default.php';
+    $configPath = defined('IMBO_CONFIG_PATH') ? IMBO_CONFIG_PATH : __DIR__ . '/../config/config.default.php';
 
     $config = require $configPath;
 

--- a/tests/router.php
+++ b/tests/router.php
@@ -18,6 +18,9 @@
  * @package Test suite
  */
 
+// Define a custom configuration file
+define('IMBO_CONFIG_PATH', __DIR__ . '/../config/config.testing.php');
+
 if (file_exists($_SERVER['DOCUMENT_ROOT'] . $_SERVER['SCRIPT_NAME'])) {
     // The file exists, serve the file as is
     return false;


### PR DESCRIPTION
Only run the Behat tests on php-5.4 or above by using the built in httpd.
