### PR TITLE
Adds x-versions of mimetypes to response formatter.

### DIFF
--- a/library/Imbo/Http/Response/ResponseFormatter.php
+++ b/library/Imbo/Http/Response/ResponseFormatter.php
@@ -61,8 +61,11 @@ class ResponseFormatter implements ListenerInterface {
         'application/json' => 'json',
         'application/xml'  => 'xml',
         'image/gif'        => 'gif',
+        'image/x-gif'      => 'gif',
         'image/png'        => 'png',
+        'image/x-png'      => 'png',
         'image/jpeg'       => 'jpg',
+        'image/x-jpeg'     => 'jpg',
     );
 
     /**


### PR DESCRIPTION
After the commit updating the accepted mimetypes at image add,
the two lists of accepted mimetypes are no longer in sync. If an image
without an extension is requested, Imbo will generate an error on
retrieval unless the corresponding mimetypes are added to the
response formatter as well.

We might want to refactor this into one single list somewhere down the line.
