### PR TITLE
getStatus does not return false when a connection error occurs

### DIFF
--- a/library/Imbo/Database/MongoDB.php
+++ b/library/Imbo/Database/MongoDB.php
@@ -371,7 +371,11 @@ class MongoDB implements DatabaseInterface {
      * {@inheritdoc}
      */
     public function getStatus() {
-        return $this->getMongo()->connect();
+        try {
+            return $this->getMongo()->connect();
+        } catch (DatabaseException $e) {
+            return false;
+        }
     }
 
     /**

--- a/library/Imbo/Storage/GridFS.php
+++ b/library/Imbo/Storage/GridFS.php
@@ -149,7 +149,11 @@ class GridFS implements StorageInterface {
      * {@inheritdoc}
      */
     public function getStatus() {
-        return $this->getMongo()->connect();
+        try {
+            return $this->getMongo()->connect();
+        } catch (StorageException $e) {
+            return false;
+        }
     }
 
     /**

--- a/tests/Imbo/IntegrationTest/Database/MongoDBTest.php
+++ b/tests/Imbo/IntegrationTest/Database/MongoDBTest.php
@@ -66,15 +66,12 @@ class MongoDBTest extends DatabaseTests {
     }
 
     /**
-     * @covers Imbo\Database\MongoDB::getMongo
-     * @expectedException Imbo\Exception\DatabaseException
-     * @expectedExceptionMessage Could not connect to database
-     * @expectedExceptionCode 500
+     * @covers Imbo\Database\MongoDB::getStatus
      */
-    public function testThrowsExceptionWhenUSingAnInvalidMongodbHostname() {
+    public function testReturnsFalseWhenFetchingStatusAndTheHostnameIsNotCorrect() {
         $db = new MongoDB(array(
             'server' => 'foobar',
         ));
-        $db->getStatus();
+        $this->assertFalse($db->getStatus());
     }
 }

--- a/tests/Imbo/IntegrationTest/Storage/GridFSTest.php
+++ b/tests/Imbo/IntegrationTest/Storage/GridFSTest.php
@@ -54,4 +54,14 @@ class GridFSTest extends StorageTests {
 
         parent::tearDown();
     }
+
+    /**
+     * @covers Imbo\Storage\GridFS::getStatus
+     */
+    public function testReturnsFalseWhenFetchingStatusAndTheHostnameIsNotCorrect() {
+        $storage = new GridFS(array(
+            'server' => 'foobar',
+        ));
+        $this->assertFalse($storage->getStatus());
+    }
 }


### PR DESCRIPTION
Catch the exception and return false when the drivers can't connect to the database.
