### PR TITLE
Stats access is verified after stats have been generated

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -7,6 +7,7 @@ __N/A__
 
 Bug fixes:
 
+* #251: Stats access event listener is triggered after the stats have been generated
 * #249: Stats access event listener does not authenticate HTTP HEAD requests
 
 Imbo-1.0.0

--- a/library/Imbo/EventListener/StatsAccess.php
+++ b/library/Imbo/EventListener/StatsAccess.php
@@ -56,8 +56,8 @@ class StatsAccess implements ListenerInterface {
      */
     public static function getSubscribedEvents() {
         return array(
-            'stats.get' => 'checkAccess',
-            'stats.head' => 'checkAccess',
+            'stats.get' => array('checkAccess' => 1),
+            'stats.head' => array('checkAccess' => 1),
         );
     }
 


### PR DESCRIPTION
The `Imbo\EventListener\StatsAccess` event listener kicks in after the stats have been generated. It should be run before the stats are generated in case the user is not allowed to access the resource anyways.
