### PR TITLE
Adds x-jpeg, x-png and x-gif as accepted mimetypes.

### DIFF
--- a/library/Imbo/Model/Image.php
+++ b/library/Imbo/Model/Image.php
@@ -26,8 +26,11 @@ class Image implements ModelInterface {
      */
     static public $mimeTypes = array(
         'image/png'  => 'png',
+        'image/x-png' => 'png',
         'image/jpeg' => 'jpg',
+        'image/x-jpeg' => 'jpg',
         'image/gif'  => 'gif',
+        'image/x-gif' => 'gif',
     );
 
     /**


### PR DESCRIPTION
These mimetypes may be returned by ImageMagick on Windows when
calling ->getMimeType() on an imagick object.
