### PR TITLE
Changed pagination data in the response from the images resource

### DIFF
--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -299,7 +299,7 @@ results in:
 
     {
       "search": {
-        "total": 10,
+        "hits": 3,
         "page": 1,
         "limit": 1,
         "count": 1
@@ -323,7 +323,7 @@ results in:
       ]
     }
 
-The ``search`` object is data related to pagination, where ``total`` is the total amount of images owned by ``<user>``, ``page`` is the current page, ``limit`` is the current limit, and ``count`` is the number of images in the visible collection.
+The ``search`` object is data related to pagination, where ``hits`` is the number of images found by your query, ``page`` is the current page, ``limit`` is the current limit, and ``count`` is the number of images in the visible collection.
 
 The ``images`` list contains image objects, where ``added`` is a formatted date of when the image was added to Imbo, ``extension`` is the original image extension, ``height`` is the height of the image in pixels, ``imageIdentifier`` is the image identifier (`MD5 checksum <http://en.wikipedia.org/wiki/MD5>`_ of the file itself), ``metadata`` is a JSON object containing metadata attached to the image, ``mime`` is the mime type of the image, ``publicKey`` is the public key of the user who owns the image, ``size`` is the size of the image in bytes, ``updated`` is a formatted date of when the image was last updated (read: when metadata attached to the image was last updated, as the image itself never changes), and ``width`` is the width of the image in pixels. The fact that the image identifier is the MD5 checksum of the image is an implementation detail and might change in the future.
 

--- a/features/images.feature
+++ b/features/images.feature
@@ -20,8 +20,8 @@ Feature: Imbo provides an images endpoint
         """
         Examples:
             | extension | content-type     | response |
-            | json      | application/json | #^{"search":{"total":3,"page":1,"limit":20,"count":3},"images":\[{.*?},{.*?},{.*?}\]}$# |
-            | xml       | application/xml  | #^<\?xml version="1.0" encoding="UTF-8"\?>\s*<imbo>\s*<search>\s*<total>3</total>\s*<page>1</page>\s*<limit>20</limit>\s*<count>3</count>\s*</search>\s*<images>\s*(<image>.*?</image>\s*){3}\s*</images>\s*</imbo>$#ms |
+            | json      | application/json | #^{"search":{"hits":3,"page":1,"limit":20,"count":3},"images":\[{.*?},{.*?},{.*?}\]}$# |
+            | xml       | application/xml  | #^<\?xml version="1.0" encoding="UTF-8"\?>\s*<imbo>\s*<search>\s*<hits>3</hits>\s*<page>1</page>\s*<limit>20</limit>\s*<count>3</count>\s*</search>\s*<images>\s*(<image>.*?</image>\s*){3}\s*</images>\s*</imbo>$#ms |
 
     Scenario Outline: Fetch images using limit
         Given I use "publickey" and "privatekey" for public and private keys
@@ -35,8 +35,8 @@ Feature: Imbo provides an images endpoint
         """
         Examples:
             | extension | content-type     | response |
-            | json      | application/json | #^{"search":{"total":3,"page":1,"limit":2,"count":2},"images":\[{.*?},{.*?}\]}$# |
-            | xml       | application/xml  | #^<\?xml version="1.0" encoding="UTF-8"\?>\s*<imbo>\s*<search>\s*<total>3</total>\s*<page>1</page>\s*<limit>2</limit>\s*<count>2</count>\s*</search>\s*<images>\s*(<image>.*?</image>\s*){2}\s*</images>\s*</imbo>$#ms |
+            | json      | application/json | #^{"search":{"hits":3,"page":1,"limit":2,"count":2},"images":\[{.*?},{.*?}\]}$# |
+            | xml       | application/xml  | #^<\?xml version="1.0" encoding="UTF-8"\?>\s*<imbo>\s*<search>\s*<hits>3</hits>\s*<page>1</page>\s*<limit>2</limit>\s*<count>2</count>\s*</search>\s*<images>\s*(<image>.*?</image>\s*){2}\s*</images>\s*</imbo>$#ms |
 
     Scenario Outline: Fetch images with a filter on image identifiers
         Given I use "publickey" and "privatekey" for public and private keys
