### PR TITLE
Stats access event listener only listens to HTTP GET

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,6 +1,14 @@
 Changelog for Imbo
 ==================
 
+Imbo-1.0.1
+----------
+__N/A__
+
+Bug fixes:
+
+* #249: Stats access event listener does not authenticate HTTP HEAD requests
+
 Imbo-1.0.0
 ----------
 __2014-01-30__

--- a/features/stats.feature
+++ b/features/stats.feature
@@ -52,3 +52,19 @@ Feature: Imbo provides a stats endpoint
             | 127.0.0.1 | 127.0.0.1,::1     | 200 OK            |
             | ::1       | 127.0.0.1,::1     | 200 OK            |
             | ::1       | *                 | 200 OK            |
+
+    Scenario Outline: Stats access event listener authenticates HEAD requests as well
+        Given the client IP is "<client-ip>"
+        When I request "/stats.json?statsAllow=<allow>" using HTTP "HEAD"
+        Then I should get a response with "<status>"
+        And the "Content-Type" response header is "application/json"
+
+        Examples:
+            | client-ip | allow             | status            |
+            | 127.0.0.1 | 10.0.0.0          | 403 Access denied |
+            | 127.0.0.1 | 2001:db8::/48     | 403 Access denied |
+            | ::1       | 2001:db8::/48     | 403 Access denied |
+            | ::1       | 127.0.0.1         | 403 Access denied |
+            | 127.0.0.1 | 127.0.0.1,::1     | 200 OK            |
+            | ::1       | 127.0.0.1,::1     | 200 OK            |
+            | ::1       | *                 | 200 OK            |

--- a/library/Imbo/EventListener/StatsAccess.php
+++ b/library/Imbo/EventListener/StatsAccess.php
@@ -57,6 +57,7 @@ class StatsAccess implements ListenerInterface {
     public static function getSubscribedEvents() {
         return array(
             'stats.get' => 'checkAccess',
+            'stats.head' => 'checkAccess',
         );
     }
 

--- a/tests/ImboUnitTest/EventListener/StatsAccessTest.php
+++ b/tests/ImboUnitTest/EventListener/StatsAccessTest.php
@@ -10,7 +10,8 @@
 
 namespace ImboUnitTest\EventListener;
 
-use Imbo\EventListener\StatsAccess;
+use Imbo\EventListener\StatsAccess,
+    Imbo\Resource\Stats as StatsResource;
 
 /**
  * @covers Imbo\EventListener\StatsAccess
@@ -151,5 +152,16 @@ class StatsAccessTest extends ListenerTests {
         }
 
         $listener->checkAccess($this->event);
+    }
+
+    /**
+     * @see https://github.com/imbo/imbo/issues/249
+     */
+    public function testListensToTheSameEventsAsTheStatsResource() {
+        $this->assertSame(
+            array_keys(StatsAccess::getSubscribedEvents()),
+            array_keys(StatsResource::getSubscribedEvents()),
+            'The stats access event listener does not listen to the same events as the stats resource, which it should'
+        );
     }
 }


### PR DESCRIPTION
The stats access event listener only listens to `stats.get` so requests using `HTTP HEAD` does not get authenticated.
