### PR TITLE
Added hhvm as a Travis-CI env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+
 notifications:
   irc:
     use_notice: true


### PR DESCRIPTION
This PR adds a new environment (hhvm) for the test suites at Travis-CI. This environment will currently fail, but the build will still pass.