### PR TITLE
Allow overriding parameters in transformation presets

### DIFF
--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -766,7 +766,7 @@ where the keys are the names of the transformations as specified in the URL, and
         // ...
     );
 
-By doing this the ``thumbnail`` part of the ``fixedGraythumb`` preset will ignore the parameters present in the URL.
+By doing this the ``thumbnail`` part of the ``fixedGraythumb`` preset will ignore the ``width`` and ``height`` query parameters, if present. By only specifying for instance ``'width' => 50`` in the configuration the height of the thumbnail can be adjusted via the query parameter, but the ``width`` is fixed.
 
 .. note:: The URL's will stay the same if you change the transformation chain in a preset. Keep this in mind if you use for instance Varnish or some other HTTP accelerator in front of your web server(s).
 

--- a/library/Imbo/EventListener/ImageTransformer.php
+++ b/library/Imbo/EventListener/ImageTransformer.php
@@ -45,8 +45,13 @@ class ImageTransformer implements ListenerInterface {
                 // Preset
                 foreach ($presets[$transformation['name']] as $name => $params) {
                     if (is_int($name)) {
+                        // No hardcoded params, use the ones from the request
                         $name = $params;
                         $params = $transformation['params'];
+                    } else {
+                        // Some hardcoded params. Merge with the ones from the request, making the
+                        // hardcoded params overwrite the ones from the request
+                        $params = array_replace($transformation['params'], $params);
                     }
 
                     $eventManager->trigger(

--- a/tests/ImboUnitTest/EventListener/ImageTransformerTest.php
+++ b/tests/ImboUnitTest/EventListener/ImageTransformerTest.php
@@ -151,4 +151,42 @@ class ImageTransformerTest extends ListenerTests {
 
         $this->listener->transform($this->event);
     }
+
+    /**
+     * @covers Imbo\EventListener\ImageTransformer::transform
+     */
+    public function testPresetsCanHardcodeSomeParameters() {
+        $this->event->expects($this->once())->method('getConfig')->will($this->returnValue(array(
+            'transformationPresets' => array(
+                'preset' => array(
+                    'thumbnail' => array(
+                        'height' => 75,
+                    ),
+                ),
+            )
+        )));
+        $this->request->expects($this->once())->method('getTransformations')->will($this->returnValue(array(
+            array(
+                'name' => 'preset',
+                'params' => array(
+                    'width' => '100',
+                    'height' => '200',
+                ),
+            ),
+        )));
+
+        $this->eventManager->expects($this->once())
+                           ->method('trigger')
+                           ->with(
+                               'image.transformation.thumbnail',
+                               array(
+                                   'image' => $this->image,
+                                   'params' => array(
+                                       'width' => '100',
+                                       'height' => 75,
+                                   ),
+                               )
+                           );
+        $this->listener->transform($this->event);
+    }
 }


### PR DESCRIPTION
This PR enables overriding of parameters not specified in the transformation preset configuration.

With a configuration like this:

``` php
<?php
return array(
    // ...

    'transformationPresets' => array(
        'customThumb' => array(
            'width' => 50,
        ),
    ),

    // ...
);
```

users can adjust the height of the thumbnail through query parameters, but not the width. Before this PR, if a preset had any parameters, the query params were completely ignored.
