### PR TITLE
Send more HashTwo headers from the VarnishHashTwo event listener

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -6,7 +6,7 @@ Imbo-1.1.0
 __N/A__
 
 * #252: New image transformation: modulate
-* #250: The Varnish HashTwo event listener now includes some extra headers
+* #250: The Varnish HashTwo event listener sends multiple headers
 
 Imbo-1.0.1
 ----------

--- a/docs/installation/event_listeners.rst
+++ b/docs/installation/event_listeners.rst
@@ -444,6 +444,5 @@ or, if you want to use a non-default header name:
 
 The header appears multiple times in the response, with slightly different values::
 
-    X-HashTwo: <publicKey>|<imageIdentifier>
-    X-HashTwo: imbo|image|<publicKey>|<imageIdentifier>
-    X-HashTwo: imbo|user|<publicKey>
+    X-HashTwo: imbo;image;<publicKey>;<imageIdentifier>
+    X-HashTwo: imbo;user;<publicKey>

--- a/features/varnish-hashtwo-listener.feature
+++ b/features/varnish-hashtwo-listener.feature
@@ -12,7 +12,7 @@ Feature: Imbo provides an event listener for the hashtwo Varnish module
         And I include an access token in the query
         When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
         Then I should get a response with "200 OK"
-        And the "X-HashTwo" response header is "publickey|fc7d2d06993047a0b5056e8fac4462a2, imbo|image|publickey|fc7d2d06993047a0b5056e8fac4462a2, imbo|user|publickey"
+        And the "X-HashTwo" response header is "imbo;image;publickey;fc7d2d06993047a0b5056e8fac4462a2, imbo;user;publickey"
 
         Examples:
             | transformation   |
@@ -29,7 +29,7 @@ Feature: Imbo provides an event listener for the hashtwo Varnish module
         And I include an access token in the query
         When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
         Then I should get a response with "200 OK"
-        And the "X-Imbo-HashTwo" response header is "publickey|fc7d2d06993047a0b5056e8fac4462a2, imbo|image|publickey|fc7d2d06993047a0b5056e8fac4462a2, imbo|user|publickey"
+        And the "X-Imbo-HashTwo" response header is "imbo;image;publickey;fc7d2d06993047a0b5056e8fac4462a2, imbo;user;publickey"
 
         Examples:
             | transformation   |

--- a/library/Imbo/EventListener/VarnishHashTwo.php
+++ b/library/Imbo/EventListener/VarnishHashTwo.php
@@ -66,9 +66,8 @@ class VarnishHashTwo implements ListenerInterface {
         $response->headers->set(
             $this->header,
             array(
-                $publicKey . '|' . $imageIdentifier,
-                'imbo|image|' . $publicKey . '|' . $imageIdentifier,
-                'imbo|user|' . $publicKey,
+                'imbo;image;' . $publicKey . ';' . $imageIdentifier,
+                'imbo;user;' . $publicKey,
             )
         );
     }

--- a/tests/ImboUnitTest/EventListener/VarnishHashTwoTest.php
+++ b/tests/ImboUnitTest/EventListener/VarnishHashTwoTest.php
@@ -72,9 +72,8 @@ class VarnishHashTwoTest extends ListenerTests {
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('id'));
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($image));
         $this->responseHeaders->expects($this->once())->method('set')->with('X-HashTwo', array(
-            'key|id',
-            'imbo|image|key|id',
-            'imbo|user|key',
+            'imbo;image;key;id',
+            'imbo;user;key',
         ));
 
         $this->listener->addHeader($this->event);
@@ -92,9 +91,8 @@ class VarnishHashTwoTest extends ListenerTests {
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('id'));
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($image));
         $this->responseHeaders->expects($this->once())->method('set')->with('X-CustomHeader', array(
-            'key|id',
-            'imbo|image|key|id',
-            'imbo|user|key',
+            'imbo;image;key;id',
+            'imbo;user;key',
         ));
 
         $listener->addHeader($this->event);


### PR DESCRIPTION
The `Imbo\EventListener\VarnishHashTwo` event listener should send some more headers, that can be used by vstatd. Examples:
- `imbo:<publicKey>|<imageIdentifier>`
- `imbo:<publicKey>`

This will also make it easier to remove all images for a given user (public key) from the cache.
