### PR TITLE
urlencode accessToken bugfix

### DIFF
--- a/library/Imbo/Http/Request/Request.php
+++ b/library/Imbo/Http/Request/Request.php
@@ -72,11 +72,7 @@ class Request extends SymfonyRequest {
     private $transformations;
 
     /**
-     * Creates a new request with values from PHP's super globals.
-     *
-     * @return Request A new request
-     *
-     * @api
+     * {@inheritdoc}
      */
     public static function createFromGlobals()
     {


### PR DESCRIPTION
We found that some services, for example _wkhtmltoimage_ in our case, are using urlencoding functions.
When it goes to IMBO, `[` and `]` elements are replaced by `%5B` and `%5D` respectively.
It is then checked against accessToken, and doesn't fit it, as checksums of 
`... 572806?t[]=crop%3Ax%3D143%2Cy ...` and 
`... 572806?t%5B%5D=crop%3Ax%3D143%2Cy ...` are different.

We solved it by making simple `str_replace` in `QUERY_STRING`,  but it doesn't seem to be good solution for official version.
Probably better would be some changes in IMBO encoding or counting checksum.
