### PR TITLE
UUID image identifiers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "ext-imagick": ">=3.0.1",
     "symfony/http-foundation": "~2.4.0",
     "symfony/event-dispatcher": "~2.4.0",
-    "symfony/console": "~2.4.0"
+    "symfony/console": "~2.4.0",
+    "rhumsaa/uuid": "~2.8"
   },
   "require-dev": {
     "mikey179/vfsStream": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,74 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "789961b48d79884feb8385706dd6b9b3",
+    "hash": "92c9502e3dbbc3c169adbb24e3a2e9de",
     "packages": [
+        {
+            "name": "rhumsaa/uuid",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "cca98c652cac412c9c2f109c69e5532f313435fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/cca98c652cac412c9c2f109c69e5532f313435fc",
+                "reference": "cca98c652cac412c9c2f109c69e5532f313435fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "doctrine/dbal": ">=2.3",
+                "moontoast/math": "~1.1",
+                "phpunit/phpunit": "~4.1",
+                "satooshi/php-coveralls": "~0.6",
+                "symfony/console": "~2.3"
+            },
+            "suggest": {
+                "doctrine/dbal": "Allow the use of a UUID as doctrine field type.",
+                "moontoast/math": "Support for converting UUID to 128-bit integer (in string form).",
+                "symfony/console": "Support for use of the bin/uuid command line tool."
+            },
+            "bin": [
+                "bin/uuid"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Rhumsaa\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marijn Huizendveld",
+                    "email": "marijn.huizendveld@gmail.com"
+                },
+                {
+                    "name": "Ben Ramsey",
+                    "homepage": "http://benramsey.com"
+                }
+            ],
+            "description": "A PHP 5.3+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+            "homepage": "https://github.com/ramsey/uuid",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "time": "2014-11-09 18:42:56"
+        },
         {
             "name": "symfony/console",
             "version": "v2.4.10",
@@ -1954,6 +2020,7 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.4.0",
         "ext-imagick": ">=3.0.1"

--- a/library/Imbo/EventListener/AccessControl.php
+++ b/library/Imbo/EventListener/AccessControl.php
@@ -75,6 +75,11 @@ class AccessControl implements ListenerInterface {
      * {@inheritdoc}
      */
     public function checkAccess(EventInterface $event) {
+        if ($event->hasArgument('skipAccessControl') &&
+            $event->getArgument('skipAccessControl') === true) {
+            return;
+        }
+
         $request = $event->getRequest();
         $response = $event->getResponse();
         $accessControl = $event->getAccessControl();

--- a/library/Imbo/EventListener/DatabaseOperations.php
+++ b/library/Imbo/EventListener/DatabaseOperations.php
@@ -80,7 +80,7 @@ class DatabaseOperations implements ListenerInterface {
 
         $event->getDatabase()->insertImage(
             $request->getUser(),
-            $request->getImage()->getChecksum(),
+            $request->getImage()->getImageIdentifier(),
             $request->getImage()
         );
     }

--- a/library/Imbo/EventListener/ExifMetadata.php
+++ b/library/Imbo/EventListener/ExifMetadata.php
@@ -138,7 +138,7 @@ class ExifMetadata implements ListenerInterface {
         $database = $event->getDatabase();
 
         $user = $request->getUser();
-        $imageIdentifier = $request->getImage()->getChecksum();
+        $imageIdentifier = $request->getImage()->getImageIdentifier();
 
         try {
             $database->updateMetadata(

--- a/library/Imbo/EventListener/ImageVariations.php
+++ b/library/Imbo/EventListener/ImageVariations.php
@@ -322,7 +322,7 @@ class ImageVariations implements ListenerInterface {
         $request = $event->getRequest();
         $user = $request->getUser();
         $originalImage = $request->getImage();
-        $imageIdentifier = $originalImage->getChecksum();
+        $imageIdentifier = $originalImage->getImageIdentifier();
         $originalWidth = $originalImage->getWidth();
 
         // Fetch parameters specified in the Imbo configuration related to what sort of variations

--- a/library/Imbo/EventListener/ResponseSender.php
+++ b/library/Imbo/EventListener/ResponseSender.php
@@ -48,12 +48,11 @@ class ResponseSender implements ListenerInterface {
         $imageIdentifier = null;
 
         if ($image = $request->getImage()) {
-            // The request has an image. This means that an image was just added. Use the image's
-            // checksum
-            $imageIdentifier = $image->getChecksum();
+            // The request has an image. This means that an image was just added.
+            // Get the image identifier from the image model
+            $imageIdentifier = $image->getImageIdentifier();
         } else if ($identifier = $request->getImageIdentifier()) {
-            // An image identifier exists in the request, use that one (and not a possible image
-            // checksum for an image attached to the response)
+            // An image identifier exists in the request URI, use that
             $imageIdentifier = $identifier;
         }
 

--- a/library/Imbo/EventListener/StorageOperations.php
+++ b/library/Imbo/EventListener/StorageOperations.php
@@ -71,7 +71,7 @@ class StorageOperations implements ListenerInterface {
         $request = $event->getRequest();
         $user = $request->getUser();
         $image = $request->getImage();
-        $imageIdentifier = $image->getChecksum();
+        $imageIdentifier = $image->getImageIdentifier();
         $blob = $image->getBlob();
 
         try {

--- a/library/Imbo/Image/ImagePreparation.php
+++ b/library/Imbo/Image/ImagePreparation.php
@@ -16,7 +16,8 @@ use Imbo\EventManager\EventInterface,
     Imbo\Exception,
     Imbo\Model\Image,
     Imagick,
-    ImagickException;
+    ImagickException,
+    Rhumsaa\Uuid\Uuid;
 
 /**
  * Image preparation
@@ -84,7 +85,8 @@ class ImagePreparation implements ListenerInterface {
               ->setBlob($imageBlob)
               ->setWidth($size['width'])
               ->setHeight($size['height'])
-              ->setOriginalChecksum(md5($imageBlob));
+              ->setOriginalChecksum(md5($imageBlob))
+              ->setImageIdentifier((string) Uuid::uuid4());
 
         $request->setImage($image);
     }

--- a/library/Imbo/Image/Transformation/Watermark.php
+++ b/library/Imbo/Image/Transformation/Watermark.php
@@ -104,7 +104,7 @@ class Watermark extends Transformation implements ListenerInterface {
         // Try to load watermark image from storage
         try {
             $watermarkData = $event->getStorage()->getImage(
-                $event->getRequest()->getPublicKey(),
+                $event->getRequest()->getUser(),
                 $imageIdentifier
             );
 

--- a/library/Imbo/Model/Error.php
+++ b/library/Imbo/Model/Error.php
@@ -179,7 +179,7 @@ class Error implements ModelInterface {
               ->setImboErrorCode($exception->getImboErrorCode() ?: Exception::ERR_UNSPECIFIED);
 
         if ($image = $request->getImage()) {
-            $model->setImageIdentifier($image->getChecksum());
+            $model->setImageIdentifier($image->getImageIdentifier());
         } else if ($identifier = $request->getImageIdentifier()) {
             $model->setImageIdentifier($identifier);
         }

--- a/library/Imbo/Resource/GlobalShortUrl.php
+++ b/library/Imbo/Resource/GlobalShortUrl.php
@@ -60,6 +60,6 @@ class GlobalShortUrl implements ResourceInterface {
 
         $request->query = new ParameterBag($params['query']);
         $event->getResponse()->headers->set('X-Imbo-ShortUrl', $request->getUri());
-        $event->getManager()->trigger('image.get');
+        $event->getManager()->trigger('image.get', ['skipAccessControl' => true]);
     }
 }

--- a/library/Imbo/Resource/Images.php
+++ b/library/Imbo/Resource/Images.php
@@ -72,7 +72,7 @@ class Images implements ResourceInterface {
 
         $model = new Model\ArrayModel();
         $model->setData(array(
-            'imageIdentifier' => $image->getChecksum(),
+            'imageIdentifier' => $image->getImageIdentifier(),
             'width' => $image->getWidth(),
             'height' => $image->getHeight(),
             'extension' => $image->getExtension(),

--- a/library/Imbo/Resource/Metadata.php
+++ b/library/Imbo/Resource/Metadata.php
@@ -91,7 +91,7 @@ class Metadata implements ResourceInterface {
         ));
 
         $model = new Model\Metadata();
-        $model->setData($event->getDatabase()->getMetadata($request->getPublicKey(), $request->getImageIdentifier()));
+        $model->setData($event->getDatabase()->getMetadata($request->getUser(), $request->getImageIdentifier()));
 
         $event->getResponse()->setModel($model);
     }

--- a/library/Imbo/Router.php
+++ b/library/Imbo/Router.php
@@ -42,16 +42,16 @@ class Router {
      * @var array
      */
     private $routes = array(
-        'image'          => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9]{32})(\.(?<extension>gif|jpg|png))?$#',
+        'image'          => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9-]{32,36})(\.(?<extension>gif|jpg|png))?$#',
         'globalshorturl' => '#^/s/(?<shortUrlId>[a-zA-Z0-9]{7})$#',
         'status'         => '#^/status(/|(\.(?<extension>json|xml)))?$#',
         'images'         => '#^/users/(?<user>[a-z0-9_-]{1,})/images(/|(\.(?<extension>json|xml)))?$#',
-        'metadata'       => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9]{32})/meta(?:data)?(/|\.(?<extension>json|xml))?$#',
+        'metadata'       => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9-]{32,36})/meta(?:data)?(/|\.(?<extension>json|xml))?$#',
         'user'           => '#^/users/(?<user>[a-z0-9_-]{1,})(/|\.(?<extension>json|xml))?$#',
         'stats'          => '#^/stats(/|(\.(?<extension>json|xml)))?$#',
         'index'          => '#^/?$#',
-        'shorturls'      => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9]{32})/shorturls(/|\.(?<extension>json|xml))?$#',
-        'shorturl'       => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9]{32})/shorturls/(?<shortUrlId>[a-zA-Z0-9]{7})$#',
+        'shorturls'      => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9-]{32,36})/shorturls(/|\.(?<extension>json|xml))?$#',
+        'shorturl'       => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9-]{32,36})/shorturls/(?<shortUrlId>[a-zA-Z0-9]{7})$#',
         'groups'         => '#^/groups(/|(\.(?<extension>json|xml)))?$#',
         'group'          => '#^/groups/(?<group>[a-z0-9_-]{1,})(/|\.(?<extension>json|xml))?$#',
         'keys'           => '#^/keys/(?<publickey>[a-z0-9_-]{1,})$#',

