### PR TITLE
Add simple vector support

### DIFF
--- a/library/Imbo/EventListener/Vector.php
+++ b/library/Imbo/EventListener/Vector.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\EventListener;
+
+use Imbo\EventManager\EventInterface,
+    Imbo\Model\Image,
+    Imbo\Exception\InvalidArgumentException,
+    Imbo\Exception\TransformationException,
+    Imbo\Exception\StorageException,
+    Imbo\Exception\DatabaseException;
+
+/**
+ * Image variations generator
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package Event\Listeners
+ */
+class Vector implements ListenerInterface {
+    /**
+     * Parameters for the event listener
+     *
+     * @var array
+     */
+    private $params = [
+        // Standard DPI to use for rendering vector images before handing them back to Imbo
+        'dpi' => 72,
+
+        // Max DPI to allow images to be used for rendering - this is also used to calculate width/height when an
+        // image is stored
+        'maxDPI' => 1000,
+
+        // Formats to rasterize
+        'formats' => [
+            'application/pdf' => true,
+        ],
+
+        // Which PDF library to use by default
+        'library' => 'xpdf',
+
+        // path to binary files for the chosen library if needed
+        'libraryPath' => 'e:/temp/xpdfbin-win-3.04/bin64',
+
+    ];
+
+    /**
+     * Class constructor
+     *
+     * @param array $params Parameters for the event listener
+     * @throws InvalidArgumentException
+     */
+    public function __construct($params = []) {
+        $params = $params ?: [];
+
+        $this->params = array_replace($this->params, $params);
+        $this->finfo = new \finfo(FILEINFO_MIME_TYPE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents() {
+        return [
+            // Generate image variations that can be used in resize operations later on
+            //'images.post' => ['generateVariations' => -10],
+            // we need to run before the default prepareImage
+            'images.post' => ['prepareImage' => 80],
+
+            // Rasterize a vector file
+            'storage.image.load' => ['rasterizeImage' => 10],
+        ];
+    }
+
+    public function prepareImage(EventInterface $event) {
+        $request = $event->getRequest();
+
+        // Fetch image data from input
+        $imageBlob = $request->getContent();
+
+        if (empty($imageBlob)) {
+            $e = new ImageException('No image attached', 400);
+            $e->setImboErrorCode(Exception::IMAGE_NO_IMAGE_ATTACHED);
+
+            throw $e;
+        }
+
+        $mime = $this->finfo->buffer($imageBlob);
+
+        error_log(serialize($mime));
+
+        if (!$mime || !isset($this->params['formats'][$mime])) {
+            return;
+        }
+
+        $size = ['width' => null, 'height' => null];
+
+        switch ($this->params['library'])
+        {
+            case 'xpdf':
+                $size = $this->getMetadataXPDF($imageBlob);
+                break;
+
+            case 'imagick':
+                break;
+        }
+
+        if (!$size || !$size['width'] || !$size['height']) {
+            return;
+        }
+
+        // Store relevant information in the image instance and attach it to the request
+        $image = new Image();
+        $image->setMimeType($mime)
+            ->setExtension(Image::getFileExtension($mime))
+            ->setBlob($imageBlob)
+            ->setWidth($size['width'])
+            ->setHeight($size['height'])
+            ->setOriginalChecksum(md5($imageBlob));
+
+        $request->setImage($image);
+    }
+
+    private function getMetadataXPDF($blob) {
+        $temp = tempnam(sys_get_temp_dir(), 'imbo-vector-pdf-');
+        file_put_contents($temp, $blob);
+
+        $pdfinfo = $this->params['libraryPath'] . '/pdfinfo';
+
+        exec($pdfinfo . ' ' . escapeshellarg($temp), $output, $return);
+        $info = $this->getOutputListAsKeyValuePairs($output);
+
+        if (!$info || empty($info['Page size'])) {
+            return;
+        }
+
+        $pageSizes = explode(' ', $info['Page size']);
+
+        if ((count($pageSizes) < 3) || !is_numeric($pageSizes[0]) || !is_numeric($pageSizes[2])) {
+            return;
+        }
+
+        return ['width' => trim($pageSizes[0]), 'height' => trim($pageSizes[2])];
+    }
+
+    private function getOutputListAsKeyValuePairs($list, $separator = ':')
+    {
+        $info = [];
+
+        foreach ($list as $line)
+        {
+            $parts = explode($separator, $line);
+
+            if (count($parts) < 2) {
+                continue;
+            }
+
+            $key = trim(array_shift($parts));
+            $value = join(':', $parts);
+            $info[$key] = trim($value);
+        }
+
+        return $info;
+    }
+
+    /**
+     * Rasterize a vector image.
+     *
+     * @param EventInterface $event The current event
+     */
+    public function rasterizeImage(EventInterface $event) {
+        $request = $event->getRequest();
+        error_log(serialize($request->getImage()));
+
+        $response = $event->getResponse();
+        $publicKey = $request->getPublicKey();
+        $imageIdentifier = $request->getImageIdentifier();
+        $vectorData = $event->getStorage()->getImage($publicKey, $imageIdentifier);
+
+        if (empty($this->params['formats'][$this->finfo->buffer($vectorData)]))
+        {
+            return;
+        }
+
+
+        // Set some data that the storage operations listener usually sets, since that will be
+        // skipped since we rasterize a vector image
+        //$lastModified = $event->getStorage()->getLastModified($publicKey, $imageIdentifier);
+        //$response->setLastModified($lastModified);
+        switch ($this->params['library'])
+        {
+            case 'xpdf':
+                $pdftoppm = $this->params['libraryPath'] . '/pdftoppm';
+                $source = tempnam(sys_get_temp_dir(), 'imbo-vector-pdf-');
+                $destDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('imbo-vector-ppm');
+
+                if (!is_dir($destDir) && !@mkdir($destDir) && !is_dir($destDir))
+                {
+                    error_log("BARF OUT");
+                    return;
+                }
+
+                $dest = $destDir . DIRECTORY_SEPARATOR . 'imbo';
+                file_put_contents($source, $vectorData);
+
+                exec($pdftoppm . ' -r ' . escapeshellarg($this->params['dpi']) . ' ' . escapeshellarg($source) . ' ' . escapeshellarg($dest));
+                $image = new \Imagick($dest . '-000001.ppm');
+                break;
+
+            case 'imagick':
+                $image = new \Imagick();
+                $image->setResolution($this->params['dpi'], $this->params['dpi']);
+                $image->readImageBlob($vectorData);
+                $image->setImageFormat('RGB');
+                $image->setIteratorIndex(0);
+                break;
+        }
+
+        // Update the model
+        $model = $response->getModel();
+        $model->setBlob($image->getImageBlob())
+            ->setWidth($image->getImageWidth())
+            ->setHeight($image->getImageHeight());
+
+        // Set a HTTP header that informs the user agent on which image variation that was used in
+        // the transformations
+        $response->headers->set('X-Imbo-Vector-DPI', $this->params['dpi']);
+
+        error_log("we deliver!");
+        // Stop the propagation of this event
+        $event->stopPropagation();
+        $event->getManager()->trigger('image.loaded');
+    }
+}

--- a/library/Imbo/Image/ImagePreparation.php
+++ b/library/Imbo/Image/ImagePreparation.php
@@ -46,6 +46,11 @@ class ImagePreparation implements ListenerInterface {
     public function prepareImage(EventInterface $event) {
         $request = $event->getRequest();
 
+        // Check if someone else has already prepared the image for us in another listener
+        if ($request->getImage()) {
+            return;
+        }
+
         // Fetch image data from input
         $imageBlob = $request->getContent();
 

--- a/library/Imbo/Model/Image.php
+++ b/library/Imbo/Model/Image.php
@@ -28,6 +28,7 @@ class Image implements ModelInterface {
         'image/png'  => 'png',
         'image/jpeg' => 'jpg',
         'image/gif'  => 'gif',
+        'application/pdf' => 'pdf',
     );
 
     /**
@@ -39,6 +40,7 @@ class Image implements ModelInterface {
         'image/x-png'  => 'image/png',
         'image/x-jpeg' => 'image/jpeg',
         'image/x-gif'  => 'image/gif',
+        'application/x-pdf' => 'application/pdf',
     );
 
     /**

--- a/tests/phpunit/ImboIntegrationTest/EventListener/VectorTest.php
+++ b/tests/phpunit/ImboIntegrationTest/EventListener/VectorTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboIntegrationTest\EventListener;
+
+use Imbo\EventListener\Vector,
+    Imbo\Model\Image;
+
+/**
+ * @covers Imbo\EventListener\Vector
+ * @group integration
+ * @group listeners
+ */
+class VectorTest extends \PHPUnit_Framework_TestCase {
+    public function testCanRender() {
+        $listener = new Vector();
+
+        $model = new Image();
+        $response = $this->getMock('Imbo\Http\Response\Response');
+        $response->expects($this->once())->method('getModel')->will($this->returnValue($model));
+        $request = $this->getMock('Imbo\Http\Request\Request');
+        $event = $this->getMock('Imbo\EventManager\Event');
+        $storage = $this->getMock('Imbo\Storage\StorageInterface');
+        $storage->expects($this->once())->method('getImage')->will($this->returnValue(file_get_contents(FIXTURES_DIR . '/test.pdf')));
+
+        $event->expects($this->once())->method('getManager')->will($this->returnValue($this->getMock('Imbo\EventManager\EventManager')));
+        $event->expects($this->once())->method('getStorage')->will($this->returnValue($storage));
+        $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
+        $event->expects($this->once())->method('getResponse')->will($this->returnValue($response));
+
+        $listener->rasterizeImage($event);
+
+        $this->assertNotEmpty($model->getBlob());
+        $this->assertGreaterThan(1, $model->getWidth());
+        $this->assertGreaterThan(1, $model->getHeight());
+    }
+}


### PR DESCRIPTION
This is the initial pull request for adding vector support in Imbo. It is currently not production ready, but I'm creating the pull request so that we can track the feature and discuss its code (and possibly needed changes in core).

The feature is currently implemented as an eventlistener, where it'll hook the store and load events of images to insert vector images (currently only PDFs) into the database, and rasterize them to an imagick instance when a request is made for a image backed by a vector format. That way all existing transformations will keep working, and we don't have to special case anything in the transformations themselves.

The current version (as can be seen in my test paths) uses xpdf and pdftoppm for converting pdf to rasterize a file, as this has proved to be the most exact solution in our current inhouse solution for converting a file before handing it over to Imbo.

There's a few issues we need to find a solution for.
- Currently the Imagick EventListener assumes that everything stored is decodable through Imagick. This is not an issue when retrieving the image (as it is inserted as an imageblob readable by Imagick anyways), but when the image is added, the Imagick eventlistener assumes that it'll have access to the image. I do not want to use stopPropagate, as this will barf any feature that depends on hooking the `images.post` event.
- The storage event listener assumes it needs to create the Image model when the file is added (in prepareImage). I've added a check to see if the model already exists, and if it does, assumes that is was created correctly further up in the event listener hierarchy. See 7445ec1.
- Currently Imbo is unable to return the file when a request is made without an extension, as it doesn't know how to serve `application/pdf` directly. We probably want to serve the file directly, but we do not want PDF as an output format for other resources (or after transformations).
- We should add a isVector() field to the model, so we're able to keep relevant metadata and possibly move the render stage to core instead of having to hook the events for each possible format.
- Width and Height may no longer refer exclusively to pixels, and for vectors might mean tens or hundreds of millimeters instead (as pixels have no meaning for vector formats). If isVector is set, physical dimensions should be assumed instead?
- We should consider having a better and more suitable way of registering resource loaders (possibly register a callback associated with a mime type to the core instead, and expect either an Imagick object or an ImageBlob readable by Imagick back).
