### PR TITLE
Removed metadata query for now

### DIFF
--- a/library/Imbo/Database/Doctrine.php
+++ b/library/Imbo/Database/Doctrine.php
@@ -274,23 +274,6 @@ class Doctrine implements DatabaseInterface {
             }
         }
 
-        if ($metadataQuery = $query->metadataQuery()) {
-            $qb->leftJoin('i', 'metadata', 'm', 'i.id = m.imageId');
-            $tmp = 0;
-
-            foreach ($metadataQuery as $key => $value) {
-                $qb->andWhere($qb->expr()->andx(
-                    $qb->expr()->eq('m.tagName', ':tagName' . $tmp),
-                    $qb->expr()->eq('m.tagValue', ':tagValue' . $tmp)
-                ));
-                $qb->setParameters(array(
-                    ':tagName' . $tmp => $key,
-                    ':tagValue' . $tmp => $value,
-                ));
-                $tmp++;
-            }
-        }
-
         if ($imageIdentifiers = $query->imageIdentifiers()) {
             $expr = $qb->expr();
             $composite = $expr->orX();

--- a/library/Imbo/Database/MongoDB.php
+++ b/library/Imbo/Database/MongoDB.php
@@ -266,14 +266,6 @@ class MongoDB implements DatabaseInterface {
             $queryData['added'] = $tmp;
         }
 
-        $metadataQuery = $query->metadataQuery();
-
-        if (!empty($metadataQuery)) {
-            foreach ($metadataQuery as $key => $value) {
-                $queryData['metadata.' . $key] = $value;
-            }
-        }
-
         $imageIdentifiers = $query->imageIdentifiers();
 
         if (!empty($imageIdentifiers)) {

--- a/library/Imbo/EventListener/DatabaseOperations.php
+++ b/library/Imbo/EventListener/DatabaseOperations.php
@@ -204,14 +204,6 @@ class DatabaseOperations implements ListenerInterface {
             }
         }
 
-        if ($params->has('query')) {
-            $data = json_decode($params->get('query'), true);
-
-            if (is_array($data)) {
-                $query->metadataQuery($data);
-            }
-        }
-
         if ($params->has('ids')) {
             $ids = $params->get('ids');
 

--- a/library/Imbo/Resource/Images/Query.php
+++ b/library/Imbo/Resource/Images/Query.php
@@ -41,13 +41,6 @@ class Query {
     private $returnMetadata = false;
 
     /**
-     * Metadata query
-     *
-     * @var array
-     */
-    private $metadataQuery = array();
-
-    /**
      * Timestamp to start fetching from
      *
      * @var int
@@ -126,22 +119,6 @@ class Query {
         }
 
         $this->returnMetadata = (bool) $returnMetadata;
-
-        return $this;
-    }
-
-    /**
-     * Set or get the metadataQuery property
-     *
-     * @param array $metadataQuery Give this a value to set the property
-     * @return array|self
-     */
-    public function metadataQuery(array $metadataQuery = null) {
-        if ($metadataQuery === null) {
-            return $this->metadataQuery;
-        }
-
-        $this->metadataQuery = $metadataQuery;
 
         return $this;
     }

--- a/tests/ImboIntegrationTest/Database/DatabaseTests.php
+++ b/tests/ImboIntegrationTest/Database/DatabaseTests.php
@@ -390,17 +390,6 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         }
     }
 
-    public function testGetImagesWithMetadataQuery() {
-        $this->insertImages();
-
-        $query = new Query();
-        $query->metadataQuery(array('key2' => 'value2'));
-        $images = $this->adapter->getImages('publickey', $query, $this->getMock('Imbo\Model\Images'));
-
-        $this->assertCount(1, $images);
-        $this->assertSame('fc7d2d06993047a0b5056e8fac4462a2', $images[0]['imageIdentifier']);
-    }
-
     public function testGetImageMimeType() {
         $images = array();
         $publicKey = 'publickey';

--- a/tests/ImboUnitTest/Database/MongoDBTest.php
+++ b/tests/ImboUnitTest/Database/MongoDBTest.php
@@ -82,34 +82,6 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @covers Imbo\Database\MongoDB::getStatus
-     */
-    public function testDottedNotationForMetadataQuery() {
-        $publicKey = 'key';
-
-        $query = $this->getMock('Imbo\Resource\Images\Query');
-        $query->expects($this->once())->method('from')->will($this->returnValue(null));
-        $query->expects($this->once())->method('to')->will($this->returnValue(null));
-        $query->expects($this->once())->method('metadataQuery')->will($this->returnValue(array(
-            'style' => 'IPA',
-            'brewery' => 'Nøgne Ø',
-        )));
-        $query->expects($this->any())->method('limit')->will($this->returnValue(10));
-
-        $cursor = $this->getMockBuilder('MongoCursor')->disableOriginalConstructor()->getMock();
-        $cursor->expects($this->once())->method('limit')->with(10)->will($this->returnSelf());
-        $cursor->expects($this->once())->method('sort')->will($this->returnSelf());
-
-        $this->imageCollection->expects($this->once())->method('find')->with(array(
-            'publicKey' => $publicKey,
-            'metadata.style' => 'IPA',
-            'metadata.brewery' => 'Nøgne Ø',
-        ), $this->isType('array'))->will($this->returnValue($cursor));
-
-        $this->assertSame(array(), $this->driver->getImages($publicKey, $query, $this->getMock('Imbo\Model\Images')));
-    }
-
-    /**
      * @covers Imbo\Database\MongoDB::insertImage
      * @expectedException Imbo\Exception\DatabaseException
      * @expectedExceptionMessage Unable to save image data

--- a/tests/ImboUnitTest/EventListener/DatabaseOperationsTest.php
+++ b/tests/ImboUnitTest/EventListener/DatabaseOperationsTest.php
@@ -193,12 +193,10 @@ class DatabaseOperationsTest extends ListenerTests {
         $query->expects($this->at(9))->method('get')->with('to')->will($this->returnValue(1355176488));
         $query->expects($this->at(10))->method('has')->with('sort')->will($this->returnValue(true));
         $query->expects($this->at(11))->method('get')->with('sort')->will($this->returnValue('size:desc'));
-        $query->expects($this->at(12))->method('has')->with('query')->will($this->returnValue(true));
-        $query->expects($this->at(13))->method('get')->with('query')->will($this->returnValue('{"key":"value"}'));
-        $query->expects($this->at(14))->method('has')->with('ids')->will($this->returnValue(true));
-        $query->expects($this->at(15))->method('get')->with('ids')->will($this->returnValue(array('identifier1', 'identifier2', 'identifier3')));
-        $query->expects($this->at(16))->method('has')->with('checksums')->will($this->returnValue(true));
-        $query->expects($this->at(17))->method('get')->with('checksums')->will($this->returnValue(array('checksum1', 'checksum2', 'checksum3')));
+        $query->expects($this->at(12))->method('has')->with('ids')->will($this->returnValue(true));
+        $query->expects($this->at(13))->method('get')->with('ids')->will($this->returnValue(array('identifier1', 'identifier2', 'identifier3')));
+        $query->expects($this->at(14))->method('has')->with('checksums')->will($this->returnValue(true));
+        $query->expects($this->at(15))->method('get')->with('checksums')->will($this->returnValue(array('checksum1', 'checksum2', 'checksum3')));
         $this->request->query = $query;
 
         $imagesQuery = $this->getMock('Imbo\Resource\Images\Query');

--- a/tests/ImboUnitTest/Resource/Images/QueryTest.php
+++ b/tests/ImboUnitTest/Resource/Images/QueryTest.php
@@ -67,16 +67,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * @covers Imbo\Resource\Images\Query::metadataQuery
-     */
-    public function testMetadataQuery() {
-        $value = array('category' => 'some category');
-        $this->assertSame(array(), $this->query->metadataQuery());
-        $this->assertSame($this->query, $this->query->metadataQuery($value));
-        $this->assertSame($value, $this->query->metadataQuery());
-    }
-
-    /**
      * @covers Imbo\Resource\Images\Query::from
      */
     public function testFrom() {


### PR DESCRIPTION
This PR removes the support fetching images based on metadata queries. This will be added later when a DSL has been defined.
