### PR TITLE
Generate private keys with base64-encoded raw random bytes

### DIFF
--- a/library/ImboCli/Command/GeneratePrivateKey.php
+++ b/library/ImboCli/Command/GeneratePrivateKey.php
@@ -47,13 +47,19 @@ class GeneratePrivateKey extends BaseCommand {
         $i = 0;
 
         while (!$strong && $this->maxTries > $i++) {
-            $data = openssl_random_pseudo_bytes(64, $strong);
+            $data = openssl_random_pseudo_bytes(32, $strong);
         }
 
         if (!$strong) {
             throw new RuntimeException('Could not generate private key');
         }
+        
+        // base64_encode to get a decent ascii compatible format, and trim ending ='s.
+        $key = rtrim(base64_encode($data), '=');
+        
+        // We change +/ into -_ to avoid any human confusion with paths
+        $key = strtr($key, '+/', '-_');
 
-        $output->writeln(hash('sha256', $data));
+        $output->writeln($key);
     }
 }

--- a/tests/phpunit/ImboCliUnitTest/Command/GeneratePrivateKeyTest.php
+++ b/tests/phpunit/ImboCliUnitTest/Command/GeneratePrivateKeyTest.php
@@ -51,7 +51,7 @@ class GeneratePrivateKeyTest extends \PHPUnit_Framework_TestCase {
         $commandTester = new CommandTester($this->command);
         $commandTester->execute(array('command' => $this->command->getName()));
 
-        $this->assertRegExp('/^[a-f0-9]{64}$/', trim($commandTester->getDisplay()));
+        $this->assertRegExp('/^[a-zA-Z_\\-0-9]{8,}$/', trim($commandTester->getDisplay()));
     }
 
     /**


### PR DESCRIPTION
Using sha256 on the generated bytes doesn't buy us anything, so instead we use the bytes directly in a base64 encoded format. This gives shorter keys within the same keyspace (and we require fewer random bytes from openssl).