### PR TITLE
Update configuration.rst to fix s3 example typo

### DIFF
--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -276,8 +276,8 @@ Examples
         // ...
 
         'storage' => function() {
-            new Imbo\Storage\S3(array(
-                'key' => '<aws access key>'
+            return new Imbo\Storage\S3(array(
+                'key' => '<aws access key>',
                 'secret' => '<aws secret key>',
                 'bucket' => 'my-imbo-bucket',
             ));


### PR DESCRIPTION
Fix to typos in s3 configuration example in documentation
(missing return keyword and missing comma)