@@ -124,3 +124,13 @@ Feature: Imbo provides an images endpoint
             | fields[]=size                 | sort[]=size:desc              | #^{"search":{.*?},"images":\[{"size":95576},{"size":66020},{"size":64828}\]}$# |
             | fields[]=size&fields[]=width  | sort[]=width&sort[]=size:desc | #^{"search":{.*?},"images":\[{"size":95576,"width":599},{"size":66020,"width":665},{"size":64828,"width":665}\]}$# |
             | fields[]=size&fields[]=width  | sort[]=width&sort[]=size      | #^{"search":{.*?},"images":\[{"size":95576,"width":599},{"size":64828,"width":665},{"size":66020,"width":665}\]}$# |
+
+    Scenario: The hits number has the number of hits in the query
+        Given I use "publickey" and "privatekey" for public and private keys
+        And I include an access token in the query
+        When I request "/users/publickey/images.json?limit=1&page=1&ids[]=fc7d2d06993047a0b5056e8fac4462a2&ids[]=b5426b4c008e378c201526d2baaec599"
+        Then I should get a response with "200 OK"
+        And the response body matches:
+        """
+        #^{"search":{"hits":2,"page":1,"limit":1,"count":1},"images":\[{.*}\]}$#
+        """

--- a/library/Imbo/Database/DatabaseInterface.php
+++ b/library/Imbo/Database/DatabaseInterface.php
@@ -11,6 +11,7 @@
 namespace Imbo\Database;
 
 use Imbo\Model\Image,
+    Imbo\Model\Images,
     Imbo\Resource\Images\Query,
     Imbo\Exception\DatabaseException,
     DateTime;
