### PR TITLE
Add event hooks to accessToken and authenticate event listeners

### DIFF
--- a/library/Imbo/EventListener/AccessToken.php
+++ b/library/Imbo/EventListener/AccessToken.php
@@ -81,7 +81,8 @@ class AccessToken implements ListenerInterface {
         $callbacks = array();
         $events = array(
             'user.get', 'images.get', 'image.get', 'metadata.get',
-            'user.head', 'images.head', 'image.head', 'metadata.head'
+            'user.head', 'images.head', 'image.head', 'metadata.head',
+            'auth.accesstoken'
         );
 
         foreach ($events as $event) {

--- a/library/Imbo/EventListener/Authenticate.php
+++ b/library/Imbo/EventListener/Authenticate.php
@@ -45,14 +45,15 @@ class Authenticate implements ListenerInterface {
     public static function getSubscribedEvents() {
         $callbacks = array();
         $events = array(
-            'images.post',      // When adding images
-            'image.delete',     // When deleting images
-            'metadata.put',     // When adding/replacing metadata
-            'metadata.post',    // When adding/patching metadata
-            'metadata.delete',  // When deleting metadata
-            'shorturls.post',   // Add a short URL
-            'shorturls.delete', // Delete a collection of short URLs
-            'shorturl.delete',  // Delete a single short URL
+            'images.post',       // When adding images
+            'image.delete',      // When deleting images
+            'metadata.put',      // When adding/replacing metadata
+            'metadata.post',     // When adding/patching metadata
+            'metadata.delete',   // When deleting metadata
+            'shorturls.post',    // Add a short URL
+            'shorturls.delete',  // Delete a collection of short URLs
+            'shorturl.delete',   // Delete a single short URL
+            'auth.authenticate', // Authenticate event
         );
 
         foreach ($events as $event) {


### PR DESCRIPTION
In order for custom resources to use the built in authenticate and accessToken validation two generic event hooks is needed. This way the custom resources can simply trigger these events in order to authenticate.