### PR TITLE
Behat config option for path of internal httpd log location

### DIFF
--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -13,6 +13,9 @@ default:
       documentRoot: public
       router: %behat.paths.base%/router.php
 
+      # httpd log file location
+      httpdLog: /dev/null
+
       # Timeout when trying to connect to the built in httpd
       timeout: 5
 

--- a/tests/behat/bootstrap/RESTContext.php
+++ b/tests/behat/bootstrap/RESTContext.php
@@ -123,7 +123,8 @@ class RESTContext extends BehatContext {
             $url['host'],
             $port,
             $params['documentRoot'],
-            $params['router']
+            $params['router'],
+            $params['httpdLog']
         );
 
         if (!$pid) {
@@ -401,15 +402,17 @@ class RESTContext extends BehatContext {
      * @param int $port The port to use
      * @param string $documentRoot The document root
      * @param string $router Path to an optional router
+     * @param string $httpdLog Path the httpd log should be written to
      * @return int Returns the PID of the httpd
      * @throws RuntimeException
      */
-    private static function startBuiltInHttpd($host, $port, $documentRoot, $router = null) {
-        $command = sprintf('php -S %s:%d -t %s %s >/dev/null 2>&1 & echo $!',
+    private static function startBuiltInHttpd($host, $port, $documentRoot, $router, $httpdLog) {
+        $command = sprintf('php -S %s:%d -t %s %s >%s 2>&1 & echo $!',
                             $host,
                             $port,
                             $documentRoot,
-                            $router);
+                            $router,
+                            $httpdLog);
 
         $output = array();
         exec($command, $output);


### PR DESCRIPTION
Sometimes while developing, you come across issues that are hard to reproduce outside the testing environment, and the messages you get from behat are often insufficient for finding the source of the problem:

```
--- Expected
+++ Actual
@@ @@
-404 User not found
+500 Internal Server Error
```

Instead of sending all the log output of the spawned httpd-server to /dev/null, this PR adds a configuration option for the location, enabling developers to instead send the output to a log file which will usually be sufficient for finding the source of the problem.