### PR TITLE
Improved crop functionality

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -5,6 +5,7 @@ Imbo-1.1.0
 ----------
 __N/A__
 
+* #256: Improved crop functionality
 * #255: Index resource is no longer cache-able
 * #254: Improved handling of the ETag response header
 * #252: New image transformation: modulate

--- a/docs/usage/image-transformations.rst
+++ b/docs/usage/image-transformations.rst
@@ -136,9 +136,24 @@ This transformation is used to crop the image.
 ``height``
     The height of the crop in pixels.
 
+``mode``
+    The crop mode (optional). Possible values are:
+
+    ``center``
+        When using the center mode the ``x`` and ``y`` parameters are ignored, and the center of the cropped area is placed in the center of the original image.
+
+    ``center-x``
+        Center the crop on the x-axis. Use the ``y`` parameter to control the upper edge of the crop.
+
+    ``center-y``
+        Center the crop on the y-axis. Use the ``x`` parameter to control the left edge of the crop.
+
 **Examples:**
 
 * ``t[]=crop:x=10,y=25,width=250,height=150``
+* ``t[]=crop:width=100,height=100,mode=center``
+* ``t[]=crop:width=50,height=50,mode=center-x,y=15``
+* ``t[]=crop:width=50,height=50,mode=center-y,x=15``
 
 .. _desaturate-transformation:
 

--- a/features/image-transformations.feature
+++ b/features/image-transformations.feature
@@ -31,6 +31,10 @@ Feature: Imbo enables dynamic transformations of images
             | canvas:width=700,height=600                                                                       | 700   | 600    |
             | crop:width=50,height=60,x=1,y=10                                                                  | 50    | 60     |
             | crop:width=5000,height=6000,x=0,y=0                                                               | 599   | 417    |
+            | crop:mode=center,width=100,height=100                                                             | 100   | 100    |
+            | crop:mode=center,width=6000,height=5000                                                           | 599   | 417    |
+            | crop:mode=center-x,y=10,width=123,height=20                                                       | 123   | 20     |
+            | crop:mode=center-y,x=10,width=234,height=30                                                       | 234   | 30     |
             | desaturate                                                                                        | 599   | 417    |
             | flipHorizontally                                                                                  | 599   | 417    |
             | flipVertically                                                                                    | 599   | 417    |

--- a/library/Imbo/Image/Transformation/Crop.php
+++ b/library/Imbo/Image/Transformation/Crop.php
@@ -38,6 +38,19 @@ class Crop extends Transformation implements ListenerInterface {
     private $y = 0;
 
     /**
+     * The crop mode
+     *
+     * Possible values are:
+     *
+     * - center
+     * - center-x
+     * - center-y
+     *
+     * @var string
+     */
+    private $mode;
+
+    /**
      * {@inheritdoc}
      */
     public static function getSubscribedEvents() {
@@ -64,15 +77,36 @@ class Crop extends Transformation implements ListenerInterface {
         // Fetch the x, y, width and height of the resulting image
         $x = !empty($params['x']) ? (int) $params['x'] : $this->x;
         $y = !empty($params['y']) ? (int) $params['y'] : $this->y;
+        $mode = !empty($params['mode']) ? $params['mode'] : null;
 
         $width = (int) $params['width'];
         $height = (int) $params['height'];
+        $imageWidth = $image->getWidth();
+        $imageHeight = $image->getHeight();
+
+        // Fix too large values for width and/or height
+        if ($width > $imageWidth) {
+            $width = $imageWidth;
+        }
+
+        if ($height > $imageHeight) {
+            $height = $imageHeight;
+        }
+
+        // Set correct x and/or y values based on the crop mode
+        if ($mode === 'center' || $mode === 'center-x') {
+            $x = (int) ($imageWidth - $width) / 2;
+        }
+
+        if ($mode === 'center' || $mode === 'center-y') {
+            $y = (int) ($imageHeight - $height) / 2;
+        }
 
         // Return if there is no need for cropping
         if (
             $x === 0 && $y === 0 &&
-            $image->getWidth() <= $width &&
-            $image->getHeight() <= $height
+            $imageWidth <= $width &&
+            $imageHeight <= $height
         ) {
             return;
         }

--- a/tests/ImboIntegrationTest/Image/Transformation/CropTest.php
+++ b/tests/ImboIntegrationTest/Image/Transformation/CropTest.php
@@ -36,6 +36,10 @@ class CropTest extends TransformationTests {
             'cropped area larger than the image' => array(array('width' => 1000, 'height' => 1000), 665, 463, false),
             'cropped area smaller than the image' => array(array('width' => 100, 'height' => 50), 100, 50, true),
             'cropped area smaller than the image with x and y offset' => array(array('width' => 100, 'height' => 100, 'x' => 600, 'y' => 400), 65, 63, true),
+            'center mode' => array(array('mode' => 'center', 'width' => 150, 'height' => 100), 150, 100, true),
+            'center-x mode' => array(array('mode' => 'center-x', 'y' => 10, 'width' => 50, 'height' => 40), 50, 40, true),
+            'center-y mode' => array(array('mode' => 'center-y', 'x' => 10, 'width' => 50, 'height' => 40), 50, 40, true),
+            'center mode with cropped area larger than the image' => array(array('mode' => 'center', 'width' => 1000, 'height' => 1000), 665, 463, false),
         );
     }
 


### PR DESCRIPTION
The crop transformation currently supports four parameters:
- `x`
- `y`
- `width`
- `height`

It should also support a cropping mode, that could be set to the following values:
- ~~`free`: Use the `x` and `y` parameters to specify the position of the upper left corner of the crop (default, and is the way the transformation works today).~~
- `center`: The transformation will disregard `x` and `y`, and place the crop in the center of the image.
- `center-x`: Center the crop on the x-axis, and use the `y` parameter to control the upper edge of the crop.
- `center-y`: Center the crop on the y-axis, and use the `x` parameter to control the left edge of the crop.
