### PR TITLE
Remove unused use-statements

### DIFF
--- a/library/Imbo/Application.php
+++ b/library/Imbo/Application.php
@@ -21,7 +21,6 @@ use Imbo\Http\Request\Request,
     Imbo\Database\DatabaseInterface,
     Imbo\Storage\StorageInterface,
     Imbo\Http\Response\Formatter,
-    Imbo\Image\Transformation,
     Imbo\Resource\ResourceInterface,
     Imbo\EventListener\Initializer\InitializerInterface;
 

--- a/library/Imbo/Database/Doctrine.php
+++ b/library/Imbo/Database/Doctrine.php
@@ -636,7 +636,6 @@ class Doctrine implements DatabaseInterface {
 
         foreach ($data as $key => $value) {
             $keys = explode($this->metadataNamespaceSeparator, $key);
-            $numKeys = count($keys);
             $tmp = &$result;
 
             foreach ($keys as $i => $key) {

--- a/library/Imbo/EventListener/DatabaseOperations.php
+++ b/library/Imbo/EventListener/DatabaseOperations.php
@@ -11,10 +11,8 @@
 namespace Imbo\EventListener;
 
 use Imbo\EventManager\EventInterface,
-    Imbo\Database\DatabaseInterface,
     Imbo\Resource\Images\Query as ImagesQuery,
-    Imbo\Model,
-    DateTime;
+    Imbo\Model;
 
 /**
  * Database operations event listener

--- a/library/Imbo/EventListener/StatsAccess.php
+++ b/library/Imbo/EventListener/StatsAccess.php
@@ -11,7 +11,6 @@
 namespace Imbo\EventListener;
 
 use Imbo\EventManager\EventInterface,
-    Imbo\Http\Request\Request,
     Imbo\Exception\RuntimeException;
 
 /**

--- a/library/Imbo/EventListener/StorageOperations.php
+++ b/library/Imbo/EventListener/StorageOperations.php
@@ -11,8 +11,7 @@
 namespace Imbo\EventListener;
 
 use Imbo\EventManager\EventInterface,
-    Imbo\Exception\StorageException,
-    Imbo\Storage\StorageInterface;
+    Imbo\Exception\StorageException;
 
 /**
  * Storage operations event listener

--- a/library/Imbo/EventManager/Event.php
+++ b/library/Imbo/EventManager/Event.php
@@ -10,11 +10,7 @@
 
 namespace Imbo\EventManager;
 
-use Imbo\Http\Request\Request,
-    Imbo\Http\Response\Response,
-    Imbo\Database\DatabaseInterface,
-    Imbo\Storage\StorageInterface,
-    Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Event class

--- a/library/Imbo/Http/Response/Response.php
+++ b/library/Imbo/Http/Response/Response.php
@@ -10,12 +10,8 @@
 
 namespace Imbo\Http\Response;
 
-use Imbo\EventManager\EventInterface,
-    Imbo\Exception,
-    Imbo\Model,
-    Symfony\Component\HttpFoundation\Response as SymfonyResponse,
-    DateTime,
-    DateTimeZone;
+use Imbo\Model,
+    Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 /**
  * Response object from the server to the client

--- a/library/Imbo/Http/Response/ResponseFormatter.php
+++ b/library/Imbo/Http/Response/ResponseFormatter.php
@@ -14,7 +14,6 @@ use Imbo\EventManager\EventInterface,
     Imbo\EventListener\ListenerInterface,
     Imbo\Model,
     Imbo\Exception,
-    Imbo\Http\ContentNegotiation,
     Symfony\Component\HttpFoundation\AcceptHeader;
 
 /**

--- a/library/Imbo/Image/ImagePreparation.php
+++ b/library/Imbo/Image/ImagePreparation.php
@@ -16,8 +16,7 @@ use Imbo\EventManager\EventInterface,
     Imbo\Exception,
     Imbo\Model\Image,
     Imagick,
-    ImagickException,
-    finfo;
+    ImagickException;
 
 /**
  * Image preparation

--- a/library/Imbo/Image/Transformation/AutoRotate.php
+++ b/library/Imbo/Image/Transformation/AutoRotate.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     Imagick,

--- a/library/Imbo/Image/Transformation/Border.php
+++ b/library/Imbo/Image/Transformation/Border.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException,

--- a/library/Imbo/Image/Transformation/Canvas.php
+++ b/library/Imbo/Image/Transformation/Canvas.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     Imagick,

--- a/library/Imbo/Image/Transformation/Compress.php
+++ b/library/Imbo/Image/Transformation/Compress.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/Desaturate.php
+++ b/library/Imbo/Image/Transformation/Desaturate.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/FlipVertically.php
+++ b/library/Imbo/Image/Transformation/FlipVertically.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/MaxSize.php
+++ b/library/Imbo/Image/Transformation/MaxSize.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/Modulate.php
+++ b/library/Imbo/Image/Transformation/Modulate.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/Resize.php
+++ b/library/Imbo/Image/Transformation/Resize.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/Rotate.php
+++ b/library/Imbo/Image/Transformation/Rotate.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException,

--- a/library/Imbo/Image/Transformation/Sepia.php
+++ b/library/Imbo/Image/Transformation/Sepia.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/Thumbnail.php
+++ b/library/Imbo/Image/Transformation/Thumbnail.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/Transpose.php
+++ b/library/Imbo/Image/Transformation/Transpose.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/Transverse.php
+++ b/library/Imbo/Image/Transformation/Transverse.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\TransformationException,
+use Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,
     ImagickException;

--- a/library/Imbo/Image/Transformation/Watermark.php
+++ b/library/Imbo/Image/Transformation/Watermark.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Model\Image,
-    Imbo\Exception\StorageException,
+use Imbo\Exception\StorageException,
     Imbo\Exception\TransformationException,
     Imbo\EventListener\ListenerInterface,
     Imbo\EventManager\EventInterface,

--- a/library/Imbo/Resource/Image.php
+++ b/library/Imbo/Resource/Image.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Resource;
 
-use Imbo\Exception\ResourceException,
-    Imbo\EventManager\EventInterface,
+use Imbo\EventManager\EventInterface,
     Imbo\Model;
 
 /**

--- a/library/Imbo/Resource/Stats.php
+++ b/library/Imbo/Resource/Stats.php
@@ -10,10 +10,7 @@
 
 namespace Imbo\Resource;
 
-use Imbo\EventManager\EventInterface,
-    Imbo\Model,
-    DateTime,
-    DateTimeZone;
+use Imbo\EventManager\EventInterface;
 
 /**
  * Stats resource

--- a/library/Imbo/Storage/Filesystem.php
+++ b/library/Imbo/Storage/Filesystem.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Storage;
 
-use Imbo\Model\Image,
-    Imbo\Exception\StorageException,
+use Imbo\Exception\StorageException,
     Imbo\Exception,
     DateTime,
     DateTimeZone;

--- a/library/Imbo/Storage/GridFS.php
+++ b/library/Imbo/Storage/GridFS.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Storage;
 
-use Imbo\Model\Image,
-    Imbo\Exception\StorageException,
+use Imbo\Exception\StorageException,
     Mongo,
     MongoClient,
     MongoGridFS,

--- a/library/Imbo/Storage/S3.php
+++ b/library/Imbo/Storage/S3.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Storage;
 
-use Imbo\Model\Image,
-    Imbo\Exception\StorageException,
+use Imbo\Exception\StorageException,
     Aws\S3\S3Client,
     Aws\S3\Exception\NoSuchKeyException,
     Aws\S3\Exception\S3Exception,

--- a/library/Imbo/Storage/StorageInterface.php
+++ b/library/Imbo/Storage/StorageInterface.php
@@ -10,8 +10,7 @@
 
 namespace Imbo\Storage;
 
-use Imbo\Model\Image,
-    Imbo\Exception\StorageException;
+use Imbo\Exception\StorageException;
 
 /**
  * Storage adapter interface


### PR DESCRIPTION
After numerous code-changes, there have been left a number of use statements in various classes that are no longer needed.

I took the liberty to remove them.