--- a/setup/doctrine.mysql.sql
+++ b/setup/doctrine.mysql.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `imageinfo` (
     `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
     `user` varchar(255) COLLATE utf8_danish_ci NOT NULL,
-    `imageIdentifier` char(32) COLLATE utf8_danish_ci NOT NULL,
+    `imageIdentifier` char(36) COLLATE utf8_danish_ci NOT NULL,
     `size` int(10) unsigned NOT NULL,
     `extension` varchar(5) COLLATE utf8_danish_ci NOT NULL,
     `mime` varchar(20) COLLATE utf8_danish_ci NOT NULL,
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS `metadata` (
 CREATE TABLE IF NOT EXISTS `shorturl` (
     `shortUrlId` char(7) COLLATE utf8_danish_ci NOT NULL,
     `user` varchar(255) COLLATE utf8_danish_ci NOT NULL,
-    `imageIdentifier` char(32) COLLATE utf8_danish_ci NOT NULL,
+    `imageIdentifier` char(36) COLLATE utf8_danish_ci NOT NULL,
     `extension` char(3) COLLATE utf8_danish_ci DEFAULT NULL,
     `query` text COLLATE utf8_danish_ci NOT NULL,
     PRIMARY KEY (`shortUrlId`),
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS `shorturl` (
 
 CREATE TABLE IF NOT EXISTS `storage_images` (
     `user` varchar(255) COLLATE utf8_danish_ci NOT NULL,
-    `imageIdentifier` char(32) COLLATE utf8_danish_ci NOT NULL,
+    `imageIdentifier` char(36) COLLATE utf8_danish_ci NOT NULL,
     `data` blob NOT NULL,
     `updated` int(10) unsigned NOT NULL,
     PRIMARY KEY (`user`,`imageIdentifier`)
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS `storage_images` (
 
 CREATE TABLE IF NOT EXISTS `storage_image_variations` (
     `user` varchar(255) COLLATE utf8_danish_ci NOT NULL,
-    `imageIdentifier` char(32) COLLATE utf8_danish_ci NOT NULL,
+    `imageIdentifier` char(36) COLLATE utf8_danish_ci NOT NULL,
     `width` int(10) unsigned NOT NULL,
     `data` blob NOT NULL,
     PRIMARY KEY (`user`,`imageIdentifier`,`width`)
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS `storage_image_variations` (
 
 CREATE TABLE IF NOT EXISTS `imagevariations` (
     `user` varchar(255) COLLATE utf8_danish_ci NOT NULL,
-    `imageIdentifier` char(32) COLLATE utf8_danish_ci NOT NULL,
+    `imageIdentifier` char(36) COLLATE utf8_danish_ci NOT NULL,
     `width` int(10) unsigned NOT NULL,
     `height` int(10) unsigned NOT NULL,
     `added` int(10) unsigned NOT NULL,

--- a/tests/behat/bootstrap/ImboContext.php
+++ b/tests/behat/bootstrap/ImboContext.php
@@ -89,6 +89,13 @@ class ImboContext extends RESTContext {
     private static $testImagePath;
 
     /**
+     * Holds the current feature for this test image
+     *
+     * @var string
+     */
+    private static $testImageFeature;
+
+    /**
      * @BeforeFeature
      */
     public static function prepare(FeatureEvent $event) {
@@ -342,10 +349,11 @@ class ImboContext extends RESTContext {
     }
 
     /**
-     * @Given /^"([^"]*)" is used as the test image$/
+     * @Given /^"([^"]*)" is used as the test image( for the "([^"]*)" feature)?$/
      */
-    public function imageIsUsedAsTestImage($testImagePath) {
-        if (self::$testImagePath === $testImagePath) {
+    public function imageIsUsedAsTestImage($testImagePath, $forFeature = null, $feature = null) {
+        if (self::$testImagePath === $testImagePath && $feature &&
+            self::$testImageFeature === $feature) {
             return;
         }
 
@@ -353,6 +361,7 @@ class ImboContext extends RESTContext {
         self::$testImageIdentifier = $this->getPreviouslyAddedImageIdentifier();
         self::$testImageUrl = $this->getPreviouslyAddedImageUrl();
         self::$testImagePath = $testImagePath;
+        self::$testImageFeature = $feature;
     }
 
     /**

--- a/tests/behat/bootstrap/ImboContext.php
+++ b/tests/behat/bootstrap/ImboContext.php
@@ -639,6 +639,20 @@ class ImboContext extends RESTContext {
     }
 
     /**
+     * @Given /^I use "([^"]*)" as the watermark image with "([^"]*)" as parameters$/
+     */
+    public function specifyAsTheWatermarkImage($watermarkPath, $parameters = '') {
+        $this->addImageToImbo($watermarkPath);
+        $imageIdentifier = $this->getPreviouslyAddedImageIdentifier();
+        $params = empty($parameters) ? '' : ',' . $parameters;
+        $transformation = 'watermark:img=' . $imageIdentifier . $params;
+
+        return [
+            new Given('I specify "' . $transformation . '" as transformation')
+        ];
+    }
+
+    /**
      * Get the previously added image identifier
      *
      * @throws RuntimeException If previous response did not include image identifier

--- a/tests/behat/bootstrap/ImboContext.php
+++ b/tests/behat/bootstrap/ImboContext.php
@@ -25,6 +25,13 @@ require 'RESTContext.php';
  */
 class ImboContext extends RESTContext {
     /**
+     * The user used by the client
+     *
+     * @var string
+     */
+    private $user;
+
+    /**
      * The public key used by the client
      *
      * @var string
@@ -108,6 +115,7 @@ class ImboContext extends RESTContext {
     public function setClientAuth($publicKey, $privateKey) {
         $this->publicKey = $publicKey;
         $this->privateKey = $privateKey;
+        $this->user = $this->user ?: $publicKey;
     }
 
     /**
@@ -288,6 +296,22 @@ class ImboContext extends RESTContext {
         }
 
         parent::setRequestHeader($header, $value);
+    }
+
+    /**
+     * @When /^I request the (?:previously )?added image(?: with the query parameters "([^"]*)")?$/
+     */
+    public function requestPreviouslyAddedImage($queryParams = '') {
+        $response = $this->getLastResponse()->json();
+        if (!isset($response['imageIdentifier'])) {
+            throw new RuntimeException(
+                'Image identifier was not present in previous response, response: ' .
+                $this->getLastResponse()->getBody(true)
+            );
+        }
+
+        $identifier = $response['imageIdentifier'];
+        $this->request('/users/' . $this->user . '/images/' . $identifier . '.' . $queryParams);
     }
 
     /**

--- a/tests/behat/bootstrap/RESTContext.php
+++ b/tests/behat/bootstrap/RESTContext.php
@@ -51,6 +51,13 @@ class RESTContext extends BehatContext {
     protected $requestHeaders = array();
 
     /**
+     * Query parameters for the request
+     *
+     * @var array
+     */
+    protected $queryParams = array();
+
+    /**
      * Optional request body to add to the request
      *
      * @var string
@@ -221,6 +228,20 @@ class RESTContext extends BehatContext {
      */
     public function setRequestHeader($header, $value) {
         $this->requestHeaders[$header] = $value;
+    }
+
+     /**
+     * @Given /^I append a query string parameter, "([^"]*)" with the value "([^"]*)"$/
+     */
+    public function appendQueryStringParameter($queryParam, $value) {
+        $this->queryParams[] = $queryParam . '=' . $value;
+    }
+
+    /**
+     * @When /^I request "([^"]*)" with the given query string$/
+     */
+    public function performRequestWithGivenQueryString($path) {
+        $this->request($path . '?' . implode('&', $this->queryParams));
     }
 
     /**

--- a/tests/behat/features/access-control.feature
+++ b/tests/behat/features/access-control.feature
@@ -92,3 +92,27 @@ Feature: Imbo provides a way to access control resources on a per-public key bas
         And Imbo uses the "custom-access-control.php" configuration
         When I request "/users/public"
         Then I should get a response with "200 OK"
+
+    Scenario Outline: Request open resources with default configuration
+        Given the "Accept" request header is "application/json"
+        When I request "<url>"
+        Then I should get a response with "<status>"
+        And the response body matches:
+          """
+          <response>
+          """
+
+        Examples:
+            | url          | status           | response |
+            | /            | 200 Hell Yeah    | #^{"version":".*?",.*}$# |
+            | /status.json | 200 OK           | #^{"date":".*?","database":true,"storage":true}$# |
+
+    Scenario: Request shortUrl with no public key or access token provided
+        Given "tests/phpunit/Fixtures/1024x256.png" exists in Imbo
+        And I generate a short URL with the following parameters:
+            """
+            {"user": "user", "query": "t[]=thumbnail"}
+            """
+        When I request the image using the generated short URL
+        Then I should get a response with "200 OK"
+        And the "Content-Type" response header is "image/png"

--- a/tests/behat/features/access-token.feature
+++ b/tests/behat/features/access-token.feature
@@ -9,13 +9,13 @@ Feature: Imbo requires an access token for read operations
     Scenario: Request user information using the correct private key
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey"
+        When I request "/users/user"
         Then I should get a response with "200 OK"
 
     Scenario: Request user information using the wrong private key
         Given I use "publickey" and "foobar" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey"
+        When I request "/users/user"
         Then I should get a response with "400 Incorrect access token"
         And the Imbo error message is "Incorrect access token" and the error code is "0"
 
@@ -28,21 +28,21 @@ Feature: Imbo requires an access token for read operations
 
     Scenario: Request user information without a valid access token
         Given I use "publickey" and "foobar" for public and private keys
-        When I request "/users/publickey"
+        When I request "/users/user?publicKey=publickey"
         Then I should get a response with "400 Missing access token"
         And the Imbo error message is "Missing access token" and the error code is "0"
 
     Scenario: Request image using no access token
         Given I use "publickey" and "privatekey" for public and private keys
         And the "Accept" request header is "*/*"
-        When I request "/users/publickey/images/929db9c5fc3099f7576f5655207eba47"
+        When I request the previously added image
         Then I should get a response with "400 Missing access token"
 
     Scenario: Can request a whitelisted transformation without access tokens
         Given I use "publickey" and "privatekey" for public and private keys
         And the "Accept" request header is "*/*"
         And Imbo uses the "access-token-whitelist-transformation.php" configuration
-        When I request "/users/publickey/images/929db9c5fc3099f7576f5655207eba47?t[]=whitelisted"
+        When I request "/users/user/images/929db9c5fc3099f7576f5655207eba47?t[]=whitelisted"
         Then I should get a response with "200 OK"
         And the width of the image is "100"
         And the height of the image is "50"
@@ -50,13 +50,13 @@ Feature: Imbo requires an access token for read operations
     Scenario: Can not issue transformations that are not whitelisted without a valid access token
         Given I use "publickey" and "privatekey" for public and private keys
         And the "Accept" request header is "*/*"
-        When I request "/users/publickey/images/929db9c5fc3099f7576f5655207eba47?t[]=thumbnail"
+        When I request "/users/user/images/929db9c5fc3099f7576f5655207eba47?t[]=thumbnail"
         Then I should get a response with "400 Missing access token"
 
     Scenario: Request user information using the correct private key and a superfluous public key query parameter
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey?publicKey=publickey"
+        When I request "/users/user?publicKey=publickey"
         Then I should get a response with "200 OK"
 
     Scenario: Request user information for a user with an incorrect public key specified as query parameter

--- a/tests/behat/features/access-token.feature
+++ b/tests/behat/features/access-token.feature
@@ -35,14 +35,14 @@ Feature: Imbo requires an access token for read operations
     Scenario: Request image using no access token
         Given I use "publickey" and "privatekey" for public and private keys
         And the "Accept" request header is "*/*"
-        When I request the previously added image
+        When I request "/users/user/images"
         Then I should get a response with "400 Missing access token"
 
     Scenario: Can request a whitelisted transformation without access tokens
         Given I use "publickey" and "privatekey" for public and private keys
         And the "Accept" request header is "*/*"
         And Imbo uses the "access-token-whitelist-transformation.php" configuration
-        When I request "/users/user/images/929db9c5fc3099f7576f5655207eba47?t[]=whitelisted"
+        When I request the previously added image with the query string "?t[]=whitelisted"
         Then I should get a response with "200 OK"
         And the width of the image is "100"
         And the height of the image is "50"

--- a/tests/behat/features/client-caching.feature
+++ b/tests/behat/features/client-caching.feature
@@ -36,24 +36,24 @@ Feature: Imbo enables client caching using related response headers
     Scenario: Request user information
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey"
+        When I request "/users/user"
         Then the response is cacheable
 
     Scenario: Request user images
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images"
+        When I request "/users/user/images"
         Then the response is cacheable
 
     Scenario: Request user image
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And the "Accept" request header is "image/*"
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2"
+        When I request the previously added image
         Then the response is cacheable
 
     Scenario: Request user image metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/meta"
+        When I request the metadata of the previously added image
         Then the response is cacheable

--- a/tests/behat/features/content-negotiation.feature
+++ b/tests/behat/features/content-negotiation.feature
@@ -16,23 +16,33 @@ Feature: Imbo supports content negotiation
         And the "Content-Type" response header is "<content-type>"
 
         Examples:
-            | resource                                                      | accept                                                          | content-type     |
-            | /status                                                       | application/json                                                | application/json |
-            | /status                                                       | application/xml                                                 | application/xml  |
-            | /status                                                       | text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 | application/xml  |
-            | /status                                                       | image/*,*/*;q=0.1                                               | application/json |
-            | /users/publickey                                              | application/json                                                | application/json |
-            | /users/publickey                                              | application/xml                                                 | application/xml  |
-            | /users/publickey                                              | text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 | application/xml  |
-            | /users/publickey                                              | image/*,*/*;q=0.1                                               | application/json |
-            | /users/publickey/images                                       | application/json                                                | application/json |
-            | /users/publickey/images                                       | application/xml                                                 | application/xml  |
-            | /users/publickey/images                                       | text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 | application/xml  |
-            | /users/publickey/images                                       | image/*,*/*;q=0.1                                               | application/json |
-            | /users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/meta | application/json                                                | application/json |
-            | /users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/meta | application/xml                                                 | application/xml  |
-            | /users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/meta | text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 | application/xml  |
-            | /users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/meta | image/*,*/*;q=0.1                                               | application/json |
+            | resource                                                 | accept                                                          | content-type     |
+            | /status                                                  | application/json                                                | application/json |
+            | /status                                                  | application/xml                                                 | application/xml  |
+            | /status                                                  | text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 | application/xml  |
+            | /status                                                  | image/*,*/*;q=0.1                                               | application/json |
+            | /users/user                                              | application/json                                                | application/json |
+            | /users/user                                              | application/xml                                                 | application/xml  |
+            | /users/user                                              | text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 | application/xml  |
+            | /users/user                                              | image/*,*/*;q=0.1                                               | application/json |
+            | /users/user/images                                       | application/json                                                | application/json |
+            | /users/user/images                                       | application/xml                                                 | application/xml  |
+            | /users/user/images                                       | text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 | application/xml  |
+            | /users/user/images                                       | image/*,*/*;q=0.1                                               | application/json |
+
+    Scenario Outline: Imbo's metadata resource can respond with different content types using content negotiation
+        Given the "Accept" request header is "<accept>"
+        And I include an access token in the query
+        When I request the metadata of the previously added image
+        Then I should get a response with "200 OK"
+        And the "Content-Type" response header is "<content-type>"
+
+        Examples:
+            | accept                                                          | content-type     |
+            | application/json                                                | application/json |
+            | application/xml                                                 | application/xml  |
+            | text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8 | application/xml  |
+            | image/*,*/*;q=0.1                                               | application/json |
 
     Scenario: If the client includes an extension, the Accept header should be ignored
         Given the "Accept" request header is "application/xml"
@@ -50,7 +60,7 @@ Feature: Imbo supports content negotiation
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And the "Accept" request header is "<accept>"
-        When I request "/users/publickey/images/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa<extension>"
+        When I request "/users/user/images/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa<extension>"
         Then I should get a response with "<reason>"
         And the "Content-Type" response header is "application/json"
 
@@ -65,7 +75,7 @@ Feature: Imbo supports content negotiation
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And the "Accept" request header is "application/json"
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2"
+        When I request the image resource for "tests/phpunit/Fixtures/image1.png"
         Then I should get a response with "406 Not acceptable"
         And the "Content-Type" response header is "application/json"
         And the "X-Imbo-Originalextension" response header is "png"
@@ -75,34 +85,34 @@ Feature: Imbo supports content negotiation
         And the "X-Imbo-Originalwidth" response header is "599"
         And the response body matches:
           """
-          /{"error":{"code":406,"message":"Not acceptable","date":"[^"]+","imboErrorCode":0},"imageIdentifier":"fc7d2d06993047a0b5056e8fac4462a2"}/
+          /{"error":{"code":406,"message":"Not acceptable","date":"[^"]+","imboErrorCode":0},"imageIdentifier":"[^"]+"}/
           """
 
     Scenario Outline: Imbo uses the original mime type of the image if the client has no preferences
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And the "Accept" request header is "image/*"
-        When I request "/users/publickey/images/<image-identifier>"
+        When I request the image resource for "<image-path>"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "<content-type>"
 
         Examples:
-            | image-identifier                 | content-type |
-            | fc7d2d06993047a0b5056e8fac4462a2 | image/png    |
-            | f3210f1bb34bfbfa432cc3560be40761 | image/jpeg   |
-            | b5426b4c008e378c201526d2baaec599 | image/gif    |
+            | image-path                        | content-type |
+            | tests/phpunit/Fixtures/image1.png | image/png    |
+            | tests/phpunit/Fixtures/image.jpg  | image/jpeg   |
+            | tests/phpunit/Fixtures/image.gif  | image/gif    |
 
     Scenario Outline: Imbo uses the original mime type of the image if configuration has disabled content negotiation for images
         Given I use "publickey" and "privatekey" for public and private keys
         And Imbo uses the "image-content-negotiation-disabled.php" configuration
         And I include an access token in the query
         And the "Accept" request header is "<requested-content-type>"
-        When I request "/users/publickey/images/<image-identifier>"
+        When I request the image resource for "<image-path>"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "<original-content-type>"
 
         Examples:
-            | image-identifier                 | requested-content-type | original-content-type |
-            | fc7d2d06993047a0b5056e8fac4462a2 | image/gif              | image/png             |
-            | f3210f1bb34bfbfa432cc3560be40761 | image/png              | image/jpeg            |
-            | b5426b4c008e378c201526d2baaec599 | image/jpeg             | image/gif             |
+            | image-path                        | requested-content-type | original-content-type |
+            | tests/phpunit/Fixtures/image1.png | image/gif              | image/png             |
+            | tests/phpunit/Fixtures/image.jpg  | image/png              | image/jpeg            |
+            | tests/phpunit/Fixtures/image.gif  | image/jpeg             | image/gif             |

--- a/tests/behat/features/cors-event-listener.feature
+++ b/tests/behat/features/cors-event-listener.feature
@@ -74,7 +74,7 @@ Feature: Imbo provides an event listener for CORS
         And the "Origin" request header is "http://allowedhost"
         And I sign the request
         And I attach "ChangeLog.markdown" to the request body
-        When I request "/users/publickey/images" using HTTP "POST"
+        When I request "/users/user/images" using HTTP "POST"
         Then I should get a response with "415 Invalid image"
         And the "Vary" response header contains "Origin"
         And the following response headers should be present:
@@ -86,8 +86,8 @@ Feature: Imbo provides an event listener for CORS
         Given I use "invalid-pubkey" and "invalid-privkey" for public and private keys
         And Imbo uses the "cors.php" configuration
         And the "Origin" request header is "http://allowedhost"
-        When I request "/users/publickey/images" using HTTP "GET"
-        Then I should get a response with "400 Missing access token"
+        When I request "/users/user/images" using HTTP "GET"
+        Then I should get a response with "400 Permission denied (public key)"
         And the following response headers should be present:
         """
         Access-Control-Allow-Origin

--- a/tests/behat/features/custom-event-listeners.feature
+++ b/tests/behat/features/custom-event-listeners.feature
@@ -28,8 +28,8 @@ Feature: Imbo supports custom event handlers in the configuration
         Given I use "publickey" and "privatekey" for public and private keys
         And Imbo uses the "custom-event-listeners.php" configuration
         And I include an access token in the query
-        When I request "/users/publickey.json"
-        Then the "X-Imbo-CurrentUser" response header is "publickey"
+        When I request "/users/user.json"
+        Then the "X-Imbo-CurrentUser" response header is "user"
 
     Scenario: Register an event listener that will only trigger for a given user and make a request to another key
         Given I use "user" and "key" for public and private keys

--- a/tests/behat/features/etags.feature
+++ b/tests/behat/features/etags.feature
@@ -24,14 +24,14 @@ Feature: Imbo adds ETag's to some responses
     Scenario: User resource includes an Etag
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey"
+        When I request "/users/user"
         Then I should get a response with "200 OK"
         And the "ETag" response header matches ""[a-z0-9]{32}""
 
     Scenario: Images resource includes an Etag
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images"
+        When I request "/users/user/images"
         Then I should get a response with "200 OK"
         And the "ETag" response header matches ""[a-z0-9]{32}""
 
@@ -39,7 +39,7 @@ Feature: Imbo adds ETag's to some responses
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And the "Accept" request header is "<acceptHeader>"
-        When I request "/users/publickey/images/929db9c5fc3099f7576f5655207eba47"
+        When I request the previously added image
         Then I should get a response with "200 OK"
         And the "ETag" response header is "<etag>"
 
@@ -54,12 +54,12 @@ Feature: Imbo adds ETag's to some responses
     Scenario: Metadata resource includes an ETag
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images/929db9c5fc3099f7576f5655207eba47/metadata"
+        When I request the metadata of the previously added image
         Then I should get a response with "200 OK"
         And the "ETag" response header matches ""[a-z0-9]{32}""
 
     Scenario: Responses that is not 200 OK does not get ETags
         Given I use "publickey" and "privatekey" for public and private keys
-        When I request "/users/publickey"
+        When I request "/users/user"
         Then I should get a response with "400 Missing access token"
         And the "ETag" response header does not exist

--- a/tests/behat/features/exif-metadata-event-listener.feature
+++ b/tests/behat/features/exif-metadata-event-listener.feature
@@ -10,7 +10,7 @@ Feature: Imbo provides an event listener for turning EXIF data into metadata
     Scenario: Fetch the added metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images/753e11e00522ff1e95600d8f91c74e8e/metadata.json"
+        When I request the metadata of the previously added image
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body contains:

--- a/tests/behat/features/head.feature
+++ b/tests/behat/features/head.feature
@@ -21,7 +21,7 @@ Feature: Imbo supports HTTP HEAD for all resources
     Scenario: Request user information
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey" using HTTP "HEAD"
+        When I request "/users/user" using HTTP "HEAD"
         And make the same request using HTTP "GET"
         Then the following response headers should be the same:
         """
@@ -35,7 +35,7 @@ Feature: Imbo supports HTTP HEAD for all resources
     Scenario: Request user images using a valid access token
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images" using HTTP "HEAD"
+        When I request "/users/user/images" using HTTP "HEAD"
         And make the same request using HTTP "GET"
         Then the following response headers should be the same:
         """
@@ -50,7 +50,7 @@ Feature: Imbo supports HTTP HEAD for all resources
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And the "Accept" request header is "image/png"
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2" using HTTP "HEAD"
+        When I request the previously added image using HTTP "HEAD"
         And make the same request using HTTP "GET"
         Then the following response headers should be the same:
         """

--- a/tests/behat/features/image-transformation-cache-listener.feature
+++ b/tests/behat/features/image-transformation-cache-listener.feature
@@ -4,7 +4,7 @@ Feature: Imbo enables caching of transformations
     I will cache and re-use transformed images
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" is used as the test image
+        Given "tests/phpunit/Fixtures/image1.png" is used as the test image for the "transformation cache" feature
 
     Scenario: Fetch the image with a specific extension that is not in the cache
         Given I use "publickey" and "privatekey" for public and private keys

--- a/tests/behat/features/image-transformation-cache-listener.feature
+++ b/tests/behat/features/image-transformation-cache-listener.feature
@@ -4,13 +4,13 @@ Feature: Imbo enables caching of transformations
     I will cache and re-use transformed images
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        Given "tests/phpunit/Fixtures/image1.png" is used as the test image
 
     Scenario: Fetch the image with a specific extension that is not in the cache
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "image-transformation-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.jpg"
+        When I request the test image as a "jpg"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/jpeg"
         And the "X-Imbo-TransformationCache" response header is "Miss"
@@ -20,7 +20,7 @@ Feature: Imbo enables caching of transformations
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "image-transformation-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.jpg"
+        When I request the test image as a "jpg"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/jpeg"
         And the "X-Imbo-TransformationCache" response header is "Hit"
@@ -30,7 +30,7 @@ Feature: Imbo enables caching of transformations
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "image-transformation-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request the test image as a "png"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/png"
         And the "X-Imbo-TransformationCache" response header is "Miss"
@@ -40,7 +40,7 @@ Feature: Imbo enables caching of transformations
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "image-transformation-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request the test image as a "png"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/png"
         And the "X-Imbo-TransformationCache" response header is "Hit"
@@ -51,7 +51,7 @@ Feature: Imbo enables caching of transformations
         And I include an access token in the query
         And I specify "crop:width=50,height=60,x=1,y=10" as transformation
         And Imbo uses the "image-transformation-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.jpg"
+        When I request the test image as a "jpg"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/jpeg"
         And the "X-Imbo-TransformationCache" response header is "Miss"
@@ -62,7 +62,7 @@ Feature: Imbo enables caching of transformations
         And I include an access token in the query
         And I specify "crop:width=50,height=60,x=1,y=10" as transformation
         And Imbo uses the "image-transformation-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.jpg"
+        When I request the test image as a "jpg"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/jpeg"
         And the "X-Imbo-TransformationCache" response header is "Hit"
@@ -72,34 +72,12 @@ Feature: Imbo enables caching of transformations
         Given I use "publickey" and "privatekey" for public and private keys
         And Imbo uses the "image-transformation-cache.php" configuration
         And I sign the request
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2" using HTTP "DELETE"
+        When I request the test image using HTTP "DELETE"
         Then I should get a response with "200 OK"
 
     Scenario: Fetch the image with a .jpg extension once more
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "image-transformation-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.jpg"
-        Then I should get a response with "200 OK"
-        And the "Content-Type" response header is "image/jpeg"
-        And the "X-Imbo-TransformationCache" response header is "Miss"
-
-    Scenario: Fetch the image with a .png extension once more
-        Given I use "publickey" and "privatekey" for public and private keys
-        And I include an access token in the query
-        And Imbo uses the "image-transformation-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
-        Then I should get a response with "200 OK"
-        And the "Content-Type" response header is "image/png"
-        And the "X-Imbo-TransformationCache" response header is "Miss"
-
-    Scenario: Fetch the image with the extra transformations added once more
-        Given I use "publickey" and "privatekey" for public and private keys
-        And I include an access token in the query
-        And I specify "crop:width=50,height=60,x=1,y=10" as transformation
-        And Imbo uses the "image-transformation-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.jpg"
-        Then I should get a response with "200 OK"
-        And the "Content-Type" response header is "image/jpeg"
-        And the "X-Imbo-TransformationCache" response header is "Miss"
-        And the checksum of the image is "2681f6eafb6fad2079df701ba90cf377"
+        When I request the test image as a "jpg"
+        Then I should get a response with "404 Image not found"

--- a/tests/behat/features/image-transformations.feature
+++ b/tests/behat/features/image-transformations.feature
@@ -12,7 +12,7 @@ Feature: Imbo enables dynamic transformations of images
         And I specify "<transformation>" as transformation
         And I include an access token in the query
         And Imbo uses the "image-transformation-presets.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request the image resource for "tests/phpunit/Fixtures/image1.png" as a "png"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/png"
         And the "X-Imbo-Originalextension" response header is "png"
@@ -78,16 +78,13 @@ Feature: Imbo enables dynamic transformations of images
             | vignette                                                                                          | 599   | 417    |
             | vignette:inner=bf1942,outer=ccc                                                                   | 599   | 417    |
             | vignette:inner=f00baa,outer=f0f0f0,scale=2.4                                                      | 599   | 417    |
-            | watermark:img=929db9c5fc3099f7576f5655207eba47                                                    | 599   | 417    |
-            | watermark:img=929db9c5fc3099f7576f5655207eba47,position=center                                    | 599   | 417    |
-            | watermark:img=929db9c5fc3099f7576f5655207eba47,x=10,y=20,position=bottom-right,width=10,height=40 | 599   | 417    |
 
     Scenario Outline: Transform the image using HTTP HEAD
         Given I use "publickey" and "privatekey" for public and private keys
         And I specify "<transformation>" as transformation
         And I include an access token in the query
         And Imbo uses the "image-transformation-presets.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png" using HTTP "HEAD"
+        When I request the image resource for "tests/phpunit/Fixtures/image1.png" as a "png" using HTTP "HEAD"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/png"
         And the "X-Imbo-Originalextension" response header is "png"
@@ -145,15 +142,12 @@ Feature: Imbo enables dynamic transformations of images
             | vignette                                                                                          |
             | vignette:inner=bf1942,outer=ccc                                                                   |
             | vignette:inner=f00baa,outer=f0f0f0,scale=2.4                                                      |
-            | watermark:img=929db9c5fc3099f7576f5655207eba47                                                    |
-            | watermark:img=929db9c5fc3099f7576f5655207eba47,position=center                                    |
-            | watermark:img=929db9c5fc3099f7576f5655207eba47,x=10,y=20,position=bottom-right,width=10,height=40 |
 
     Scenario Outline: Gracefully handle transformation errors
         Given I use "publickey" and "privatekey" for public and private keys
         And I specify "<transformation>" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request the image resource for "tests/phpunit/Fixtures/image1.png" as a "png"
         Then I should get a response with "<reason-phrase>"
         And the "Content-Type" response header is "application/json"
         And the "X-Imbo-Originalextension" response header is "png"
@@ -188,7 +182,7 @@ Feature: Imbo enables dynamic transformations of images
           strip
           """
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request the image resource for "tests/phpunit/Fixtures/image1.png" as a "png"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/png"
         And the "X-Imbo-Originalextension" response header is "png"
@@ -203,7 +197,7 @@ Feature: Imbo enables dynamic transformations of images
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And the "Accept" request header is "<accept>"
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2"
+        When I request the image resource for "tests/phpunit/Fixtures/image1.png"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "<content-type>"
         And the "X-Imbo-Originalextension" response header is "png"
@@ -221,7 +215,7 @@ Feature: Imbo enables dynamic transformations of images
     Scenario Outline: Fetch different formats of the image based on the image extension
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.<extension>"
+        When I request the image resource for "tests/phpunit/Fixtures/image1.png" as a "<extension>"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "<content-type>"
         And the "X-Imbo-Originalextension" response header is "png"

--- a/tests/behat/features/image-variations.feature
+++ b/tests/behat/features/image-variations.feature
@@ -11,23 +11,25 @@ Feature: Imbo provides an event listener that generates variations when adding i
         Given I use "publickey" and "privatekey" for public and private keys
         And Imbo uses the "image-variations.php" configuration
         And I include an access token in the query
-        When I request "/users/publickey/images/b60df41830245ee8f278e3ddfe5238a3.png"
-        Then the "X-Imbo-ImageVariation" response header does not exist
+        When I request the previously added image as a "png"
+        Then I should get a response with "200 OK"
+        And the "X-Imbo-ImageVariation" response header does not exist
 
     Scenario: Request an image with no scaling transformations
         Given I use "publickey" and "privatekey" for public and private keys
         And Imbo uses the "image-variations.php" configuration
         And I specify "desaturate" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/b60df41830245ee8f278e3ddfe5238a3.png"
-        Then the "X-Imbo-ImageVariation" response header does not exist
+        When I request the previously added image as a "png"
+        Then I should get a response with "200 OK"
+        And the "X-Imbo-ImageVariation" response header does not exist
 
     Scenario: Request an image with a resize transformation which upscales the original
         Given I use "publickey" and "privatekey" for public and private keys
         And Imbo uses the "image-variations.php" configuration
         And I specify "resize:width=2048" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/b60df41830245ee8f278e3ddfe5238a3.png"
+        When I request the previously added image as a "png"
         Then the "X-Imbo-ImageVariation" response header does not exist
         And the width of the image is "2048"
 
@@ -36,9 +38,9 @@ Feature: Imbo provides an event listener that generates variations when adding i
         And Imbo uses the "image-variations.php" configuration
         And I specify "maxSize:width=320" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/b60df41830245ee8f278e3ddfe5238a3.png"
-        Then the "X-Imbo-ImageVariation" response header matches "320x80"
-        And the "X-Imbo-ImageIdentifier" response header matches "b60df41830245ee8f278e3ddfe5238a3"
+        When I request the previously added image as a "png"
+        Then I should get a response with "200 OK"
+        And the "X-Imbo-ImageVariation" response header matches "320x80"
         And the width of the image is "320"
 
     Scenario: Request an image with a maxSize transformation which only slightly downscales the original
@@ -46,8 +48,9 @@ Feature: Imbo provides an event listener that generates variations when adding i
         And Imbo uses the "image-variations.php" configuration
         And I specify "maxSize:width=1020" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/b60df41830245ee8f278e3ddfe5238a3.png"
-        Then the "X-Imbo-ImageVariation" response header does not exist
+        When I request the previously added image as a "png"
+        Then I should get a response with "200 OK"
+        And the "X-Imbo-ImageVariation" response header does not exist
         And the width of the image is "1020"
 
     Scenario: Request an image with a thumbnail transformation using inset mode and no width
@@ -55,8 +58,9 @@ Feature: Imbo provides an event listener that generates variations when adding i
         And Imbo uses the "image-variations.php" configuration
         And I specify "thumbnail:height=128,fit=inset" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/b60df41830245ee8f278e3ddfe5238a3.png"
-        Then the "X-Imbo-ImageVariation" response header matches "512x128"
+        When I request the previously added image as a "png"
+        Then I should get a response with "200 OK"
+        And the "X-Imbo-ImageVariation" response header matches "512x128"
         And the width of the image is "50"
 
     Scenario: Request an image with a maxSize and border transformation
@@ -68,8 +72,9 @@ Feature: Imbo provides an event listener that generates variations when adding i
           maxSize:width=100
           """
         And I include an access token in the query
-        When I request "/users/publickey/images/b60df41830245ee8f278e3ddfe5238a3.png"
-        Then the "X-Imbo-ImageVariation" response header matches "512x128"
+        When I request the previously added image as a "png"
+        Then I should get a response with "200 OK"
+        And the "X-Imbo-ImageVariation" response header matches "512x128"
         And the pixel at coordinate "5, 5" should have a color of "#215d10"
         And the width of the image is "100"
         And the height of the image is "100"

--- a/tests/behat/features/image.feature
+++ b/tests/behat/features/image.feature
@@ -7,31 +7,32 @@ Feature: Imbo provides an image endpoint
         Given I use "publickey" and "privatekey" for public and private keys
         And I sign the request
         And I attach "tests/phpunit/Fixtures/image1.png" to the request body
-        When I request "/users/publickey/images" using HTTP "POST"
+        When I request "/users/user/images" using HTTP "POST"
         Then I should get a response with "201 Created"
         And the "Content-Type" response header is "application/json"
-        And the response body is:
+        And the response body matches:
           """
-          {"imageIdentifier":"fc7d2d06993047a0b5056e8fac4462a2","width":599,"height":417,"extension":"png"}
+          /{"imageIdentifier":"[^"]+","width":599,"height":417,"extension":"png"}/
           """
 
     Scenario: Add an image that already exists
         Given I use "publickey" and "privatekey" for public and private keys
         And I sign the request
         And I attach "tests/phpunit/Fixtures/image1.png" to the request body
-        When I request "/users/publickey/images" using HTTP "POST"
-        Then I should get a response with "200 OK"
+        When I request "/users/user/images" using HTTP "POST"
+        Then I should get a response with "201 Created"
         And the "Content-Type" response header is "application/json"
-        And the response body is:
+        And the response body matches:
           """
-          {"imageIdentifier":"fc7d2d06993047a0b5056e8fac4462a2","width":599,"height":417,"extension":"png"}
+          /{"imageIdentifier":"[^"]+","width":599,"height":417,"extension":"png"}/
           """
 
     Scenario: Fetch image
-        Given I use "publickey" and "privatekey" for public and private keys
+        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        And I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And the "Accept" request header is "image/png"
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2"
+        When I request the previously added image
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/png"
         And the "X-Imbo-Originalextension" response header is "png"
@@ -42,10 +43,11 @@ Feature: Imbo provides an image endpoint
         And the response body length is "95576"
 
     Scenario: Fetch image information when not accepting images
-        Given I use "publickey" and "privatekey" for public and private keys
+        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        And I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And the "Accept" request header is "application/json"
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2"
+        When I request the previously added image
         Then I should get a response with "406 Not acceptable"
         And the "Content-Type" response header is "application/json"
         And the "X-Imbo-Originalextension" response header is "png"
@@ -55,20 +57,21 @@ Feature: Imbo provides an image endpoint
         And the "X-Imbo-Originalwidth" response header is "599"
 
     Scenario: Delete an image
-        Given I use "publickey" and "privatekey" for public and private keys
+        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        And I use "publickey" and "privatekey" for public and private keys
         And I sign the request
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2" using HTTP "DELETE"
+        When I request the previously added image using HTTP "DELETE"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
-        And the response body is:
+        And the response body matches:
           """
-          {"imageIdentifier":"fc7d2d06993047a0b5056e8fac4462a2"}
+          /{"imageIdentifier":"[^"]+"}/
           """
 
     Scenario: Delete an image that does not exist
         Given I use "publickey" and "privatekey" for public and private keys
         And I sign the request
-        When I request "/users/publickey/images/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" using HTTP "DELETE"
+        When I request "/users/user/images/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" using HTTP "DELETE"
         Then I should get a response with "404 Image not found"
         And the "Content-Type" response header is "application/json"
         And the Imbo error message is "Image not found" and the error code is "0"
@@ -77,7 +80,7 @@ Feature: Imbo provides an image endpoint
         Given I use "publickey" and "privatekey" for public and private keys
         And I sign the request
         And I attach "tests/phpunit/Fixtures/broken-image.jpg" to the request body
-        When I request "/users/publickey/images" using HTTP "POST"
+        When I request "/users/user/images" using HTTP "POST"
         Then I should get a response with "415 Invalid image"
         And the "Content-Type" response header is "application/json"
         And the Imbo error message is "Invalid image" and the error code is "205"
@@ -86,7 +89,7 @@ Feature: Imbo provides an image endpoint
         Given I use "publickey" and "privatekey" for public and private keys
         And I sign the request
         And I attach "tests/phpunit/Fixtures/slightly-broken-image.png" to the request body
-        When I request "/users/publickey/images" using HTTP "POST"
+        When I request "/users/user/images" using HTTP "POST"
         Then I should get a response with "415 Invalid image"
         And the "Content-Type" response header is "application/json"
         And the Imbo error message is "Invalid image" and the error code is "205"

--- a/tests/behat/features/images.feature
+++ b/tests/behat/features/images.feature
@@ -4,7 +4,8 @@ Feature: Imbo provides an images endpoint
     I want to make requests against the images endpoint
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        Given Imbo starts with an empty database
+        And "tests/phpunit/Fixtures/image1.png" exists in Imbo
         And "tests/phpunit/Fixtures/image.jpg" exists in Imbo
         And "tests/phpunit/Fixtures/image.gif" exists in Imbo
         And "tests/phpunit/Fixtures/1024x256.png" exists in Imbo
@@ -12,7 +13,7 @@ Feature: Imbo provides an images endpoint
     Scenario Outline: Fetch images with no filter
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images.<extension>"
+        When I request "/users/user/images.<extension>"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "<content-type>"
         And the response body matches:
@@ -27,7 +28,7 @@ Feature: Imbo provides an images endpoint
     Scenario Outline: Fetch images using limit
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images.<extension>?limit=2"
+        When I request "/users/user/images.<extension>?limit=2"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "<content-type>"
         And the response body matches:
@@ -39,28 +40,33 @@ Feature: Imbo provides an images endpoint
             | json      | application/json | #^{"search":{"hits":4,"page":1,"limit":2,"count":2},"images":\[{.*?},{.*?}\]}$# |
             | xml       | application/xml  | #^<\?xml version="1.0" encoding="UTF-8"\?>\s*<imbo>\s*<search>\s*<hits>4</hits>\s*<page>1</page>\s*<limit>2</limit>\s*<count>2</count>\s*</search>\s*<images>\s*(<image>.*?</image>\s*){2}\s*</images>\s*</imbo>$#ms |
 
-    Scenario Outline: Fetch images with a filter on image identifiers
+    Scenario: Fetch images with a filter on non-existant image identifier
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images.json?ids[]=<filter>"
+        When I request "/users/user/images.json?ids[]=foobar"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body matches:
         """
-        <response>
+        #^{"search":{.*?},"images":\[\]}$#
         """
 
-        Examples:
-            | filter                           | response |
-            | foobar                           | #^{"search":{.*?},"images":\[\]}$# |
-            | fc7d2d06993047a0b5056e8fac4462a2 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"fc7d2d06993047a0b5056e8fac4462a2","originalChecksum":"fc7d2d06993047a0b5056e8fac4462a2","extension":"png","size":95576,"width":599,"height":417,"mime":"image\\/png","imageIdentifier":"fc7d2d06993047a0b5056e8fac4462a2","user":"publickey"}\]}$# |
-            | f3210f1bb34bfbfa432cc3560be40761 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"f3210f1bb34bfbfa432cc3560be40761","originalChecksum":"f3210f1bb34bfbfa432cc3560be40761","extension":"jpg","size":64828,"width":665,"height":463,"mime":"image\\/jpeg","imageIdentifier":"f3210f1bb34bfbfa432cc3560be40761","user":"publickey"}\]}$# |
-            | b5426b4c008e378c201526d2baaec599 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"b5426b4c008e378c201526d2baaec599","originalChecksum":"b5426b4c008e378c201526d2baaec599","extension":"gif","size":66020,"width":665,"height":463,"mime":"image\\/gif","imageIdentifier":"b5426b4c008e378c201526d2baaec599","user":"publickey"}\]}$# |
+    Scenario: Fetch images with a filter on existing image identifier
+        Given I use "publickey" and "privatekey" for public and private keys
+        And I include an access token in the query
+        And I append a query string parameter, "ids[]" with the image identifier of "tests/phpunit/Fixtures/image1.png"
+        When I request "/users/user/images.json" with the given query string
+        Then I should get a response with "200 OK"
+        And the "Content-Type" response header is "application/json"
+        And the response body matches:
+        """
+        #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"fc7d2d06993047a0b5056e8fac4462a2","originalChecksum":"fc7d2d06993047a0b5056e8fac4462a2","extension":"png","size":95576,"width":599,"height":417,"mime":"image\\/png","imageIdentifier":".*?","user":"user"}\]}$#
+        """
 
     Scenario Outline: Fetch images with a filter on checksums
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images.json?checksums[]=<filter>"
+        When I request "/users/user/images.json?checksums[]=<filter>"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body matches:
@@ -71,14 +77,14 @@ Feature: Imbo provides an images endpoint
         Examples:
             | filter                           | response |
             | foobar                           | #^{"search":{.*?},"images":\[\]}$# |
-            | fc7d2d06993047a0b5056e8fac4462a2 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"fc7d2d06993047a0b5056e8fac4462a2","originalChecksum":"fc7d2d06993047a0b5056e8fac4462a2","extension":"png","size":95576,"width":599,"height":417,"mime":"image\\/png","imageIdentifier":"fc7d2d06993047a0b5056e8fac4462a2","user":"publickey"}\]}$# |
-            | f3210f1bb34bfbfa432cc3560be40761 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"f3210f1bb34bfbfa432cc3560be40761","originalChecksum":"f3210f1bb34bfbfa432cc3560be40761","extension":"jpg","size":64828,"width":665,"height":463,"mime":"image\\/jpeg","imageIdentifier":"f3210f1bb34bfbfa432cc3560be40761","user":"publickey"}\]}$# |
-            | b5426b4c008e378c201526d2baaec599 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"b5426b4c008e378c201526d2baaec599","originalChecksum":"b5426b4c008e378c201526d2baaec599","extension":"gif","size":66020,"width":665,"height":463,"mime":"image\\/gif","imageIdentifier":"b5426b4c008e378c201526d2baaec599","user":"publickey"}\]}$# |
+            | fc7d2d06993047a0b5056e8fac4462a2 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"fc7d2d06993047a0b5056e8fac4462a2","originalChecksum":"fc7d2d06993047a0b5056e8fac4462a2","extension":"png","size":95576,"width":599,"height":417,"mime":"image\\/png","imageIdentifier":".*?","user":"user"}\]}$# |
+            | f3210f1bb34bfbfa432cc3560be40761 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"f3210f1bb34bfbfa432cc3560be40761","originalChecksum":"f3210f1bb34bfbfa432cc3560be40761","extension":"jpg","size":64828,"width":665,"height":463,"mime":"image\\/jpeg","imageIdentifier":".*?","user":"user"}\]}$# |
+            | b5426b4c008e378c201526d2baaec599 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"b5426b4c008e378c201526d2baaec599","originalChecksum":"b5426b4c008e378c201526d2baaec599","extension":"gif","size":66020,"width":665,"height":463,"mime":"image\\/gif","imageIdentifier":".*?","user":"user"}\]}$# |
 
     Scenario Outline: Fetch images only displaying certain fields
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images.<extension>?<fields>"
+        When I request "/users/user/images.<extension>?<fields>"
         Then I should get a response with "200 OK"
         And the response body matches:
         """
@@ -95,7 +101,7 @@ Feature: Imbo provides an images endpoint
     Scenario Outline: Fetch images with metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images.<extension>?metadata=1&fields[]=<fields>"
+        When I request "/users/user/images.<extension>?metadata=1&fields[]=<fields>"
         Then I should get a response with "200 OK"
         And the response body matches:
         """
@@ -112,7 +118,7 @@ Feature: Imbo provides an images endpoint
     Scenario Outline: Fetch images and use custom sorting
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images.json?<fields>&<sort>"
+        When I request "/users/user/images.json?<fields>&<sort>"
         Then I should get a response with "200 OK"
         And the response body matches:
         """
@@ -129,24 +135,24 @@ Feature: Imbo provides an images endpoint
     Scenario: The hits number has the number of hits in the query
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images.json?limit=1&page=1&ids[]=fc7d2d06993047a0b5056e8fac4462a2&ids[]=b5426b4c008e378c201526d2baaec599"
+        And I append a query string parameter, "page" with the value "1"
+        And I append a query string parameter, "limit" with the value "1"
+        And I append a query string parameter, "ids[]" with the image identifier of "tests/phpunit/Fixtures/image1.png"
+        And I append a query string parameter, "ids[]" with the image identifier of "tests/phpunit/Fixtures/image.jpg"
+        When I request "/users/user/images.json" with the given query string
         Then I should get a response with "200 OK"
         And the response body matches:
         """
         #^{"search":{"hits":2,"page":1,"limit":1,"count":1},"images":\[{.*}\]}$#
         """
 
-    Scenario Outline: Fetch images with a filter on original checksums
+    Scenario: Fetch images with a filter on original checksums
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images.json?<filter>"
+        When I request "/users/user/images.json?originalChecksums[]=b60df41830245ee8f278e3ddfe5238a3"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body matches:
         """
-        <response>
+        #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"b60df41830245ee8f278e3ddfe5238a3","originalChecksum":"b60df41830245ee8f278e3ddfe5238a3","extension":"png","size":12505,"width":1024,"height":256,"mime":"image\\/png","imageIdentifier":"[^"]+","user":"user"}\]}$#
         """
-
-        Examples:
-            | filter                                               | response |
-            | originalChecksums[]=b60df41830245ee8f278e3ddfe5238a3 | #^{"search":{.*?},"images":\[{"added":"[^"]+","updated":"[^"]+","checksum":"b60df41830245ee8f278e3ddfe5238a3","originalChecksum":"b60df41830245ee8f278e3ddfe5238a3","extension":"png","size":12505,"width":1024,"height":256,"mime":"image\\/png","imageIdentifier":"b60df41830245ee8f278e3ddfe5238a3","user":"publickey"}\]}$# |

--- a/tests/behat/features/level-transformation.feature
+++ b/tests/behat/features/level-transformation.feature
@@ -10,7 +10,7 @@ Feature: Imbo can adjust color levels of images
         Given I use "publickey" and "privatekey" for public and private keys
         And I specify "level:channel=r,amount=100" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/7e798b6f4773ea7d2eec5f484db4fbff.png"
+        When I request the previously added image as a "png"
         Then I should get a response with "200 OK"
         And the pixel at coordinate "5, 55" should have a color of "#de3f3f"
 
@@ -18,6 +18,6 @@ Feature: Imbo can adjust color levels of images
         Given I use "publickey" and "privatekey" for public and private keys
         And I specify "level:channel=rgb,amount=100" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/7e798b6f4773ea7d2eec5f484db4fbff.png"
+        When I request the previously added image as a "png"
         Then I should get a response with "200 OK"
         And the pixel at coordinate "22, 32" should have a color of "#ffed00"

--- a/tests/behat/features/max-image-size-event-listener.feature
+++ b/tests/behat/features/max-image-size-event-listener.feature
@@ -8,12 +8,12 @@ Feature: Imbo provides an event listener for enforcing a max image size
         And I sign the request
         And I attach "tests/phpunit/Fixtures/1024x256.png" to the request body
         And Imbo uses the "enforce-max-image-size.php" configuration
-        When I request "/users/publickey/images" using HTTP "POST"
+        When I request "/users/user/images" using HTTP "POST"
         Then I should get a response with "201 Created"
         And the "Content-Type" response header is "application/json"
         And the response body matches:
           """
-          /{"imageIdentifier":"[a-z0-9]{32}","width":1000,"height":250,"extension":"png"}/
+          /{"imageIdentifier":".*?","width":1000,"height":250,"extension":"png"}/
           """
 
     Scenario: Add an image that is above the maximum height
@@ -21,12 +21,12 @@ Feature: Imbo provides an event listener for enforcing a max image size
         And I sign the request
         And I attach "tests/phpunit/Fixtures/256x1024.png" to the request body
         And Imbo uses the "enforce-max-image-size.php" configuration
-        When I request "/users/publickey/images" using HTTP "POST"
+        When I request "/users/user/images" using HTTP "POST"
         Then I should get a response with "201 Created"
         And the "Content-Type" response header is "application/json"
         And the response body matches:
           """
-          /{"imageIdentifier":"[a-z0-9]{32}","width":150,"height":600,"extension":"png"}/
+          /{"imageIdentifier":".*?","width":150,"height":600,"extension":"png"}/
           """
 
     Scenario: Add an image that is above the maximum width and height
@@ -34,10 +34,10 @@ Feature: Imbo provides an event listener for enforcing a max image size
         And I sign the request
         And I attach "tests/phpunit/Fixtures/1024x1024.png" to the request body
         And Imbo uses the "enforce-max-image-size.php" configuration
-        When I request "/users/publickey/images" using HTTP "POST"
+        When I request "/users/user/images" using HTTP "POST"
         Then I should get a response with "201 Created"
         And the "Content-Type" response header is "application/json"
         And the response body matches:
           """
-          /{"imageIdentifier":"[a-z0-9]{32}","width":600,"height":600,"extension":"png"}/
+          /{"imageIdentifier":".*?","width":600,"height":600,"extension":"png"}/
           """

--- a/tests/behat/features/metadata-cache-listener.feature
+++ b/tests/behat/features/metadata-cache-listener.feature
@@ -4,7 +4,7 @@ Feature: Imbo enables caching of metadata
     I will cache and re-use fetched metadata
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" is used as the test image
+        Given "tests/phpunit/Fixtures/image1.png" is used as the test image for the "metadata cache" feature
 
     Scenario: Attach metadata to an image
         Given I use "publickey" and "privatekey" for public and private keys

--- a/tests/behat/features/metadata-cache-listener.feature
+++ b/tests/behat/features/metadata-cache-listener.feature
@@ -4,7 +4,7 @@ Feature: Imbo enables caching of metadata
     I will cache and re-use fetched metadata
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        Given "tests/phpunit/Fixtures/image1.png" is used as the test image
 
     Scenario: Attach metadata to an image
         Given I use "publickey" and "privatekey" for public and private keys
@@ -14,7 +14,7 @@ Feature: Imbo enables caching of metadata
           """
         And I sign the request
         And Imbo uses the "metadata-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata" using HTTP "PUT"
+        When I request the metadata of the test image using HTTP "PUT"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body is:
@@ -26,7 +26,7 @@ Feature: Imbo enables caching of metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "metadata-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata"
+        When I request the metadata of the test image
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the "X-Imbo-MetadataCache" response header is "Miss"
@@ -39,7 +39,7 @@ Feature: Imbo enables caching of metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "metadata-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata"
+        When I request the metadata of the test image
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the "X-Imbo-MetadataCache" response header is "Hit"
@@ -52,7 +52,7 @@ Feature: Imbo enables caching of metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "metadata-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/meta.xml"
+        When I request the metadata of the test image as "xml"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/xml"
         And the "X-Imbo-MetadataCache" response header is "Hit"
@@ -65,7 +65,7 @@ Feature: Imbo enables caching of metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I sign the request
         And Imbo uses the "metadata-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata" using HTTP "DELETE"
+        When I request the metadata of the test image using HTTP "DELETE"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body is:
@@ -77,7 +77,7 @@ Feature: Imbo enables caching of metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "metadata-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata"
+        When I request the metadata of the test image
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the "X-Imbo-MetadataCache" response header is "Miss"
@@ -90,7 +90,7 @@ Feature: Imbo enables caching of metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         And Imbo uses the "metadata-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/meta.xml"
+        When I request the metadata of the test image as "xml"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/xml"
         And the "X-Imbo-MetadataCache" response header is "Hit"
@@ -99,21 +99,3 @@ Feature: Imbo enables caching of metadata
            #<\?xml version="1.0" encoding="UTF-8"\?>\s*<imbo>\s*<metadata></metadata>\s*</imbo>#ms
            """
 
-    Scenario: Fetch metadata when the image has been deleted:
-        Given Imbo uses the "metadata-cache.php" configuration
-        And the image is deleted
-
-        And Imbo uses the "metadata-cache.php" configuration
-        And "tests/phpunit/Fixtures/image1.png" exists in Imbo
-
-        And I use "publickey" and "privatekey" for public and private keys
-        And I include an access token in the query
-        And Imbo uses the "metadata-cache.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata"
-        Then I should get a response with "200 OK"
-        And the "Content-Type" response header is "application/json"
-        And the "X-Imbo-MetadataCache" response header is "Miss"
-        And the response body is:
-           """
-          {}
-           """

--- a/tests/behat/features/metadata.feature
+++ b/tests/behat/features/metadata.feature
@@ -4,7 +4,7 @@ Feature: Imbo provides a metadata endpoint
     I want to make requests against the metadata endpoint
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" is used as the test image
+        Given "tests/phpunit/Fixtures/image1.png" is used as the test image for the "metadata" feature
 
     Scenario Outline: Get metadata when image has no metadata attached
         Given I use "publickey" and "privatekey" for public and private keys

--- a/tests/behat/features/metadata.feature
+++ b/tests/behat/features/metadata.feature
@@ -4,12 +4,12 @@ Feature: Imbo provides a metadata endpoint
     I want to make requests against the metadata endpoint
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        Given "tests/phpunit/Fixtures/image1.png" is used as the test image
 
     Scenario Outline: Get metadata when image has no metadata attached
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata.<extension>"
+        When I request the metadata of the test image as "<extension>"
         Then I should get a response with "200 OK"
         And the response body matches:
            """
@@ -28,7 +28,7 @@ Feature: Imbo provides a metadata endpoint
           {"foo": "bar"}
           """
         And I sign the request
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata" using HTTP "PUT"
+        When I request the metadata of the test image using HTTP "PUT"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body is:
@@ -39,7 +39,7 @@ Feature: Imbo provides a metadata endpoint
     Scenario Outline: Get metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata.<extension>"
+        When I request the metadata of the test image as "<extension>"
         Then I should get a response with "200 OK"
         And the response body matches:
            """
@@ -55,10 +55,10 @@ Feature: Imbo provides a metadata endpoint
         Given I use "publickey" and "privatekey" for public and private keys
         And the request body contains:
           """
-          {"bar": "foo"}
+          {"bar":"foo"}
           """
         And I sign the request
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata" using HTTP "POST"
+        When I request the metadata of the test image using HTTP "POST"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body is:
@@ -69,7 +69,7 @@ Feature: Imbo provides a metadata endpoint
     Scenario Outline: Get updated metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata.<extension>"
+        When I request the metadata of the test image as "<extension>"
         Then I should get a response with "200 OK"
         And the response body matches:
            """
@@ -88,7 +88,7 @@ Feature: Imbo provides a metadata endpoint
           {"key": "value"}
           """
         And I sign the request
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata" using HTTP "PUT"
+        When I request the metadata of the test image using HTTP "PUT"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body is:
@@ -99,7 +99,7 @@ Feature: Imbo provides a metadata endpoint
     Scenario Outline: Get replaced metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata.<extension>"
+        When I request the metadata of the test image as "<extension>"
         Then I should get a response with "200 OK"
         And the response body matches:
            """
@@ -114,7 +114,7 @@ Feature: Imbo provides a metadata endpoint
     Scenario: Delete metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I sign the request
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata" using HTTP "DELETE"
+        When I request the metadata of the test image using HTTP "DELETE"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body is:
@@ -125,7 +125,7 @@ Feature: Imbo provides a metadata endpoint
     Scenario Outline: Get deleted metadata
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2/metadata.<extension>"
+        When I request the metadata of the test image as "<extension>"
         Then I should get a response with "200 OK"
         And the response body matches:
            """

--- a/tests/behat/features/shorturls.feature
+++ b/tests/behat/features/shorturls.feature
@@ -3,17 +3,12 @@ Feature: Imbo can generate short URLs for images on demand
     As an HTTP Client
     I can request the short URLs resource
 
-    Background:
-        Given "tests/phpunit/Fixtures/image.png" exists in Imbo
-
     Scenario: Generate a short URL
-        Given I use "publickey" and "privatekey" for public and private keys
-        And I sign the request
-        And the request body contains:
-          """
-          {"imageIdentifier": "<imageIdentifier>", "user": "user", "extension": "gif", "query": "t[]=thumbnail:width=45,height=55&t[]=desaturate"}
-          """
-        When I request the shorturls resource for the test image using HTTP "POST"
+        Given "tests/phpunit/Fixtures/image.png" exists in Imbo
+        And I generate a short URL with the following parameters:
+            """
+            {"user": "user", "extension": "gif"}
+            """
         Then I should get a response with "201 Created"
         And the "Content-Type" response header is "application/json"
         And the response body matches:
@@ -22,7 +17,8 @@ Feature: Imbo can generate short URLs for images on demand
            """
 
     Scenario Outline: Request an image using the short URL
-        Given I generate a short URL with the following parameters:
+        Given "tests/phpunit/Fixtures/image.png" exists in Imbo
+        And I generate a short URL with the following parameters:
             """
             <params>
             """

--- a/tests/behat/features/shorturls.feature
+++ b/tests/behat/features/shorturls.feature
@@ -4,7 +4,7 @@ Feature: Imbo can generate short URLs for images on demand
     I can request the short URLs resource
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        Given "tests/phpunit/Fixtures/image.png" exists in Imbo
 
     Scenario: Generate a short URL
         Given I use "publickey" and "privatekey" for public and private keys

--- a/tests/behat/features/shorturls.feature
+++ b/tests/behat/features/shorturls.feature
@@ -4,16 +4,16 @@ Feature: Imbo can generate short URLs for images on demand
     I can request the short URLs resource
 
     Background:
-        Given "tests/phpunit/Fixtures/image.png" exists in Imbo
+        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
 
     Scenario: Generate a short URL
-        Given I use "user" and "key" for public and private keys
+        Given I use "publickey" and "privatekey" for public and private keys
         And I sign the request
         And the request body contains:
           """
-          {"imageIdentifier": "929db9c5fc3099f7576f5655207eba47", "user": "user", "extension": "gif", "query": "t[]=thumbnail:width=45,height=55&t[]=desaturate"}
+          {"imageIdentifier": "<imageIdentifier>", "user": "user", "extension": "gif", "query": "t[]=thumbnail:width=45,height=55&t[]=desaturate"}
           """
-        When I request "/users/user/images/929db9c5fc3099f7576f5655207eba47/shorturls.json" using HTTP "POST"
+        When I request the shorturls resource for the test image using HTTP "POST"
         Then I should get a response with "201 Created"
         And the "Content-Type" response header is "application/json"
         And the response body matches:
@@ -40,8 +40,8 @@ Feature: Imbo can generate short URLs for images on demand
 
         Examples:
             | params                                                                                                                                                       | mime       | width | height |
-            | {"imageIdentifier": "929db9c5fc3099f7576f5655207eba47", "user": "publickey"}                                                                                 | image/png  | 665   | 463    |
-            | {"imageIdentifier": "929db9c5fc3099f7576f5655207eba47", "user": "publickey", "extension": "gif"}                                                             | image/gif  | 665   | 463    |
-            | {"imageIdentifier": "929db9c5fc3099f7576f5655207eba47", "user": "publickey", "query": "t[]=thumbnail"}                                                       | image/png  | 50    | 50     |
-            | {"imageIdentifier": "929db9c5fc3099f7576f5655207eba47", "user": "publickey", "query": "t[]=thumbnail:width=45,height=55&t[]=desaturate"}                     | image/png  | 45    | 55     |
-            | {"imageIdentifier": "929db9c5fc3099f7576f5655207eba47", "user": "publickey", "extension": "jpg", "query": "t[]=thumbnail:width=45,height=55&t[]=desaturate"} | image/jpeg | 45    | 55     |
+            | {"user": "user"}                                                                                 | image/png  | 665   | 463    |
+            | {"user": "user", "extension": "gif"}                                                             | image/gif  | 665   | 463    |
+            | {"user": "user", "query": "t[]=thumbnail"}                                                       | image/png  | 50    | 50     |
+            | {"user": "user", "query": "t[]=thumbnail:width=45,height=55&t[]=desaturate"}                     | image/png  | 45    | 55     |
+            | {"user": "user", "extension": "jpg", "query": "t[]=thumbnail:width=45,height=55&t[]=desaturate"} | image/jpeg | 45    | 55     |

--- a/tests/behat/features/stats.feature
+++ b/tests/behat/features/stats.feature
@@ -4,7 +4,8 @@ Feature: Imbo provides a stats endpoint
     I want to make requests against the stats endpoint
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        Given Imbo starts with an empty database
+        And "tests/phpunit/Fixtures/image1.png" exists in Imbo
         And "tests/phpunit/Fixtures/image.jpg" exists in Imbo
         And "tests/phpunit/Fixtures/image.gif" exists in Imbo
 

--- a/tests/behat/features/strip-exif-transformation.feature
+++ b/tests/behat/features/strip-exif-transformation.feature
@@ -10,7 +10,7 @@ Feature: Imbo can strip EXIF data from images
         Given I use "publickey" and "privatekey" for public and private keys
         And I specify "strip" as transformation
         And I include an access token in the query
-        When I request "/users/user/images/753e11e00522ff1e95600d8f91c74e8e.jpg"
+        When I request the previously added image as a "jpg"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/jpeg"
         And the image should not have any "exif" properties

--- a/tests/behat/features/strip-exif-transformation.feature
+++ b/tests/behat/features/strip-exif-transformation.feature
@@ -10,7 +10,7 @@ Feature: Imbo can strip EXIF data from images
         Given I use "publickey" and "privatekey" for public and private keys
         And I specify "strip" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/753e11e00522ff1e95600d8f91c74e8e.jpg"
+        When I request "/users/user/images/753e11e00522ff1e95600d8f91c74e8e.jpg"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "image/jpeg"
         And the image should not have any "exif" properties

--- a/tests/behat/features/user.feature
+++ b/tests/behat/features/user.feature
@@ -27,7 +27,7 @@ Feature: Imbo provides a user endpoint
     Scenario Outline: The user endpoint only supports HTTP GET and HEAD
         Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/users/publickey.json" using HTTP "<method>"
+        When I request "/users/user.json" using HTTP "<method>"
         Then I should get a response with "<status>"
 
         Examples:

--- a/tests/behat/features/user.feature
+++ b/tests/behat/features/user.feature
@@ -4,7 +4,7 @@ Feature: Imbo provides a user endpoint
     I want to make requests against the user endpoint
 
     Scenario Outline: Request user information
-        Given I use "user" and "key" for public and private keys
+        Given I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         When I request "/users/user.<extension>"
         Then I should get a response with "200 OK"

--- a/tests/behat/features/varnish-hashtwo-listener.feature
+++ b/tests/behat/features/varnish-hashtwo-listener.feature
@@ -11,7 +11,7 @@ Feature: Imbo provides an event listener for the hashtwo Varnish module
         And I specify "<transformation>" as transformation
         And I include an access token in the query
         And Imbo uses the "varnish-hashtwo.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request "/users/user/images/fc7d2d06993047a0b5056e8fac4462a2.png"
         Then I should get a response with "200 OK"
         And the "X-HashTwo" response header is "imbo;image;publickey;fc7d2d06993047a0b5056e8fac4462a2, imbo;user;publickey"
 
@@ -29,7 +29,7 @@ Feature: Imbo provides an event listener for the hashtwo Varnish module
         And I specify "<transformation>" as transformation
         And I include an access token in the query
         And Imbo uses the "varnish-hashtwo.php" configuration
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request "/users/user/images/fc7d2d06993047a0b5056e8fac4462a2.png"
         Then I should get a response with "200 OK"
         And the "X-Imbo-HashTwo" response header is "imbo;image;publickey;fc7d2d06993047a0b5056e8fac4462a2, imbo;user;publickey"
 

--- a/tests/behat/features/varnish-hashtwo-listener.feature
+++ b/tests/behat/features/varnish-hashtwo-listener.feature
@@ -11,9 +11,9 @@ Feature: Imbo provides an event listener for the hashtwo Varnish module
         And I specify "<transformation>" as transformation
         And I include an access token in the query
         And Imbo uses the "varnish-hashtwo.php" configuration
-        When I request "/users/user/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request the previously added image as a "png"
         Then I should get a response with "200 OK"
-        And the "X-HashTwo" response header is "imbo;image;publickey;fc7d2d06993047a0b5056e8fac4462a2, imbo;user;publickey"
+        And the "X-HashTwo" response header matches "imbo;image;user;[a-f0-9-]{32,36}, imbo;user;user"
 
         Examples:
             | transformation   |
@@ -29,9 +29,9 @@ Feature: Imbo provides an event listener for the hashtwo Varnish module
         And I specify "<transformation>" as transformation
         And I include an access token in the query
         And Imbo uses the "varnish-hashtwo.php" configuration
-        When I request "/users/user/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request the previously added image as a "png"
         Then I should get a response with "200 OK"
-        And the "X-Imbo-HashTwo" response header is "imbo;image;publickey;fc7d2d06993047a0b5056e8fac4462a2, imbo;user;publickey"
+        And the "X-Imbo-HashTwo" response header matches "imbo;image;user;[a-f0-9-]{32,36}, imbo;user;user"
 
         Examples:
             | transformation   |

--- a/tests/behat/features/watermark-transformation.feature
+++ b/tests/behat/features/watermark-transformation.feature
@@ -4,15 +4,27 @@ Feature: Imbo can apply watermarks to images
     I can use the watermark transformation
 
     Background:
-        Given "tests/phpunit/Fixtures/image1.png" exists in Imbo
+        Given "tests/phpunit/Fixtures/image.png" is used as the test image for the "watermark" feature
 
     Scenario: Apply a non-existing watermark
         Given I use "publickey" and "privatekey" for public and private keys
         And I specify "watermark:img=foobar" as transformation
         And I include an access token in the query
-        When I request "/users/user/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request the test image
         Then I should get a response with "400 Watermark image not found"
 
-#            | watermark:img=929db9c5fc3099f7576f5655207eba47                                                    | 599   | 417    |
-#            | watermark:img=929db9c5fc3099f7576f5655207eba47,position=center                                    | 599   | 417    |
-#            | watermark:img=929db9c5fc3099f7576f5655207eba47,x=10,y=20,position=bottom-right,width=10,height=40 | 599   | 417    |
+    Scenario Outline: Apply an existing watermark
+        Given I use "publickey" and "privatekey" for public and private keys
+        And I use "tests/phpunit/Fixtures/colors.png" as the watermark image with "<parameters>" as parameters
+        And I include an access token in the query
+        When I request the test image as a "png"
+        Then I should get a response with "200 OK"
+        And the width of the image is "665"
+        And the height of the image is "463"
+        And the pixel at coordinate "<coordinates>" should have a color of "<color>"
+
+        Examples:
+            | parameters                                        | coordinates | color   |
+            |                                                   | 0, 0        | #000000 |
+            | position=center                                   | 337, 226    | #00ffff |
+            | x=10,y=5,position=bottom-right,width=20,height=20 | 659, 453    | #ff0000 |

--- a/tests/behat/features/watermark-transformation.feature
+++ b/tests/behat/features/watermark-transformation.feature
@@ -10,5 +10,9 @@ Feature: Imbo can apply watermarks to images
         Given I use "publickey" and "privatekey" for public and private keys
         And I specify "watermark:img=foobar" as transformation
         And I include an access token in the query
-        When I request "/users/publickey/images/fc7d2d06993047a0b5056e8fac4462a2.png"
+        When I request "/users/user/images/fc7d2d06993047a0b5056e8fac4462a2.png"
         Then I should get a response with "400 Watermark image not found"
+
+#            | watermark:img=929db9c5fc3099f7576f5655207eba47                                                    | 599   | 417    |
+#            | watermark:img=929db9c5fc3099f7576f5655207eba47,position=center                                    | 599   | 417    |
+#            | watermark:img=929db9c5fc3099f7576f5655207eba47,x=10,y=20,position=bottom-right,width=10,height=40 | 599   | 417    |

--- a/tests/behat/imbo-configs/config.testing.php
+++ b/tests/behat/imbo-configs/config.testing.php
@@ -8,23 +8,34 @@
  * distributed with this source code.
  */
 
+use Imbo\Auth\AccessControl\Adapter\AdapterInterface as ACI,
+    Imbo\Auth\AccessControl\Adapter\ArrayAdapter;
+
 // Default config for testing
 $testConfig = array(
-    'auth' => array(
-        'publickey' => 'privatekey',
-        'user' => 'key',
-    ),
+    'accessControl' => function() {
+        return new ArrayAdapter([
+            [
+                'publicKey' => 'publickey',
+                'privateKey' => 'privatekey',
+                'acl' => [[
+                    'resources' => ArrayAdapter::getReadWriteResources(),
+                    'users' => ['user'],
+                ]]
+            ],
+        ]);
+    },
 
     'database' => function() {
-        return new Imbo\Database\MongoDB(array(
+        return new Imbo\Database\MongoDB([
             'databaseName' => 'imbo_testing',
-        ));
+        ]);
     },
 
     'storage' => function() {
-        return new Imbo\Storage\GridFS(array(
+        return new Imbo\Storage\GridFS([
             'databaseName' => 'imbo_testing',
-        ));
+        ]);
     },
 );
 
@@ -35,7 +46,7 @@ $defaultConfig = require __DIR__ . '/../../../config/config.default.php';
 if (isset($_SERVER['HTTP_X_IMBO_TEST_CONFIG'])) {
     $customConfig = require __DIR__ . '/' . basename($_SERVER['HTTP_X_IMBO_TEST_CONFIG']);
 } else {
-    $customConfig = array();
+    $customConfig = [];
 }
 
 // Return the merged configuration, having the custom config overwrite the default testing config,

--- a/tests/behat/imbo-configs/custom-event-listeners.php
+++ b/tests/behat/imbo-configs/custom-event-listeners.php
@@ -88,7 +88,7 @@ return array(
             'listener' => 'CustomEventListener',
             'params' => array('key1' => 'value1', 'key2' => 'value2'),
             'users' => array(
-                'whitelist' => array('publickey'),
+                'whitelist' => array('user'),
             ),
         ),
     ),

--- a/tests/behat/imbo-configs/ro-rw-auth.php
+++ b/tests/behat/imbo-configs/ro-rw-auth.php
@@ -33,6 +33,15 @@ return [
                     'users' => ['someuser'],
                 ]]
             ],
+
+            [
+                'publicKey'  => 'foo',
+                'privateKey' => 'bar',
+                'acl' => [[
+                    'resources' => ArrayAdapter::getReadOnlyResources(),
+                    'users' => ['user'],
+                ]]
+            ]
         ]);
     }
 ];

--- a/tests/phpunit/ImboIntegrationTest/EventListener/ExifMetadataTest.php
+++ b/tests/phpunit/ImboIntegrationTest/EventListener/ExifMetadataTest.php
@@ -103,9 +103,11 @@ class ExifMetadataTest extends \PHPUnit_Framework_TestCase {
     public function testCanGetAndSaveProperties() {
         $listener = new ExifMetadata();
         $user = 'foobar';
+        $imageIdentifier = 'imageId';
 
         $image = new Image();
         $image->setBlob(file_get_contents(FIXTURES_DIR . '/exif-logo.jpg'));
+        $image->setImageIdentifier($imageIdentifier);
 
         $request = $this->getMock('Imbo\Http\Request\Request');
         $request->expects($this->exactly(2))->method('getImage')->will($this->returnValue($image));
@@ -114,7 +116,7 @@ class ExifMetadataTest extends \PHPUnit_Framework_TestCase {
         $database = $this->getMock('Imbo\Database\DatabaseInterface');
         $database->expects($this->once())->method('updateMetadata')->with(
             $this->equalTo($user),
-            $this->equalTo('753e11e00522ff1e95600d8f91c74e8e'),
+            $this->equalTo($imageIdentifier),
             $this->arrayHasKey('gps:location')
         );
 

--- a/tests/phpunit/ImboIntegrationTest/Image/Transformation/WatermarkTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Image/Transformation/WatermarkTest.php
@@ -229,11 +229,11 @@ class WatermarkTest extends TransformationTests {
         $storage = $this->getMock('Imbo\Storage\StorageInterface');
         $storage->expects($this->once())
                 ->method('getImage')
-                ->with('publickey', $expectedWatermark)
+                ->with('someUser', $expectedWatermark)
                 ->will($this->returnValue(file_get_contents(FIXTURES_DIR . '/black.png')));
 
         $request = $this->getMock('Imbo\Http\Request\Request');
-        $request->expects($this->once())->method('getPublicKey')->will($this->returnValue('publickey'));
+        $request->expects($this->once())->method('getUser')->will($this->returnValue('someUser'));
 
         $event = new Event();
         $event->setArguments(array(

--- a/tests/phpunit/ImboUnitTest/EventListener/DatabaseOperationsTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/DatabaseOperationsTest.php
@@ -80,7 +80,7 @@ class DatabaseOperationsTest extends ListenerTests {
      * @covers Imbo\EventListener\DatabaseOperations::insertImage
      */
     public function testCanInsertImage() {
-        $this->image->expects($this->once())->method('getChecksum')->will($this->returnValue($this->imageIdentifier));
+        $this->image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue($this->imageIdentifier));
         $this->request->expects($this->any())->method('getImage')->will($this->returnValue($this->image));
         $this->database->expects($this->once())->method('insertImage')->with($this->user, $this->imageIdentifier, $this->image);
 

--- a/tests/phpunit/ImboUnitTest/EventListener/ExifMetadataTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ExifMetadataTest.php
@@ -136,11 +136,11 @@ class ExifMetadataTest extends ListenerTests {
      */
     public function testCanFilterData($data, $tags, $expectedData) {
         $user = 'user';
-        $checksum = 'checksum';
+        $imageIdentifier = 'imageIdentifier';
         $blob = 'blob';
 
         $image = $this->getMock('Imbo\Model\Image');
-        $image->expects($this->once())->method('getChecksum')->will($this->returnValue($checksum));
+        $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue($imageIdentifier));
         $image->expects($this->once())->method('getBlob')->will($this->returnValue($blob));
 
         $imagick = $this->getMock('Imagick');
@@ -149,10 +149,10 @@ class ExifMetadataTest extends ListenerTests {
 
         $request = $this->getMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getUser')->will($this->returnValue($user));
-        $request->expects($this->exactly(2))->method('getImage')->will($this->returnValue($image));
+        $request->expects($this->any())->method('getImage')->will($this->returnValue($image));
 
         $database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $database->expects($this->once())->method('updateMetadata')->with($user, $checksum, $expectedData);
+        $database->expects($this->once())->method('updateMetadata')->with($user, $imageIdentifier, $expectedData);
 
         $event = $this->getMock('Imbo\EventManager\Event');
         $event->expects($this->exactly(2))->method('getRequest')->will($this->returnValue($request));
@@ -177,7 +177,7 @@ class ExifMetadataTest extends ListenerTests {
         $database->expects($this->once())->method('deleteImage')->with('user', 'imageidentifier');
 
         $image = $this->getMock('Imbo\Model\Image');
-        $image->expects($this->once())->method('getChecksum')->will($this->returnValue('imageidentifier'));
+        $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageidentifier'));
 
         $request = $this->getMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getUser')->will($this->returnValue('user'));

--- a/tests/phpunit/ImboUnitTest/EventListener/ImageVariationsTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ImageVariationsTest.php
@@ -67,7 +67,7 @@ class ImageVariationsTest extends ListenerTests {
         $this->eventManager = $this->getMock('Imbo\EventManager\EventManager');
         $this->imageStorage = $this->getMock('Imbo\Storage\StorageInterface');
 
-        $this->imageModel->method('getChecksum')->willReturn($this->imageIdentifier);
+        $this->imageModel->method('getImageIdentifier')->willReturn($this->imageIdentifier);
 
         $this->request = $this->getMock('Imbo\Http\Request\Request');
         $this->request->expects($this->any())->method('getUser')->will($this->returnValue($this->user));

--- a/tests/phpunit/ImboUnitTest/EventListener/ResponseSenderTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ResponseSenderTest.php
@@ -49,7 +49,7 @@ class ResponseSenderTest extends ListenerTests {
      */
     public function testCanSendTheResponse() {
         $image = $this->getMock('Imbo\Model\Image');
-        $image->expects($this->once())->method('getChecksum')->will($this->returnValue('checksum'));
+        $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('checksum'));
 
         $request = $this->getMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));

--- a/tests/phpunit/ImboUnitTest/EventListener/StorageOperationsTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/StorageOperationsTest.php
@@ -100,11 +100,11 @@ class StorageOperationsTest extends ListenerTests {
     public function testCanInsertImage() {
         $image = $this->getMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image data'));
-        $image->expects($this->once())->method('getChecksum')->will($this->returnValue('checksum'));
+        $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageId'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
         $this->response->expects($this->once())->method('setStatusCode')->with(201);
-        $this->storage->expects($this->once())->method('store')->with($this->user, 'checksum', 'image data');
-        $this->storage->expects($this->once())->method('imageExists')->with($this->user, 'checksum')->will($this->returnValue(false));
+        $this->storage->expects($this->once())->method('store')->with($this->user, 'imageId', 'image data');
+        $this->storage->expects($this->once())->method('imageExists')->with($this->user, 'imageId')->will($this->returnValue(false));
 
         $this->listener->insertImage($this->event);
     }
@@ -115,11 +115,11 @@ class StorageOperationsTest extends ListenerTests {
     public function testCanInsertImageThatAlreadyExists() {
         $image = $this->getMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image data'));
-        $image->expects($this->once())->method('getChecksum')->will($this->returnValue('checksum'));
+        $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageId'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
         $this->response->expects($this->once())->method('setStatusCode')->with(200);
-        $this->storage->expects($this->once())->method('store')->with($this->user, 'checksum', 'image data');
-        $this->storage->expects($this->once())->method('imageExists')->with($this->user, 'checksum')->will($this->returnValue(true));
+        $this->storage->expects($this->once())->method('store')->with($this->user, 'imageId', 'image data');
+        $this->storage->expects($this->once())->method('imageExists')->with($this->user, 'imageId')->will($this->returnValue(true));
 
         $this->listener->insertImage($this->event);
     }
@@ -133,13 +133,13 @@ class StorageOperationsTest extends ListenerTests {
     public function testWillDeleteImageFromDatabaseAndThrowExceptionWhenStoringFails() {
         $image = $this->getMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image data'));
-        $image->expects($this->once())->method('getChecksum')->will($this->returnValue('checksum'));
+        $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageId'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
-        $this->storage->expects($this->once())->method('store')->with($this->user, 'checksum', 'image data')->will($this->throwException(
+        $this->storage->expects($this->once())->method('store')->with($this->user, 'imageId', 'image data')->will($this->throwException(
             new StorageException('Could not store image', 500)
         ));
         $database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $database->expects($this->once())->method('deleteImage')->with($this->user, 'checksum');
+        $database->expects($this->once())->method('deleteImage')->with($this->user, 'imageId');
         $this->event->expects($this->once())->method('getDatabase')->will($this->returnValue($database));
 
         $this->listener->insertImage($this->event);

--- a/tests/phpunit/ImboUnitTest/Image/ImagePreparationTest.php
+++ b/tests/phpunit/ImboUnitTest/Image/ImagePreparationTest.php
@@ -108,7 +108,6 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
     public function testPopulatesRequestWhenImageIsValid() {
         $imagePath = FIXTURES_DIR . '/image.png';
         $imageData = file_get_contents($imagePath);
-        $imageIdentifier = md5($imageData);
 
         $this->request->expects($this->once())->method('getContent')->will($this->returnValue($imageData));
         $this->request->expects($this->once())->method('setImage')->with($this->isInstanceOf('Imbo\Model\Image'));

--- a/tests/phpunit/ImboUnitTest/Image/Transformation/WatermarkTest.php
+++ b/tests/phpunit/ImboUnitTest/Image/Transformation/WatermarkTest.php
@@ -66,11 +66,11 @@ class WatermarkTest extends \PHPUnit_Framework_TestCase {
         $storage = $this->getMock('Imbo\Storage\StorageInterface');
         $storage->expects($this->once())
                 ->method('getImage')
-                ->with('publickey', 'foobar')
+                ->with('someuser', 'foobar')
                 ->will($this->throwException($e));
 
         $request = $this->getMock('Imbo\Http\Request\Request');
-        $request->expects($this->once())->method('getPublicKey')->will($this->returnValue('publickey'));
+        $request->expects($this->once())->method('getUser')->will($this->returnValue('someuser'));
 
         $event = $this->getMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));

--- a/tests/phpunit/ImboUnitTest/Model/ErrorTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/ErrorTest.php
@@ -127,19 +127,19 @@ class ErrorTest extends \PHPUnit_Framework_TestCase {
     /**
      * @covers Imbo\Model\Error::createFromException
      */
-    public function testWillUseImageChecksumAsImageIdentifierIfRequestHasAnImageWhenCreatingError() {
+    public function testWillUseImageIdentifierFromImageModelIfRequestHasAnImageWhenCreatingError() {
         $exception = new RuntimeException('You wronged', 400);
         $exception->setImboErrorCode(123);
 
         $request = $this->getMock('Imbo\Http\Request\Request');
         $image = $this->getMock('Imbo\Model\Image');
-        $image->expects($this->once())->method('getChecksum')->will($this->returnValue('checksum'));
+        $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageId'));
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));
-        $request->expects($this->never())->method('checksum');
+        $request->expects($this->never())->method('imageId');
 
         $model = Error::createFromException($exception, $request);
 
         $this->assertSame(123, $model->getImboErrorCode());
-        $this->assertSame('checksum', $model->getImageIdentifier());
+        $this->assertSame('imageId', $model->getImageIdentifier());
     }
 }

--- a/tests/phpunit/ImboUnitTest/Resource/ImagesTest.php
+++ b/tests/phpunit/ImboUnitTest/Resource/ImagesTest.php
@@ -77,7 +77,7 @@ class ImagesTest extends ResourceTests {
         $this->manager->expects($this->at(0))->method('trigger')->with('db.image.insert');
         $this->manager->expects($this->at(1))->method('trigger')->with('storage.image.insert');
         $image = $this->getMock('Imbo\Model\Image');
-        $image->expects($this->once())->method('getChecksum')->will($this->returnValue('id'));
+        $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('id'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
         $this->response->expects($this->once())->method('setModel')->with($this->isInstanceOf('Imbo\Model\ArrayModel'));
 

--- a/tests/phpunit/ImboUnitTest/Resource/MetadataTest.php
+++ b/tests/phpunit/ImboUnitTest/Resource/MetadataTest.php
@@ -101,8 +101,8 @@ class MetadataTest extends ResourceTests {
         $this->request->expects($this->once())->method('getContent')->will($this->returnValue('{"foo":"bar"}'));
         $this->manager->expects($this->once())->method('trigger')->with('db.metadata.update', array('metadata' => $metadata));
         $this->response->expects($this->once())->method('setModel')->with($this->isInstanceOf('Imbo\Model\ModelInterface'));
-        $this->database->expects($this->once())->method('getMetadata')->with('key', 'id')->will($this->returnValue(array('foo' => 'bar')));
-        $this->request->expects($this->once())->method('getPublicKey')->will($this->returnValue('key'));
+        $this->database->expects($this->once())->method('getMetadata')->with('user', 'id')->will($this->returnValue(array('foo' => 'bar')));
+        $this->request->expects($this->once())->method('getUser')->will($this->returnValue('user'));
         $this->request->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('id'));
 
         $this->resource->post($this->event);


### PR DESCRIPTION
This PR replaces the use of MD5-sums for image identifiers with UUIDs. This is a pretty big change:

- Image identifiers are now 36 characters instead of 32 (will require database changes for those using Doctrine adapter with the provided setup schema)
- Adding the same image twice will now end up as two separate images with different image identifiers. Clients should make use of `imageExists` which will check based on `originalChecksum`.
- URLs for new images will be slightly longer (4 chars)

Also, a *lot* of tests depended on the hardcoded md5 value of fixture images. The tests have been updated to maintain some state (the image identifier of the previously added image, for instance).
