### PR TITLE
Verify extension provided when generating ShortUrls

### DIFF
--- a/library/Imbo/Resource/ShortUrls.php
+++ b/library/Imbo/Resource/ShortUrls.php
@@ -12,7 +12,8 @@ namespace Imbo\Resource;
 
 use Imbo\EventManager\EventInterface,
     Imbo\Exception\InvalidArgumentException,
-    Imbo\Model\ArrayModel;
+    Imbo\Model\ArrayModel,
+    Imbo\Model\Image;
 
 /**
  * Short URL collection
@@ -69,7 +70,12 @@ class ShortUrls implements ResourceInterface {
             throw new InvalidArgumentException('Missing or invalid image identifier', 400);
         }
 
-        $extension = isset($image['extension']) ? $image['extension'] : null;
+        $extension = isset($image['extension']) ? strtolower($image['extension']) : null;
+
+        if ($extension !== null && !in_array($extension, Image::$mimeTypes)) {
+            throw new InvalidArgumentException('Extension provided is not a recognized format', 400);
+        }
+
         $queryString = isset($image['query']) ? $image['query'] : null;
 
         if ($queryString) {

--- a/tests/phpunit/ImboUnitTest/Resource/ShortUrlsTest.php
+++ b/tests/phpunit/ImboUnitTest/Resource/ShortUrlsTest.php
@@ -125,6 +125,18 @@ class ShortUrlsTest extends ResourceTests {
         $this->getNewResource()->createShortUrl($this->event);
     }
 
+    /**
+     * @expectedException Imbo\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Extension provided is not a recognized format
+     * @expectedExceptionCode 400
+     */
+    public function testWillThrowAnExceptionWhenExtensionIsNotRecognized() {
+        $this->request->expects($this->once())->method('getContent')->will($this->returnValue('{"publicKey": "key", "imageIdentifier": "id", "extension": "foo"}'));
+        $this->request->expects($this->once())->method('getPublicKey')->will($this->returnValue('key'));
+        $this->request->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('id'));
+        $this->getNewResource()->createShortUrl($this->event);
+    }
+
     public function createShortUrlParams() {
         return array(
             'no extension, no query' => array(


### PR DESCRIPTION
When generating ShortUrls, the server does not currently validate the extension provided by the client.

If the user provides an unsupported extension, the ShortUrl is generated, but upon trying to fetch it, Imbo will respond with a 500 error and throw an exception: "Unable to set image format".

This PR validates the extension provided (if any) against the list of known image formats supported in Imbo.