@@ -82,12 +83,15 @@ interface DatabaseInterface {
     /**
      * Get images based on some query parameters
      *
+     * This method is also responsible for setting a correct "hits" number in the images model.
+     *
      * @param string $publicKey The public key of the user
      * @param Query $query A query instance
+     * @param Images $model The images model
      * @return array
      * @throws DatabaseException
      */
-    function getImages($publicKey, Query $query);
+    function getImages($publicKey, Query $query, Images $model);
 
     /**
      * Load information from database into the image object

--- a/library/Imbo/Database/MongoDB.php
+++ b/library/Imbo/Database/MongoDB.php
@@ -11,6 +11,7 @@
 namespace Imbo\Database;
 
 use Imbo\Model\Image,
+    Imbo\Model\Images,
     Imbo\Resource\Images\Query,
     Imbo\Exception\DatabaseException,
     MongoClient,
@@ -239,7 +240,7 @@ class MongoDB implements DatabaseInterface {
     /**
      * {@inheritdoc}
      */
-    public function getImages($publicKey, Query $query) {
+    public function getImages($publicKey, Query $query, Images $model) {
         // Initialize return value
         $images = array();
 
@@ -320,6 +321,9 @@ class MongoDB implements DatabaseInterface {
                 $image['updated'] = new DateTime('@' . $image['updated'], new DateTimeZone('UTC'));
                 $images[] = $image;
             }
+
+            // Update model
+            $model->setHits($cursor->count());
         } catch (MongoException $e) {
             throw new DatabaseException('Unable to search for images', 500, $e);
         }

--- a/library/Imbo/EventListener/DatabaseOperations.php
+++ b/library/Imbo/EventListener/DatabaseOperations.php
@@ -232,7 +232,12 @@ class DatabaseOperations implements ListenerInterface {
         $response = $event->getResponse();
         $database = $event->getDatabase();
 
-        $images = $database->getImages($publicKey, $query);
+        // Create the model and set some pagination values
+        $model = new Model\Images();
+        $model->setLimit($query->limit())
+              ->setPage($query->page());
+
+        $images = $database->getImages($publicKey, $query, $model);
         $modelImages = array();
 
         foreach ($images as $image) {
@@ -255,11 +260,8 @@ class DatabaseOperations implements ListenerInterface {
             $modelImages[] = $entry;
         }
 
-        $model = new Model\Images();
-        $model->setTotal($database->getNumImages($publicKey))
-              ->setLimit($query->limit())
-              ->setPage($query->page())
-              ->setImages($modelImages);
+        // Add images to the model
+        $model->setImages($modelImages);
 
         if ($params->has('fields')) {
             $fields = $params->get('fields');

--- a/library/Imbo/Http/Response/Formatter/JSON.php
+++ b/library/Imbo/Http/Response/Formatter/JSON.php
@@ -122,7 +122,7 @@ class JSON extends Formatter implements FormatterInterface {
 
         return $this->encode(array(
             'search' => array(
-                'total' => $model->getTotal(),
+                'hits' => $model->getHits(),
                 'page' => $model->getPage(),
                 'limit' => $model->getLimit(),
                 'count' => $model->getCount(),

--- a/library/Imbo/Http/Response/Formatter/XML.php
+++ b/library/Imbo/Http/Response/Formatter/XML.php
@@ -157,7 +157,7 @@ USER;
 <?xml version="1.0" encoding="UTF-8"?>
 <imbo>
   <search>
-    <total>{$model->getTotal()}</total>
+    <hits>{$model->getHits()}</hits>
     <page>{$model->getPage()}</page>
     <limit>{$model->getLimit()}</limit>
     <count>{$model->getCount()}</count>

--- a/library/Imbo/Model/Images.php
+++ b/library/Imbo/Model/Images.php
@@ -32,11 +32,11 @@ class Images implements ModelInterface {
     private $fields = array();
 
     /**
-     * Total number of images
+     * Query hits
      *
      * @var int
      */
-    private $total;
+    private $hits;
 
     /**
      * Limit the number of images
@@ -104,24 +104,24 @@ class Images implements ModelInterface {
     }
 
     /**
-     * Set the total
+     * Set the hits property
      *
-     * @param int $total The total
+     * @param int $hits The amount of query hits
      * @return self
      */
-    public function setTotal($total) {
-        $this->total = (int) $total;
+    public function setHits($hits) {
+        $this->hits = (int) $hits;
 
         return $this;
     }
 
     /**
-     * Get the total
+     * Get the hits property
      *
      * @return int
      */
-    public function getTotal() {
-        return $this->total;
+    public function getHits() {
+        return $this->hits;
     }
 
     /**

--- a/tests/ImboIntegrationTest/Database/DoctrineTest.php
+++ b/tests/ImboIntegrationTest/Database/DoctrineTest.php
@@ -26,9 +26,9 @@ class DoctrineTest extends DatabaseTests {
     private $pdo;
 
     /**
-     * @see ImboIntegrationTest\Database\DatabaseTests::getDriver()
+     * @see ImboIntegrationTest\Database\DatabaseTests::getAdapter()
      */
-    protected function getDriver() {
+    protected function getAdapter() {
         return new Doctrine(array(
             'pdo' => $this->pdo,
         ));
@@ -95,6 +95,10 @@ class DoctrineTest extends DatabaseTests {
     }
 
     public function tearDown() {
+        $this->pdo->query("DROP TABLE IF EXISTS imageinfo");
+        $this->pdo->query("DROP TABLE IF EXISTS metadata");
+        $this->pdo->query("DROP TABLE IF EXISTS shorturl");
+        $this->pdo->query("DROP INDEX IF EXISTS shorturlparams");
         $this->pdo = null;
 
         parent::tearDown();

--- a/tests/ImboIntegrationTest/Database/MongoDBTest.php
+++ b/tests/ImboIntegrationTest/Database/MongoDBTest.php
@@ -21,9 +21,9 @@ use Imbo\Database\MongoDB,
  */
 class MongoDBTest extends DatabaseTests {
     /**
-     * @see ImboIntegrationTest\Database\DatabaseTests::getDriver()
+     * @see ImboIntegrationTest\Database\DatabaseTests::getAdapter()
      */
-    protected function getDriver() {
+    protected function getAdapter() {
         return new MongoDB(array(
             'databaseName' => 'imboIntegrationTestDatabase',
         ));

--- a/tests/ImboUnitTest/Database/MongoDBTest.php
+++ b/tests/ImboUnitTest/Database/MongoDBTest.php
@@ -106,7 +106,7 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
             'metadata.brewery' => 'Nøgne Ø',
         ), $this->isType('array'))->will($this->returnValue($cursor));
 
-        $this->assertSame(array(), $this->driver->getImages($publicKey, $query));
+        $this->assertSame(array(), $this->driver->getImages($publicKey, $query, $this->getMock('Imbo\Model\Images')));
     }
 
     /**
@@ -214,7 +214,7 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
                               ->method('find')
                               ->will($this->throwException(new MongoException()));
 
-        $this->driver->getImages('key', $this->getMock('Imbo\Resource\Images\Query'));
+        $this->driver->getImages('key', $this->getMock('Imbo\Resource\Images\Query'), $this->getMock('Imbo\Model\Images'));
     }
 
     /**

--- a/tests/ImboUnitTest/Http/Response/Formatter/JSONTest.php
+++ b/tests/ImboUnitTest/Http/Response/Formatter/JSONTest.php
@@ -179,7 +179,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
         $images = array($image);
         $model = $this->getMock('Imbo\Model\Images');
         $model->expects($this->once())->method('getImages')->will($this->returnValue($images));
-        $model->expects($this->once())->method('getTotal')->will($this->returnValue(100));
+        $model->expects($this->once())->method('getHits')->will($this->returnValue(100));
         $model->expects($this->once())->method('getPage')->will($this->returnValue(2));
         $model->expects($this->once())->method('getLimit')->will($this->returnValue(20));
         $model->expects($this->once())->method('getCount')->will($this->returnValue(1));
@@ -189,7 +189,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
         $json = $this->formatter->format($model);
 
         $data = json_decode($json, true);
-        $this->assertSame(array('total' => 100, 'page' => 2, 'limit' => 20, 'count' => 1), $data['search']);
+        $this->assertSame(array('hits' => 100, 'page' => 2, 'limit' => 20, 'count' => 1), $data['search']);
         $this->assertCount(1, $data['images']);
         $image = $data['images'][0];
 

--- a/tests/ImboUnitTest/Http/Response/Formatter/XMLTest.php
+++ b/tests/ImboUnitTest/Http/Response/Formatter/XMLTest.php
@@ -174,7 +174,7 @@ class XMLTest extends \PHPUnit_Framework_TestCase {
         $images = array($image);
         $model = $this->getMock('Imbo\Model\Images');
         $model->expects($this->once())->method('getImages')->will($this->returnValue($images));
-        $model->expects($this->once())->method('getTotal')->will($this->returnValue(100));
+        $model->expects($this->once())->method('getHits')->will($this->returnValue(100));
         $model->expects($this->once())->method('getPage')->will($this->returnValue(2));
         $model->expects($this->once())->method('getLimit')->will($this->returnValue(20));
         $model->expects($this->once())->method('getCount')->will($this->returnValue(1));
@@ -184,7 +184,7 @@ class XMLTest extends \PHPUnit_Framework_TestCase {
         $xml = $this->formatter->format($model);
 
         // Check the search data
-        foreach (array('total' => 100, 'page' => 2, 'limit' => 20, 'count' => 1) as $tag => $value) {
+        foreach (array('hits' => 100, 'page' => 2, 'limit' => 20, 'count' => 1) as $tag => $value) {
             $this->assertTag(
                 array(
                     'tag' => $tag,

--- a/tests/ImboUnitTest/Model/ImagesTest.php
+++ b/tests/ImboUnitTest/Model/ImagesTest.php
@@ -63,13 +63,13 @@ class ImagesTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @covers Imbo\Model\Images::setTotal
-     * @covers Imbo\Model\Images::getTotal
+     * @covers Imbo\Model\Images::setHits
+     * @covers Imbo\Model\Images::getHits
      */
-    public function testCanSetAndGetTotal() {
-        $this->assertNull($this->model->getTotal());
-        $this->assertSame($this->model, $this->model->setTotal(10));
-        $this->assertSame(10, $this->model->getTotal());
+    public function testCanSetAndGetHits() {
+        $this->assertNull($this->model->getHits());
+        $this->assertSame($this->model, $this->model->setHits(10));
+        $this->assertSame(10, $this->model->getHits());
     }
 
     /**


### PR DESCRIPTION
Renamed the `total` element of the `search` object to `hits`, and made it be set to the total number if images found by the query, without taking `page` and/or `limit` into consideration.
