### PR TITLE
Wrapped Imbo\Database\Doctrine::getStatus() in a try/catch. Fixes #312.

### DIFF
--- a/library/Imbo/Database/Doctrine.php
+++ b/library/Imbo/Database/Doctrine.php
@@ -20,6 +20,7 @@ use Imbo\Model\Image,
     Doctrine\DBAL\DriverManager,
     Doctrine\DBAL\Connection,
     PDO,
+    PDOException,
     DateTime,
     DateTimeZone;
 
@@ -449,9 +450,13 @@ class Doctrine implements DatabaseInterface {
      * {@inheritdoc}
      */
     public function getStatus() {
-        $connection = $this->getConnection();
+        try {
+            $connection = $this->getConnection();
 
-        return $connection->isConnected() || $connection->connect();
+            return $connection->isConnected() || $connection->connect();
+        } catch (PDOException $e) {
+            return false;
+        }
     }
 
     /**

--- a/tests/phpunit/ImboUnitTest/Database/DoctrineTest.php
+++ b/tests/phpunit/ImboUnitTest/Database/DoctrineTest.php
@@ -12,6 +12,7 @@ namespace ImboUnitTest\Database;
 
 use Imbo\Database\Doctrine,
     Doctrine\DBAL\Connection,
+    PDOException,
     ReflectionMethod;
 
 /**
@@ -74,6 +75,15 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
     public function testGetStatusWhenDatabaseIsNotConnectedAndCanNotConnect() {
         $this->connection->expects($this->once())->method('isConnected')->will($this->returnValue(false));
         $this->connection->expects($this->once())->method('connect')->will($this->returnValue(false));
+        $this->assertFalse($this->driver->getStatus());
+    }
+
+    /**
+     * @covers Imbo\Database\Doctrine::getStatus
+     */
+    public function testGetStatusWhenDatabaseIsNotConnectedAndConnectThrowsAnException() {
+        $this->connection->expects($this->once())->method('isConnected')->will($this->returnValue(false));
+        $this->connection->expects($this->once())->method('connect')->will($this->throwException(new PDOException));
         $this->assertFalse($this->driver->getStatus());
     }
 


### PR DESCRIPTION
This ensures that `Imbo\Database\Doctrine::getStatus()` will return false even if `connect()` throws a PDOException - which it will on incorrect credentials.

I've added a unit test that checks that the exception is handled correctly...
