### PR TITLE
Add PHP7 as a travis build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+matrix:
+  allow_failures:
+    - php: 7.0
 notifications:
   irc:
     use_notice: true


### PR DESCRIPTION
This PR adds a new environment (PHP7) for the test suites at Travis-CI. This environment might currently fail, but the build will still pass.
