### PR TITLE
Added a Vary on Origin when responding to OPTIONS CORS-requests

### DIFF
--- a/library/Imbo/EventListener/Cors.php
+++ b/library/Imbo/EventListener/Cors.php
@@ -148,6 +148,9 @@ class Cors implements ListenerInterface {
         // This is an OPTIONS request, send 204 since no more content will follow
         $response->setStatusCode(204);
 
+        // Vary on Origin to prevent caching allowed/disallowed requests
+        $event->getResponse()->setVary('Origin', false);
+
         // Fall back if the passed origin is not allowed
         if (!$this->originIsAllowed($origin)) {
             return;

--- a/tests/behat/features/cors-event-listener.feature
+++ b/tests/behat/features/cors-event-listener.feature
@@ -46,6 +46,7 @@ Feature: Imbo provides an event listener for CORS
         And the "Access-Control-Allow-Headers" response header contains "X-Imbo-Signature"
         And the "Access-Control-Allow-Headers" response header contains "X-Imbo-Something"
         And the "Access-Control-Max-Age" response header is "1349"
+        And the "Vary" response header contains "Origin"
         And the "Allow" response header contains "GET"
         And the "Allow" response header contains "HEAD"
         And the "Allow" response header contains "OPTIONS"
@@ -55,6 +56,7 @@ Feature: Imbo provides an event listener for CORS
         And Imbo uses the "cors.php" configuration
         When I request "/" using HTTP "OPTIONS"
         Then I should get a response with "204 No Content"
+        And the "Vary" response header contains "Origin"
         And the "Allow" response header contains "GET"
         And the "Allow" response header contains "HEAD"
         And the "Allow" response header contains "OPTIONS"


### PR DESCRIPTION
PR to fix issue #338. The tests fail without the changes to `Imbo\EventListener\Cors` and succeeds with the change.

Kind regards
Morten