### PR TITLE
urldecode query params before generating access tokens and auth signatures

### DIFF
--- a/features/bootstrap/ImboContext.php
+++ b/features/bootstrap/ImboContext.php
@@ -110,7 +110,7 @@ class ImboContext extends RESTContext {
         $this->client->getEventDispatcher()->addListener('request.before_send', function($event) {
             $request = $event['request'];
             $request->getQuery()->remove('accessToken');
-            $accessToken = hash_hmac('sha256', $request->getUrl(), $this->privateKey);
+            $accessToken = hash_hmac('sha256', urldecode($request->getUrl()), $this->privateKey);
             $request->getQuery()->set('accessToken', $accessToken);
         }, -100);
     }
@@ -133,7 +133,7 @@ class ImboContext extends RESTContext {
             $query->remove('timestamp');
 
             $timestamp = gmdate('Y-m-d\TH:i:s\Z');
-            $data = $request->getMethod() . '|' . $request->getUrl() . '|' . $this->publicKey . '|' . $timestamp;
+            $data = $request->getMethod() . '|' . urldecode($request->getUrl()) . '|' . $this->publicKey . '|' . $timestamp;
 
             // Generate signature
             $signature = hash_hmac('sha256', $data, $this->privateKey);

--- a/library/Imbo/Http/Request/Request.php
+++ b/library/Imbo/Http/Request/Request.php
@@ -182,7 +182,7 @@ class Request extends SymfonyRequest {
     }
 
     /**
-     * Get the URI without the Symfony normalization applied to the query string
+     * Get the URI without the Symfony normalization applied to the query string, un-encoded
      *
      * @return string
      */
@@ -190,7 +190,7 @@ class Request extends SymfonyRequest {
         $query = $this->server->get('QUERY_STRING');
 
         if (!empty($query)) {
-            $query = '?' . $query;
+            $query = '?' . urldecode($query);
         }
 
         return $this->getSchemeAndHttpHost() . $this->getBaseUrl() . $this->getPathInfo() . $query;

--- a/tests/ImboUnitTest/Http/Request/RequestTest.php
+++ b/tests/ImboUnitTest/Http/Request/RequestTest.php
@@ -205,4 +205,31 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
         $request = new Request($query);
         $request->getTransformations();
     }
+
+    public function getQueryStrings() {
+        return array(
+            'transformation with params' => array(
+                't[]=thumbnail:width=100',
+                't[]=thumbnail:width=100',
+            ),
+            'transformation with params, encoded' => array(
+                't%5B0%5D%3Dthumbnail%3Awidth%3D100',
+                't[0]=thumbnail:width=100',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getQueryStrings
+     */
+    public function testGetRawUriDecodesUri($queryString, $expectedQueryString) {
+        $request = new Request(array(), array(), array(), array(), array(), array(
+            'SERVER_NAME' => 'imbo',
+            'SERVER_PORT' => 80,
+            'QUERY_STRING' => $queryString,
+        ));
+
+        $uri = $request->getRawUri();
+        $this->assertSame($expectedQueryString, substr($uri, strpos($uri, '?') + 1));
+    }
 }


### PR DESCRIPTION
Since the docs are pretty clear about the URL's having to be un-encoded when used for generating the access tokens and auth info it might be a good idea to enforce this on the server.
