### PR TITLE
Fix usage of hard coded temp directory in FileSystem-based tests.

### DIFF
--- a/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Storage/FilesystemTest.php
+++ b/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Storage/FilesystemTest.php
@@ -22,7 +22,7 @@ class FilesystemTest extends StorageTests {
     /**
      * @var string
      */
-    private $path = '/tmp/imboVariationsFilesystemIntegrationTest';
+    private $path = null;
 
     /**
      * @see ImboIntegrationTest\Storage\StorageTests::getAdapter()
@@ -37,6 +37,8 @@ class FilesystemTest extends StorageTests {
      * Set up the directory for each test, ensuring it's empty
      */
     public function setUp() {
+        $this->path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'imboVariationsFilesystemIntegrationTest';
+
         if (is_dir($this->path)) {
             $this->rmdir($this->path);
         }

--- a/tests/phpunit/ImboIntegrationTest/Storage/FilesystemTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Storage/FilesystemTest.php
@@ -21,7 +21,7 @@ class FilesystemTest extends StorageTests {
     /**
      * @var string
      */
-    private $path = '/tmp/imboFilesystemIntegrationTest';
+    private $path = null;
 
     /**
      * @see ImboIntegrationTest\Storage\StorageTests::getDriver()
@@ -33,6 +33,8 @@ class FilesystemTest extends StorageTests {
     }
 
     public function setUp() {
+        $this->path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'imboFilesystemIntegrationTest';
+
         if (is_dir($this->path)) {
             $this->rmdir($this->path);
         }


### PR DESCRIPTION
There are two tests that attempt to create files in the system's temp
directory, but uses a hard coded path to /tmp to do so. This patch changes
the tests to use `sys_get_temp_dir()` to retrieve the actual location
instead.

Since I didn't want to override the PHPUnit Test Case constructor for
compability reasons, I decided to initialize the variable in the `setUp`
method instead.