### PR TITLE
Strip x- mime types before validation

### DIFF
--- a/library/Imbo/Image/ImagePreparation.php
+++ b/library/Imbo/Image/ImagePreparation.php
@@ -61,7 +61,7 @@ class ImagePreparation implements ListenerInterface {
 
         try {
             $imagick->readImageBlob($imageBlob);
-            $mime = $imagick->getImageMimeType();
+            $mime = str_replace('x-', '', $imagick->getImageMimeType());
             $size = $imagick->getImageGeometry();
         } catch (ImagickException $e) {
             $e = new ImageException('Invalid image', 415);

--- a/library/Imbo/Model/Image.php
+++ b/library/Imbo/Model/Image.php
@@ -26,11 +26,8 @@ class Image implements ModelInterface {
      */
     static public $mimeTypes = array(
         'image/png'  => 'png',
-        'image/x-png' => 'png',
         'image/jpeg' => 'jpg',
-        'image/x-jpeg' => 'jpg',
         'image/gif'  => 'gif',
-        'image/x-gif' => 'gif',
     );
 
     /**


### PR DESCRIPTION
I needed a fix for #286 as all my images were being rejected. It may not be the most elegant of solutions but it's a start, so thought I'd PR.

I've also removed x-{n} from the supported mime types array as these are no longer needed.
