### PR TITLE
Removed class level covers annotation from all test cases

### DIFF
--- a/tests/Imbo/IntegrationTest/Cache/APCTest.php
+++ b/tests/Imbo/IntegrationTest/Cache/APCTest.php
@@ -15,7 +15,6 @@ use Imbo\Cache\APC;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Cache\APC
  */
 class APCTest extends CacheTests {
     protected function getDriver() {

--- a/tests/Imbo/IntegrationTest/Cache/MemcachedTest.php
+++ b/tests/Imbo/IntegrationTest/Cache/MemcachedTest.php
@@ -16,7 +16,6 @@ use Imbo\Cache\Memcached,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Cache\Memcached
  */
 class MemcachedTest extends CacheTests {
     protected function getDriver() {

--- a/tests/Imbo/IntegrationTest/Database/DoctrineTest.php
+++ b/tests/Imbo/IntegrationTest/Database/DoctrineTest.php
@@ -16,7 +16,6 @@ use Imbo\Database\Doctrine,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Database\Doctrine
  */
 class DoctrineTest extends DatabaseTests {
     /**

--- a/tests/Imbo/IntegrationTest/Database/MongoDBTest.php
+++ b/tests/Imbo/IntegrationTest/Database/MongoDBTest.php
@@ -16,7 +16,6 @@ use Imbo\Database\MongoDB,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Database\MongoDB
  */
 class MongoDBTest extends DatabaseTests {
     /**

--- a/tests/Imbo/IntegrationTest/EventListener/MaxImageSizeTest.php
+++ b/tests/Imbo/IntegrationTest/EventListener/MaxImageSizeTest.php
@@ -16,7 +16,6 @@ use Imbo\EventListener\MaxImageSize,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\EventListener\MaxImageSize
  */
 class MaxImageSizeTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/BorderTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/BorderTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Border;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Border
  */
 class BorderTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/CanvasTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/CanvasTest.php
@@ -16,7 +16,6 @@ use Imbo\Image\Transformation\Canvas,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Canvas
  */
 class CanvasTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/CompressTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/CompressTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Compress;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Compress
  */
 class CompressTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/ConvertTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/ConvertTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Convert;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Convert
  */
 class ConvertTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/CropTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/CropTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Crop;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Crop
  */
 class CropTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/DesaturateTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/DesaturateTest.php
@@ -16,7 +16,6 @@ use Imbo\Image\Transformation\Desaturate;
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Desaturate
  */
 class DesaturateTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/FlipHorizontallyTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/FlipHorizontallyTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\FlipHorizontally;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\FlipHorizontally
  */
 class FlipHorizontallyTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/FlipVerticallyTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/FlipVerticallyTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\FlipVertically;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\FlipVertically
  */
 class FlipVerticallyTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/MaxSizeTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/MaxSizeTest.php
@@ -16,7 +16,6 @@ use Imbo\Image\Transformation\MaxSize;
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\MaxSize
  */
 class MaxSizeTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/ResizeTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/ResizeTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Resize;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Resize
  */
 class ResizeTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/RotateTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/RotateTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Rotate;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Rotate
  */
 class RotateTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/SepiaTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/SepiaTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Sepia;
 /**
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Sepia
  */
 class SepiaTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/ThumbnailTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/ThumbnailTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Thumbnail;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Thumbnail
  */
 class ThumbnailTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/TransposeTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/TransposeTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Transpose;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Transpose
  */
 class TransposeTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Image/Transformation/TransverseTest.php
+++ b/tests/Imbo/IntegrationTest/Image/Transformation/TransverseTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Transverse;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Image\Transformation\Transverse
  */
 class TransverseTest extends TransformationTests {
     /**

--- a/tests/Imbo/IntegrationTest/Storage/DoctrineTest.php
+++ b/tests/Imbo/IntegrationTest/Storage/DoctrineTest.php
@@ -16,7 +16,6 @@ use Imbo\Storage\Doctrine,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Storage\Doctrine
  */
 class DoctrineTest extends StorageTests {
     /**

--- a/tests/Imbo/IntegrationTest/Storage/FilesystemTest.php
+++ b/tests/Imbo/IntegrationTest/Storage/FilesystemTest.php
@@ -15,7 +15,6 @@ use Imbo\Storage\Filesystem;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Storage\Filesystem
  */
 class FilesystemTest extends StorageTests {
     /**

--- a/tests/Imbo/IntegrationTest/Storage/GridFSTest.php
+++ b/tests/Imbo/IntegrationTest/Storage/GridFSTest.php
@@ -16,7 +16,6 @@ use Imbo\Storage\GridFS,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Integration tests
- * @covers Imbo\Storage\GridFS
  */
 class GridFSTest extends StorageTests {
     /**

--- a/tests/Imbo/UnitTest/ApplicationTest.php
+++ b/tests/Imbo/UnitTest/ApplicationTest.php
@@ -19,7 +19,6 @@ use Imbo\Application,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Application
  */
 class ApplicationTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/ContainerTest.php
+++ b/tests/Imbo/UnitTest/ContainerTest.php
@@ -15,7 +15,6 @@ use Imbo\Container;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Container
  */
 class ContainerTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Database/DoctrineTest.php
+++ b/tests/Imbo/UnitTest/Database/DoctrineTest.php
@@ -16,7 +16,6 @@ use Imbo\Database\Doctrine,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Database\Doctrine
  */
 class DoctrineTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Database/MongoDBTest.php
+++ b/tests/Imbo/UnitTest/Database/MongoDBTest.php
@@ -17,7 +17,6 @@ use Imbo\Database\MongoDB,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Database\MongoDB
  */
 class MongoDBTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/EventListener/AccessTokenTest.php
+++ b/tests/Imbo/UnitTest/EventListener/AccessTokenTest.php
@@ -15,7 +15,6 @@ use Imbo\EventListener\AccessToken;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\AccessToken
  */
 class AccessTokenTest extends ListenerTests {
     /**

--- a/tests/Imbo/UnitTest/EventListener/AuthenticateTest.php
+++ b/tests/Imbo/UnitTest/EventListener/AuthenticateTest.php
@@ -15,7 +15,6 @@ use Imbo\EventListener\Authenticate;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\Authenticate
  */
 class AuthenticateTest extends ListenerTests {
     /**

--- a/tests/Imbo/UnitTest/EventListener/CorsTest.php
+++ b/tests/Imbo/UnitTest/EventListener/CorsTest.php
@@ -15,7 +15,6 @@ use Imbo\EventListener\Cors;
 /**
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\Cors
  */
 class CorsTest extends ListenerTests {
     /**

--- a/tests/Imbo/UnitTest/EventListener/DatabaseOperationsTest.php
+++ b/tests/Imbo/UnitTest/EventListener/DatabaseOperationsTest.php
@@ -15,7 +15,6 @@ use Imbo\EventListener\DatabaseOperations;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\DatabaseOperations
  */
 class DatabaseOperationsTest extends ListenerTests {
     /**

--- a/tests/Imbo/UnitTest/EventListener/ImageTransformationCacheTest.php
+++ b/tests/Imbo/UnitTest/EventListener/ImageTransformationCacheTest.php
@@ -16,7 +16,6 @@ use Imbo\EventListener\ImageTransformationCache,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\ImageTransformationCache
  */
 class ImageTransformationCacheTest extends ListenerTests {
     /**

--- a/tests/Imbo/UnitTest/EventListener/ImageTransformerTest.php
+++ b/tests/Imbo/UnitTest/EventListener/ImageTransformerTest.php
@@ -18,7 +18,6 @@ use Imbo\EventListener\ImageTransformer,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\ImageTransformer
  */
 class ImageTransformerTest extends ListenerTests {
     /**

--- a/tests/Imbo/UnitTest/EventListener/ListenerDefinitionTest.php
+++ b/tests/Imbo/UnitTest/EventListener/ListenerDefinitionTest.php
@@ -15,7 +15,6 @@ use Imbo\EventListener\ListenerDefinition;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\ListenerDefinition
  */
 class ListenerDefinitionTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/EventListener/MaxImageSizeTest.php
+++ b/tests/Imbo/UnitTest/EventListener/MaxImageSizeTest.php
@@ -15,7 +15,6 @@ use Imbo\EventListener\MaxImageSize;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\MaxImageSize
  */
 class MaxImageSizeTest extends ListenerTests {
     /**

--- a/tests/Imbo/UnitTest/EventListener/MetadataCacheTest.php
+++ b/tests/Imbo/UnitTest/EventListener/MetadataCacheTest.php
@@ -15,7 +15,6 @@ use Imbo\EventListener\MetadataCache;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\MetadataCache
  */
 class MetadataCacheTest extends ListenerTests {
     /**

--- a/tests/Imbo/UnitTest/EventListener/StorageOperationsTest.php
+++ b/tests/Imbo/UnitTest/EventListener/StorageOperationsTest.php
@@ -16,7 +16,6 @@ use Imbo\EventListener\StorageOperations,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventListener\StorageOperations
  */
 class StorageOperationsTest extends ListenerTests {
     /**

--- a/tests/Imbo/UnitTest/EventManager/EventManagerTest.php
+++ b/tests/Imbo/UnitTest/EventManager/EventManagerTest.php
@@ -15,7 +15,6 @@ use Imbo\EventManager\EventManager;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventManager\EventManager
  */
 class EventManagerTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/EventManager/EventTest.php
+++ b/tests/Imbo/UnitTest/EventManager/EventTest.php
@@ -20,7 +20,6 @@ use Imbo\EventManager\Event,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\EventManager\Event
  */
 class EventTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Imbo/UnitTest/Exception/InvalidArgumentExceptionTest.php
@@ -15,7 +15,6 @@ use Imbo\Exception\InvalidArgumentException;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Exception\InvalidArgumentException
  */
 class InvalidArgumentExceptionTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Exception/RuntimeExceptionTest.php
+++ b/tests/Imbo/UnitTest/Exception/RuntimeExceptionTest.php
@@ -15,7 +15,6 @@ use Imbo\Exception\RuntimeException;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Exception\RuntimeException
  */
 class RuntimeExceptionTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Helpers/DateFormatterTest.php
+++ b/tests/Imbo/UnitTest/Helpers/DateFormatterTest.php
@@ -17,7 +17,6 @@ use Imbo\Helpers\DateFormatter,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Helpers\DateFormatter
  */
 class DateFormatterTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Http/ContentNegotiationTest.php
+++ b/tests/Imbo/UnitTest/Http/ContentNegotiationTest.php
@@ -15,7 +15,6 @@ use Imbo\Http\ContentNegotiation;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Http\ContentNegotiation
  */
 class ContentNegotiationTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Http/HeaderContainerTest.php
+++ b/tests/Imbo/UnitTest/Http/HeaderContainerTest.php
@@ -15,7 +15,6 @@ use Imbo\Http\HeaderContainer;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Http\HeaderContainer
  */
 class HeaderContainerTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Http/ParameterContainerTest.php
+++ b/tests/Imbo/UnitTest/Http/ParameterContainerTest.php
@@ -15,7 +15,6 @@ use Imbo\Http\ParameterContainer;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Http\ParameterContainer
  */
 class ParameterContainerTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Http/Request/RequestTest.php
+++ b/tests/Imbo/UnitTest/Http/Request/RequestTest.php
@@ -15,7 +15,6 @@ use Imbo\Http\Request\Request;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Http\Request\Request
  */
 class RequestTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Http/Response/ResponseTest.php
+++ b/tests/Imbo/UnitTest/Http/Response/ResponseTest.php
@@ -18,7 +18,6 @@ use Imbo\Http\Response\Response,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Http\Response\Response
  */
 class ResponseTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Http/ServerContainerTest.php
+++ b/tests/Imbo/UnitTest/Http/ServerContainerTest.php
@@ -15,7 +15,6 @@ use Imbo\Http\ServerContainer;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Http\ServerContainer
  */
 class ServerContainerTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Image/ImagePreparationTest.php
+++ b/tests/Imbo/UnitTest/Image/ImagePreparationTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\ImagePreparation;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Image\ImagePreparation
  */
 class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Image/ImageTest.php
+++ b/tests/Imbo/UnitTest/Image/ImageTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Image;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Image\Image
  */
 class ImageTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Image/Transformation/CollectionTest.php
+++ b/tests/Imbo/UnitTest/Image/Transformation/CollectionTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Collection;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Image\Transformation\Collection
  */
 class CollectionTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Image/Transformation/ConvertTest.php
+++ b/tests/Imbo/UnitTest/Image/Transformation/ConvertTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Convert;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Image\Transformation\Convert
  */
 class ConvertTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Image/Transformation/CropTest.php
+++ b/tests/Imbo/UnitTest/Image/Transformation/CropTest.php
@@ -15,7 +15,6 @@ use Imbo\Image\Transformation\Crop;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Image\Transformation\Crop
  */
 class CropTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Image/Transformation/TransformationTest.php
+++ b/tests/Imbo/UnitTest/Image/Transformation/TransformationTest.php
@@ -18,7 +18,6 @@ use Imbo\Image\Transformation\Transformation,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Image\Transformation\Transformation
  */
 class TransformationTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Resource/ImageTest.php
+++ b/tests/Imbo/UnitTest/Resource/ImageTest.php
@@ -15,7 +15,6 @@ use Imbo\Resource\Image;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Resource\Image
  */
 class ImageTest extends ResourceTests {
     /**

--- a/tests/Imbo/UnitTest/Resource/Images/QueryTest.php
+++ b/tests/Imbo/UnitTest/Resource/Images/QueryTest.php
@@ -15,7 +15,6 @@ use Imbo\Resource\Images\Query;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Resource\Images\Query
  */
 class QueryTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Resource/ImagesTest.php
+++ b/tests/Imbo/UnitTest/Resource/ImagesTest.php
@@ -15,7 +15,6 @@ use Imbo\Resource\Images;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Resource\Images
  */
 class ImagesTest extends ResourceTests {
     /**

--- a/tests/Imbo/UnitTest/Resource/MetadataTest.php
+++ b/tests/Imbo/UnitTest/Resource/MetadataTest.php
@@ -15,7 +15,6 @@ use Imbo\Resource\Metadata;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Resource\Metadata
  */
 class MetadataTest extends ResourceTests {
     /**

--- a/tests/Imbo/UnitTest/Resource/StatusTest.php
+++ b/tests/Imbo/UnitTest/Resource/StatusTest.php
@@ -15,7 +15,6 @@ use Imbo\Resource\Status;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Resource\Status
  */
 class StatusTest extends ResourceTests {
     /**

--- a/tests/Imbo/UnitTest/Resource/UserTest.php
+++ b/tests/Imbo/UnitTest/Resource/UserTest.php
@@ -15,7 +15,6 @@ use Imbo\Resource\User;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Resource\User
  */
 class UserTest extends ResourceTests {
     /**

--- a/tests/Imbo/UnitTest/RouterTest.php
+++ b/tests/Imbo/UnitTest/RouterTest.php
@@ -15,7 +15,6 @@ use Imbo\Router;
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Router
  */
 class RouterTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Storage/DoctrineTest.php
+++ b/tests/Imbo/UnitTest/Storage/DoctrineTest.php
@@ -16,7 +16,6 @@ use Imbo\Storage\Doctrine,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Storage\Doctrine
  */
 class DoctrineTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Storage/FilesystemTest.php
+++ b/tests/Imbo/UnitTest/Storage/FilesystemTest.php
@@ -17,7 +17,6 @@ use Imbo\Storage\Filesystem,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Storage\Filesystem
  */
 class FilesystemTest extends \PHPUnit_Framework_TestCase {
     /**

--- a/tests/Imbo/UnitTest/Storage/GridFSTest.php
+++ b/tests/Imbo/UnitTest/Storage/GridFSTest.php
@@ -19,7 +19,6 @@ use Imbo\Storage\GridFS,
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Test suite\Unit tests
- * @covers Imbo\Storage\GridFS
  */
 class GridFSTest extends \PHPUnit_Framework_TestCase {
     /**


### PR DESCRIPTION
This PR removes all class level covers annotations as this makes the code coverage report slightly misleading.
