### PR TITLE
Try to use a ppa instead of compiling imagemagick

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 before_install:
   - sudo add-apt-repository -y ppa:moti-p/cc
   - sudo apt-get update
-  - sudo apt-get -y upgrade imagemagick
+  - sudo apt-get -y --reinstall install imagemagick
   - printf "\n" | pecl install imagick-beta
 before_script:
   - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
This fix will make Travis-CI use a PPA when installing ImageMagick, instead of compiling.
