### PR TITLE
Vary on Origin when Cors-listener is enabled

### DIFF
--- a/library/Imbo/EventListener/Cors.php
+++ b/library/Imbo/EventListener/Cors.php
@@ -190,6 +190,9 @@ class Cors implements ListenerInterface {
 
         $origin = $request->headers->get('Origin', '*');
 
+        // Vary on Origin to prevent caching allowed/disallowed requests
+        $event->getResponse()->setVary('Origin', false);
+
         // Fall back if the passed origin is not allowed
         if (!$this->originIsAllowed($origin)) {
             return;

--- a/library/Imbo/Http/Response/ResponseFormatter.php
+++ b/library/Imbo/Http/Response/ResponseFormatter.php
@@ -170,7 +170,7 @@ class ResponseFormatter implements ListenerInterface {
             $formatter = $this->supportedTypes[$mime];
         } else {
             // Set Vary to Accept since we are doing content negotiation based on Accept
-            $response->setVary('Accept');
+            $response->setVary('Accept', false);
 
             // No extension have been provided
             $acceptableTypes = array();

--- a/tests/behat/features/cors-event-listener.feature
+++ b/tests/behat/features/cors-event-listener.feature
@@ -11,6 +11,7 @@ Feature: Imbo provides an event listener for CORS
         And the "Access-Control-Allow-Origin" response header is "http://allowedhost"
         And the "Access-Control-Expose-Headers" response header contains "X-Imbo-ImageIdentifier"
         And the "Access-Control-Expose-Headers" response header contains "X-Imbo-Version"
+        And the "Vary" response header contains "Origin"
         And the "Allow" response header contains "GET"
         And the "Allow" response header contains "HEAD"
         And the "Allow" response header contains "OPTIONS"
@@ -20,6 +21,7 @@ Feature: Imbo provides an event listener for CORS
         And Imbo uses the "cors.php" configuration
         When I request "/" using HTTP "HEAD"
         Then I should get a response with "200 Hell Yeah"
+        And the "Vary" response header contains "Origin"
         And the "Allow" response header contains "GET"
         And the "Allow" response header contains "HEAD"
         And the "Allow" response header contains "OPTIONS"
@@ -69,6 +71,7 @@ Feature: Imbo provides an event listener for CORS
         And I attach "ChangeLog.markdown" to the request body
         When I request "/users/publickey/images" using HTTP "POST"
         Then I should get a response with "415 Invalid image"
+        And the "Vary" response header contains "Origin"
         And the following response headers should be present:
         """
         Access-Control-Allow-Origin


### PR DESCRIPTION
When Imbo is running behind a cache such as Varnish and a browser sends a request using XHR with CORS, the Origin header is present. Imbo validates the origin against a whitelist and responds with an Access-Control-Allow-Origin header containing the origin from the request. This is however cached in Varnish, and subsequent requests against the same resource with a different Origin header will get a cached response with a response header which causes the browser to reject the request.

This PR adds Origin to the list of headers to vary on, ensuring that the responses can be cached.
