### PR TITLE
Fix two issues in StripImageTest 

### DIFF
--- a/tests/phpunit/ImboIntegrationTest/Image/Transformation/StripTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Image/Transformation/StripTest.php
@@ -60,6 +60,14 @@ class StripTest extends TransformationTests {
 
         $this->getTransformation()->setImagick($imagick)->transform($event);
 
+        // we need to actually re-read the image data on Windows (or certain ImageMagick versions?)
+        // to see the change in image properties..
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $data = $imagick->getImagesBlob();
+            $imagick->clear();
+            $imagick->readImageBlob($data);
+        }
+
         foreach ($imagick->getImageProperties() as $key => $value) {
             $this->assertStringStartsNotWith('exif', $key);
         }

--- a/tests/phpunit/ImboIntegrationTest/Image/Transformation/StripTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Image/Transformation/StripTest.php
@@ -60,8 +60,6 @@ class StripTest extends TransformationTests {
 
         $this->getTransformation()->setImagick($imagick)->transform($event);
 
-        $imagick->stripImage();
-
         foreach ($imagick->getImageProperties() as $key => $value) {
             $this->assertStringStartsNotWith('exif', $key);
         }


### PR DESCRIPTION
There are two different issues  with the StripImageTest. It currently features a call to `stripImage` by itself, which should be performed by the transformation itself (which is what we're testing). This PR removes that extraneous call. 

The test also fails on Windows with my version of ImageMagick, since the values in `getImageProperties` seems to be loaded when reading the image, and not when get call to `getImageProperties` is made. This fixes the test by re-reading the image data before checking if the properties are still there.