### PR TITLE
In special cases, access tokens can be bypassed

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,6 +1,14 @@
 Changelog for Imbo
 ==================
 
+Imbo-1.1.1
+----------
+__2014-02-14__
+
+Bug fixes:
+
+* #258: In special cases, images can be accessed without access tokens
+
 Imbo-1.1.0
 ----------
 __2014-02-13__

--- a/config/config.testing.php
+++ b/config/config.testing.php
@@ -146,7 +146,16 @@ return array(
 
     'eventListeners' => array(
         'auth' => 'Imbo\EventListener\Authenticate',
-        'accessToken' => 'Imbo\EventListener\AccessToken',
+        'accessToken' => array(
+            'listener' => 'Imbo\EventListener\AccessToken',
+            'params' => array(
+                'transformations' => array(
+                   'whitelist' => array(
+                        'whitelisted',
+                    ),
+                ),
+            ),
+        ),
         'statsAccess' => array(
             'listener' => 'Imbo\EventListener\StatsAccess',
             'params' => array('allow' => $statsAllow),
@@ -242,6 +251,13 @@ return array(
         'graythumb' => array(
             'thumbnail',
             'desaturate',
+        ),
+        'whitelisted' => array(
+            'crop' => array(
+                'width' => 100,
+                'height' => 50,
+                'mode' => 'center',
+            )
         ),
     ),
 

--- a/features/access-token.feature
+++ b/features/access-token.feature
@@ -3,6 +3,9 @@ Feature: Imbo requires an access token for read operations
     As an HTTP Client
     I must specify an access token in the URI
 
+    Background:
+        Given "tests/Fixtures/image.png" exists in Imbo
+
     Scenario: Request user information using the correct private key
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
@@ -21,3 +24,23 @@ Feature: Imbo requires an access token for read operations
         When I request "/users/publickey"
         Then I should get a response with "400 Missing access token"
         And the Imbo error message is "Missing access token" and the error code is "0"
+
+    Scenario: Request image using no access token
+        Given I use "publickey" and "privatekey" for public and private keys
+        And the "Accept" request header is "*/*"
+        When I request "/users/publickey/images/929db9c5fc3099f7576f5655207eba47"
+        Then I should get a response with "400 Missing access token"
+
+    Scenario: Can request a whitelisted transformation without access tokens
+        Given I use "publickey" and "privatekey" for public and private keys
+        And the "Accept" request header is "*/*"
+        When I request "/users/publickey/images/929db9c5fc3099f7576f5655207eba47?t[]=whitelisted"
+        Then I should get a response with "200 OK"
+        And the width of the image is "100"
+        And the height of the image is "50"
+
+    Scenario: Can not issue transformations that are not whitelisted without a valid access token
+        Given I use "publickey" and "privatekey" for public and private keys
+        And the "Accept" request header is "*/*"
+        When I request "/users/publickey/images/929db9c5fc3099f7576f5655207eba47?t[]=thumbnail"
+        Then I should get a response with "400 Missing access token"

--- a/tests/ImboUnitTest/EventListener/AccessTokenTest.php
+++ b/tests/ImboUnitTest/EventListener/AccessTokenTest.php
@@ -101,8 +101,14 @@ class AccessTokenTest extends ListenerTests {
      */
     public function getFilterData() {
         return array(
-            array(
+            'no filter and no transformations' => array(
                 $filter = array(),
+                $transformations = array(),
+                $whitelisted = false,
+            ),
+            // @see https://github.com/imbo/imbo/issues/258
+            'configured filters, but no transformations in the request' => array(
+                $filter = array('transformations' => array('whitelist' => array('border'))),
                 $transformations = array(),
                 $whitelisted = false,
             ),


### PR DESCRIPTION
In a very special case, original images (as in images with no transformations) can be viewed without any access tokens.

If the server admin has configured the `Imbo\EventListener\AccessToken` event listener with a whitelist and/or a blacklist of transformations, requests against the image resource that does not include any transformations at all in the request is allowed.
