### PR TITLE
Index resource should not be cache-able

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -5,6 +5,7 @@ Imbo-1.1.0
 ----------
 __N/A__
 
+* #255: Index resource is no longer cache-able
 * #254: Improved handling of the ETag response header
 * #252: New image transformation: modulate
 * #250: The Varnish HashTwo event listener sends multiple headers

--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -54,6 +54,8 @@ The index resource does not require any authentication per default.
 
 * 200 Hell Yeah
 
+.. note:: The index resource is not cache-able.
+
 .. _stats-resource:
 
 Stats resource - ``/stats``
@@ -696,6 +698,7 @@ Cache-Control
 
 Some responses from Imbo are not cache-able. These will typically include ``Cache-Control: max-age=0, no-store, private``. The following resources are not cache-able:
 
+* :ref:`index-resource`
 * :ref:`stats-resource`
 * :ref:`status-resource`
 

--- a/features/client-caching.feature
+++ b/features/client-caching.feature
@@ -6,8 +6,26 @@ Feature: Imbo enables client caching using related response headers
     Background:
         Given "tests/Fixtures/image1.png" exists in Imbo
 
+    Scenario: Request index page (not cacheable)
+        When I request "/"
+        Then the response is not cacheable
+        And the following response headers should not be present:
+        """
+        last-modified
+        etag
+        """
+
     Scenario: Request status information (not cacheable)
         When I request "/status"
+        Then the response is not cacheable
+        And the following response headers should not be present:
+        """
+        last-modified
+        etag
+        """
+
+    Scenario: Request stats information (not cacheable)
+        When I request "/stats=statsAllow=*"
         Then the response is not cacheable
         And the following response headers should not be present:
         """

--- a/library/Imbo/Resource/Index.php
+++ b/library/Imbo/Resource/Index.php
@@ -71,5 +71,10 @@ class Index implements ResourceInterface {
         ));
 
         $response->setModel($model);
+
+        // Prevent caching
+        $response->setMaxAge(0)
+                 ->setPrivate();
+        $response->headers->addCacheControlDirective('no-store');
     }
 }

--- a/tests/ImboUnitTest/Resource/IndexTest.php
+++ b/tests/ImboUnitTest/Resource/IndexTest.php
@@ -60,10 +60,17 @@ class IndexTest extends ResourceTests {
     /**
      * @covers Imbo\Resource\Index::get
      */
-    public function testUsesAnArrayModel() {
+    public function testSupportsHttpGet() {
         $this->request->expects($this->once())->method('getSchemeAndHttpHost')->will($this->returnValue('http://imbo'));
         $this->request->expects($this->once())->method('getBaseUrl')->will($this->returnValue(''));
         $this->response->expects($this->once())->method('setModel')->with($this->isInstanceOf('Imbo\Model\ArrayModel'));
+        $this->response->expects($this->once())->method('setMaxAge')->with(0)->will($this->returnSelf());
+        $this->response->expects($this->once())->method('setPrivate');
+
+        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $responseHeaders->expects($this->once())->method('addCacheControlDirective')->with('no-store');
+
+        $this->response->headers = $responseHeaders;
 
         $this->resource->get($this->event);
     }


### PR DESCRIPTION
Today only the `/stats` and `/status` resources are not cache-able. The index resource (`/`) should not be cache-able either.
