### PR TITLE
ShortUrls cannot be retrieved with latest MongoDB driver

### DIFF
--- a/library/Imbo/Database/MongoDB.php
+++ b/library/Imbo/Database/MongoDB.php
@@ -523,11 +523,7 @@ class MongoDB implements DatabaseInterface {
             $result = $this->getShortUrlCollection()->findOne(array(
                 'shortUrlId' => $shortUrlId,
             ), array(
-                '_id' => null,
-                'publicKey',
-                'imageIdentifier',
-                'extension',
-                'query',
+                '_id' => false
             ));
 
             if (!$result) {


### PR DESCRIPTION
This PR fixes a bug where the latest MongoDB driver would return no fields from a `findOne()`-call with an invalid field specification.

This currently returns all fields except `_id`. If we want to explicitly return the fields that were specified earlier, it could be changed to:

``` php
array(
    '_id' => false,
    'publicKey' => true,
    'imageIdentifier' => true,
    'extension' => true,
    'query' => true,
)
```
