### PR TITLE
Add php 5.6 to build matrix and enable apcu-extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 5.4
   - 5.5
+  - 5.6
 notifications:
   irc:
     use_notice: true
@@ -18,10 +19,12 @@ before_install:
   - sudo add-apt-repository -y ppa:moti-p/cc
   - sudo apt-get update
   - sudo apt-get -y --reinstall install imagemagick
+  - printf "\n" | pecl install apcu-beta
   - printf "\n" | pecl install imagick-beta
 before_script:
   - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo "apc.enable_cli=On" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - composer self-update
   - composer -n --no-ansi install --dev --prefer-source
 script:


### PR DESCRIPTION
Apart from the bug fixed in #294, tests seems to work fine on php 5.6, so I have added it to the travis build matrix. Also enabled the apcu-extension to ensure the entire test suite is run on travis.
