### PR TITLE
Disable the usage of the convert transformation via the t query parameter

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -5,6 +5,7 @@ Imbo-0.2.0
 ----------
 __N/A__
 
+* The convert transformation can no longer be triggered via the t query parameter per default
 * Fixed #150: Error model can't be formatted using an image formatter
 
 Imbo-0.1.0

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -195,9 +195,6 @@ $config = array(
         'compress' => function (array $params) {
             return new Image\Transformation\Compress($params);
         },
-        'convert' => function (array $params) {
-            return new Image\Transformation\Convert($params);
-        },
         'crop' => function (array $params) {
             return new Image\Transformation\Crop($params);
         },

--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -226,6 +226,8 @@ Image transformations
 
 Below you can find information on the transformations shipped with Imbo along with their parameters.
 
+.. _border-transformation:
+
 border
 ######
 
@@ -297,8 +299,6 @@ This transformation compresses images on the fly resulting in a smaller payload.
 .. warning::
     This transformation currently only works as expected for ``image/jpeg`` images.
 
-.. _convert-transformation:
-
 convert
 #######
 
@@ -313,6 +313,8 @@ This transformation can be used to change the image type. It is not applied like
 * ``curl http://imbo/users/<user>/images/<image>.gif``
 * ``curl http://imbo/users/<user>/images/<image>.jpg``
 * ``curl http://imbo/users/<user>/images/<image>.png``
+
+It is not possible to explicitly trigger this transformation via the ``t[]`` query parameter.
 
 crop
 ####

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -707,21 +707,21 @@ Use ``whitelist`` if you want the listener to skip the access token check for ce
 
     array('transformations' => array(
         'whitelist' => array(
-            'convert',
+            'border',
         )
     ))
 
-means that the access token will **not** be enforced for the :ref:`convert-transformation` transformation.
+means that the access token will **not** be enforced for the :ref:`border-transformation` transformation.
 
 .. code-block:: php
 
     array('transformations' => array(
         'blacklist' => array(
-            'convert',
+            'border',
         )
     ))
 
-means that the access token will be enforced **only** for the :ref:`convert-transformation` transformation.
+means that the access token will be enforced **only** for the :ref:`border-transformation` transformation.
 
 If both ``whitelist`` and ``blacklist`` are specified all transformations will require an access token unless it's included in ``whitelist``.
 

--- a/library/Imbo/Application.php
+++ b/library/Imbo/Application.php
@@ -25,7 +25,8 @@ use Imbo\Http\Request\Request,
     Imbo\Database\DatabaseInterface,
     Imbo\Storage\StorageInterface,
     Imbo\Resource\Images\Query,
-    Imbo\Http\Response\Formatter;
+    Imbo\Http\Response\Formatter,
+    Imbo\Image\Transformation;
 
 /**
  * Imbo application
@@ -402,25 +403,13 @@ class Application {
             return new Formatter\XML($container->get('dateFormatter'));
         });
         $container->setStatic('gifFormatter', function(Container $container) {
-            $config = $container->get('config');
-            $callback = $config['imageTransformations']['convert'];
-            $transformation = $callback(array('type' => 'gif'));
-
-            return new Formatter\Gif($transformation);
+            return new Formatter\Gif(new Transformation\Convert(array('type' => 'gif')));
         });
         $container->setStatic('jpegFormatter', function(Container $container) {
-            $config = $container->get('config');
-            $callback = $config['imageTransformations']['convert'];
-            $transformation = $callback(array('type' => 'jpg'));
-
-            return new Formatter\Jpeg($transformation);
+            return new Formatter\Jpeg(new Transformation\Convert(array('type' => 'jpg')));
         });
         $container->setStatic('pngFormatter', function(Container $container) {
-            $config = $container->get('config');
-            $callback = $config['imageTransformations']['convert'];
-            $transformation = $callback(array('type' => 'png'));
-
-            return new Formatter\Png($transformation);
+            return new Formatter\Png(new Transformation\Convert(array('type' => 'png')));
         });
 
         $this->container = $container;

--- a/library/Imbo/EventListener/AccessToken.php
+++ b/library/Imbo/EventListener/AccessToken.php
@@ -41,18 +41,18 @@ class AccessToken implements ListenerInterface {
          * 'transformations' => array(
          *     'whitelist' => array(
          *         'border',
-         *         'convert',
+         *         'thumbnail',
          *      ),
          * )
          *
          * Use the 'whitelist' for making the listener skip the access token check for some
          * transformations, and the 'blacklist' key for the opposite:
          *
-         * 'whitelist' => array('convert') means that the access token
-         * will *not* be enforced for the Convert transformation, but for all others.
+         * 'whitelist' => array('border') means that the access token
+         * will *not* be enforced for the Border transformation, but for all others.
          *
-         * 'blacklist' => array('convert') means that the access token
-         * will be enforced *only* when the Convert transformation is in effect.
+         * 'blacklist' => array('border') means that the access token
+         * will be enforced *only* when the Border transformation is in effect.
          *
          * If both 'whitelist' and 'blacklist' are specified all transformations will require an
          * access token unless included in the 'whitelist'.

--- a/library/Imbo/Http/Response/Formatter/ImageFormatter.php
+++ b/library/Imbo/Http/Response/Formatter/ImageFormatter.php
@@ -11,7 +11,7 @@
 namespace Imbo\Http\Response\Formatter;
 
 use Imbo\Model,
-    Imbo\Image\Transformation\TransformationInterface;
+    Imbo\Image\Transformation;
 
 /**
  * Gif image formatter
@@ -23,7 +23,7 @@ abstract class ImageFormatter implements ImageFormatterInterface {
     /**
      * Convert transformation
      *
-     * @var TransformationInterface
+     * @var Transformation\Convert
      */
     private $transformation;
 
@@ -32,7 +32,7 @@ abstract class ImageFormatter implements ImageFormatterInterface {
      *
      * @param TransformationInterface $transformation A convert transformation
      */
-    public function __construct(TransformationInterface $transformation) {
+    public function __construct(Transformation\Convert $transformation) {
         $this->transformation = $transformation;
     }
 

--- a/tests/Imbo/UnitTest/EventListener/AccessTokenTest.php
+++ b/tests/Imbo/UnitTest/EventListener/AccessTokenTest.php
@@ -86,58 +86,58 @@ class AccessTokenTest extends ListenerTests {
             array(
                 $filter = array(),
                 $transformations = array(
-                    array('name' => 'convert', 'params' => array()),
-                ),
-                $whitelisted = false,
-            ),
-            array(
-                $filter = array('transformations' => array('whitelist' => array('convert'))),
-                $transformations = array(
-                    array('name' => 'convert', 'params' => array()),
-                ),
-                $whitelisted = true,
-            ),
-            array(
-                $filter = array('transformations' => array('whitelist' => array('convert'))),
-                $transformations = array(
-                    array('name' => 'convert', 'params' => array()),
                     array('name' => 'border', 'params' => array()),
                 ),
                 $whitelisted = false,
             ),
             array(
-                $filter = array('transformations' => array('blacklist' => array('convert'))),
+                $filter = array('transformations' => array('whitelist' => array('border'))),
                 $transformations = array(
                     array('name' => 'border', 'params' => array()),
                 ),
                 $whitelisted = true,
             ),
             array(
-                $filter = array('transformations' => array('blacklist' => array('convert'))),
+                $filter = array('transformations' => array('whitelist' => array('border'))),
                 $transformations = array(
-                    array('name' => 'convert', 'params' => array()),
                     array('name' => 'border', 'params' => array()),
+                    array('name' => 'thumbnail', 'params' => array()),
                 ),
                 $whitelisted = false,
             ),
             array(
-                $filter = array('transformations' => array('whitelist' => array('convert'), 'blacklist' => array('border'))),
+                $filter = array('transformations' => array('blacklist' => array('border'))),
                 $transformations = array(
-                    array('name' => 'convert', 'params' => array()),
+                    array('name' => 'thumbnail', 'params' => array()),
                 ),
                 $whitelisted = true,
             ),
             array(
-                $filter = array('transformations' => array('whitelist' => array('convert'), 'blacklist' => array('border'))),
+                $filter = array('transformations' => array('blacklist' => array('border'))),
+                $transformations = array(
+                    array('name' => 'border', 'params' => array()),
+                    array('name' => 'thumbnail', 'params' => array()),
+                ),
+                $whitelisted = false,
+            ),
+            array(
+                $filter = array('transformations' => array('whitelist' => array('border'), 'blacklist' => array('thumbnail'))),
+                $transformations = array(
+                    array('name' => 'border', 'params' => array()),
+                ),
+                $whitelisted = true,
+            ),
+            array(
+                $filter = array('transformations' => array('whitelist' => array('border'), 'blacklist' => array('thumbnail'))),
                 $transformations = array(
                     array('name' => 'canvas', 'params' => array()),
                 ),
                 $whitelisted = false,
             ),
             array(
-                $filter = array('transformations' => array('whitelist' => array('convert'), 'blacklist' => array('convert'))),
+                $filter = array('transformations' => array('whitelist' => array('border'), 'blacklist' => array('border'))),
                 $transformations = array(
-                    array('name' => 'convert', 'params' => array()),
+                    array('name' => 'border', 'params' => array()),
                 ),
                 $whitelisted = false,
             ),

--- a/tests/Imbo/UnitTest/Http/Response/Formatter/GifTest.php
+++ b/tests/Imbo/UnitTest/Http/Response/Formatter/GifTest.php
@@ -11,7 +11,7 @@
 namespace Imbo\UnitTest\Http\Response\Formatter;
 
 use Imbo\Http\Response\Formatter\Gif,
-    Imbo\Image\Transformation\TransformationInterface;
+    Imbo\Image\Transformation\Convert;
 
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
@@ -22,8 +22,8 @@ class GifTest extends ImageFormatterTests {
     /**
      * {@inheritdoc}
      */
-    protected function getFormatter(TransformationInterface $transformation) {
-        return new Gif($transformation);
+    protected function getFormatter(Convert $convert) {
+        return new Gif($convert);
     }
 
     /**

--- a/tests/Imbo/UnitTest/Http/Response/Formatter/ImageFormatterTests.php
+++ b/tests/Imbo/UnitTest/Http/Response/Formatter/ImageFormatterTests.php
@@ -10,7 +10,7 @@
 
 namespace Imbo\UnitTest\Http\Response\Formatter;
 
-use Imbo\Image\Transformation\TransformationInterface;
+use Imbo\Image\Transformation\Convert;
 
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
@@ -28,10 +28,10 @@ abstract class ImageFormatterTests extends \PHPUnit_Framework_TestCase {
     /**
      * Get the formatter we want to test
      *
-     * @param TransformationInterface $transformation The transformation to use with the formatter
+     * @param Convert $convert The convert transformation to use with the formatter
      * @return ImageFormatterInterface
      */
-    abstract protected function getFormatter(TransformationInterface $transformation);
+    abstract protected function getFormatter(Convert $convert);
 
     /**
      * Get the expected content type for the formatter
@@ -44,7 +44,7 @@ abstract class ImageFormatterTests extends \PHPUnit_Framework_TestCase {
      * Set up the formatter
      */
     public function setUp() {
-        $this->transformation = $this->getMock('Imbo\Image\Transformation\TransformationInterface');
+        $this->transformation = $this->getMockBuilder('Imbo\Image\Transformation\Convert')->disableOriginalConstructor()->getMock();
         $this->formatter = $this->getFormatter($this->transformation);
         $this->model = $this->getMock('Imbo\Model\Image');
     }

--- a/tests/Imbo/UnitTest/Http/Response/Formatter/JpegTest.php
+++ b/tests/Imbo/UnitTest/Http/Response/Formatter/JpegTest.php
@@ -11,7 +11,7 @@
 namespace Imbo\UnitTest\Http\Response\Formatter;
 
 use Imbo\Http\Response\Formatter\Jpeg,
-    Imbo\Image\Transformation\TransformationInterface;
+    Imbo\Image\Transformation\Convert;
 
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
@@ -22,8 +22,8 @@ class JpegTest extends ImageFormatterTests {
     /**
      * {@inheritdoc}
      */
-    protected function getFormatter(TransformationInterface $transformation) {
-        return new Jpeg($transformation);
+    protected function getFormatter(Convert $convert) {
+        return new Jpeg($convert);
     }
 
     /**

--- a/tests/Imbo/UnitTest/Http/Response/Formatter/PngTest.php
+++ b/tests/Imbo/UnitTest/Http/Response/Formatter/PngTest.php
@@ -11,7 +11,7 @@
 namespace Imbo\UnitTest\Http\Response\Formatter;
 
 use Imbo\Http\Response\Formatter\Png,
-    Imbo\Image\Transformation\TransformationInterface;
+    Imbo\Image\Transformation\Convert;
 
 /**
  * @author Christer Edvartsen <cogo@starzinger.net>
@@ -22,8 +22,8 @@ class PngTest extends ImageFormatterTests {
     /**
      * {@inheritdoc}
      */
-    protected function getFormatter(TransformationInterface $transformation) {
-        return new Png($transformation);
+    protected function getFormatter(Convert $convert) {
+        return new Png($convert);
     }
 
     /**


### PR DESCRIPTION
This PR disabled the usage of the convert transformation via the `t[]` query parameter. Convert can now only be triggered when using one of the following extensions on the image endpoint:
- .jpg
- .gif
- .png
