### PR TITLE
Doctrine driver does not limit on publicKey when listing images

### DIFF
--- a/library/Imbo/Database/Doctrine.php
+++ b/library/Imbo/Database/Doctrine.php
@@ -234,7 +234,8 @@ class Doctrine implements DatabaseInterface {
 
         $qb = $this->getConnection()->createQueryBuilder();
         $qb->select('*')
-           ->from($this->tableNames['imageinfo'], 'i');
+           ->from($this->tableNames['imageinfo'], 'i')
+           ->where('i.publicKey = :publicKey')->setParameter(':publicKey', $publicKey);
 
         if ($sort = $query->sort()) {
             // Fields valid for sorting
@@ -268,7 +269,7 @@ class Doctrine implements DatabaseInterface {
 
         if ($from || $to) {
             if ($from !== null) {
-                $qb->where('added >= :from')->setParameter(':from', $from);
+                $qb->andWhere('added >= :from')->setParameter(':from', $from);
             }
 
             if ($to !== null) {
@@ -338,7 +339,7 @@ class Doctrine implements DatabaseInterface {
                 'updated'          => new DateTime('@' . $row['updated'], new DateTimeZone('UTC')),
                 'checksum'         => $row['checksum'],
                 'originalChecksum' => isset($row['originalChecksum']) ? $row['originalChecksum'] : null,
-                'publicKey'        => $publicKey,
+                'publicKey'        => $row['publicKey'],
                 'imageIdentifier'  => $row['imageIdentifier'],
                 'mime'             => $row['mime'],
                 'size'             => (int) $row['size'],


### PR DESCRIPTION
There was a bug in the Doctrine driver, causing requests against `/users/<user>/images` to actually return images for _all_ public keys, not just the specified `<user>`.

This PR fixes this, and adds a test to the database suite which ensures all adapters implement this properly.
