### PR TITLE
Increase priority of CORS-listener

### DIFF
--- a/library/Imbo/EventListener/Cors.php
+++ b/library/Imbo/EventListener/Cors.php
@@ -89,7 +89,7 @@ class Cors implements ListenerInterface {
         foreach ($this->params['allowedMethods'] as $resource => $methods) {
             foreach ($methods as $method) {
                 $eventName = $resource . '.' . strtolower($method);
-                $events[$eventName] = array('invoke' => 20);
+                $events[$eventName] = array('invoke' => 100);
             }
 
             // Always enable the listener for the OPTIONS method


### PR DESCRIPTION
The CORS-listener will not trigger if an event listener with a high priority terminates the request. This makes it impossible for browsers using CORS to get back the error message from the server, instead resulting in a CORS-error.

This PR simply bumps the priority up to 100, which enables it to add the required headers before events like image validation and similar.
