### PR TITLE
Global image endpoint

### DIFF
--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -647,9 +647,9 @@ results in:
 Global images resource - ``/images``
 ++++++++++++++++++++++++++++++++++++++++++
 
-The global images resource is used to search for images across users, given that the public key has access to the images of these users. This resource is read only, and behaves in the same way as described in the `Get image collections` section of :doc:`_images-resource`, with one additional query parameter:
+The global images resource is used to search for images across users, given that the public key has access to the images of these users.
 
-In addition to the parameters specified for `Get image collections`, the following query parameter must be specified:
+This resource is read only, and behaves in the same way as described in the `Get image collections` section of :doc:`_images-resource`. In addition to the parameters specified for `Get image collections`, the following query parameter must be specified:
 
 ``user[]``
     An array of users to get images for.

--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -642,6 +642,24 @@ results in:
 * 400 Bad request
 * 404 Image not found
 
+.. _global-images-resource:
+
+Global images resource - ``/images``
+++++++++++++++++++++++++++++++++++++++++++
+
+The global images resource is used to search for images across users, given that the public key has access to the images of these users. This resource is read only, and behaves in the same way as described in the `Get image collections` section of :doc:`_images-resource`, with one additional query parameter:
+
+In addition to the parameters specified for `Get image collections`, the following query parameter must be specified:
+
+``user[]``
+    An array of users to get images for.
+
+.. code-block:: bash
+
+    curl "http://imbo/images?user[]=foo&user[]=bar"
+
+results in a response with the exact same format as shown under `Get image collections`.
+
 .. _publickey-resource:
 
 Public key resource - ``/keys/<publicKey>``

--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -227,7 +227,7 @@ results in:
       "lastModified": "Wed, 18 Apr 2012 15:12:52 GMT"
     }
 
-where ``id`` is the user (the same used in the URI of the request), ``numImages`` is the number of images the user has stored in Imbo and ``lastModified`` is when the user last uploaded or deleted an image, or when the user last updated metadata of an image. If the user has not added any images yet, the ``lastModified`` value will be set to the current time on the server.
+where ``user`` is the user (the same used in the URI of the request), ``numImages`` is the number of images the user has stored in Imbo and ``lastModified`` is when the user last uploaded or deleted an image, or when the user last updated metadata of an image. If the user has not added any images yet, the ``lastModified`` value will be set to the current time on the server.
 
 **Typical response codes:**
 

--- a/library/Imbo/Application.php
+++ b/library/Imbo/Application.php
@@ -120,6 +120,7 @@ class Application {
             'Imbo\Resource\ShortUrls',
             'Imbo\Resource\ShortUrl',
             'Imbo\Resource\User',
+            'Imbo\Resource\GlobalImages',
             'Imbo\Resource\Images',
             'Imbo\Resource\Image',
             'Imbo\Resource\Metadata',

--- a/library/Imbo/Auth/AccessControl/Adapter/AdapterInterface.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/AdapterInterface.php
@@ -74,6 +74,15 @@ interface AdapterInterface {
     const RESOURCE_SHORTURLS_DELETE        = 'shorturls.delete';
 
     /**
+     * Get a list of users the public key has access for on a given resource
+     *
+     * @param  string $publicKey Public key to check access for
+     * @param  string $resource  Resource identifier (e.g. image.get, images.post)
+     * @return array             List of users the public key kan access the given resource for
+     */
+    function getUsersForResource($publicKey, $resource);
+
+    /**
      * Check if a given public key has access to a given resource
      *
      * @param  string  $publicKey Public key to check access for

--- a/library/Imbo/Auth/AccessControl/Adapter/ArrayAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/ArrayAdapter.php
@@ -73,7 +73,7 @@ class ArrayAdapter extends AbstractAdapter implements AdapterInterface {
         $users = call_user_func_array('array_merge', $userLists);
 
         // Check if public key has access to user with same name
-        if ($this->hasAccess($publicKey, $resource)) {
+        if ($this->hasAccess($publicKey, $resource, $publicKey)) {
             $userList[] = $publicKey;
         }
 

--- a/library/Imbo/Auth/AccessControl/Adapter/ArrayAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/ArrayAdapter.php
@@ -57,6 +57,39 @@ class ArrayAdapter extends AbstractAdapter implements AdapterInterface {
     /**
      * {@inheritdoc}
      */
+    public function getUsersForResource($publicKey, $resource) {
+        if (!$publicKey || !$resource) {
+            return [];
+        }
+
+        $accessList = $this->getAccessListForPublicKey($publicKey);
+
+        // Get all user lists
+        $userLists = array_filter(array_map(function($acl) {
+            return isset($acl['users']) ? $acl['users'] : false;
+        }, $accessList));
+
+        // Merge user lists
+        $users = call_user_func_array('array_merge', $userLists);
+
+        // Check if public key has access to user with same name
+        if ($this->hasAccess($publicKey, $resource)) {
+            $userList[] = $publicKey;
+        }
+
+        // Check for each user specified in acls
+        foreach ($users as $user) {
+            if ($this->hasAccess($publicKey, $resource, $user)) {
+                $userList[] = $user;
+            }
+        }
+
+        return $userList;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function hasAccess($publicKey, $resource, $user = null) {
         foreach ($this->accessList as $access) {
             if ($access['publicKey'] !== $publicKey) {

--- a/library/Imbo/Auth/AccessControl/Adapter/MongoDB.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/MongoDB.php
@@ -108,6 +108,39 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
     /**
      * {@inheritdoc}
      */
+    public function getUsersForResource($publicKey, $resource) {
+        if (!$publicKey || !$resource) {
+            return [];
+        }
+
+        $accessList = $this->getAccessListForPublicKey($publicKey);
+
+        // Get all user lists
+        $userLists = array_filter(array_map(function($acl) {
+            return isset($acl['users']) ? $acl['users'] : false;
+        }, $accessList));
+
+        // Merge user lists
+        $users = call_user_func_array('array_merge', $userLists);
+
+        // Check if public key has access to user with same name
+        if ($this->hasAccess($publicKey, $resource)) {
+            $userList[] = $publicKey;
+        }
+
+        // Check for each user specified in acls
+        foreach ($users as $user) {
+            if ($this->hasAccess($publicKey, $resource, $user)) {
+                $userList[] = $user;
+            }
+        }
+
+        return $userList;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function hasAccess($publicKey, $resource, $user = null) {
         $accessList = $this->getAccessListForPublicKey($publicKey) ?: [];
 

--- a/library/Imbo/Auth/AccessControl/Adapter/MongoDB.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/MongoDB.php
@@ -124,7 +124,7 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
         $users = call_user_func_array('array_merge', $userLists);
 
         // Check if public key has access to user with same name
-        if ($this->hasAccess($publicKey, $resource)) {
+        if ($this->hasAccess($publicKey, $resource, $publicKey)) {
             $userList[] = $publicKey;
         }
 

--- a/library/Imbo/Database/DatabaseInterface.php
+++ b/library/Imbo/Database/DatabaseInterface.php
@@ -85,13 +85,13 @@ interface DatabaseInterface {
      *
      * This method is also responsible for setting a correct "hits" number in the images model.
      *
-     * @param string $user The user which the image belongs to
+     * @param array $users The users which the images belongs to
      * @param Query $query A query instance
      * @param Images $model The images model
      * @return array
      * @throws DatabaseException
      */
-    function getImages($user, Query $query, Images $model);
+    function getImages(array $users, Query $query, Images $model);
 
     /**
      * Load information from database into the image object
@@ -114,18 +114,18 @@ interface DatabaseInterface {
     function getImageProperties($user, $imageIdentifier);
 
     /**
-     * Get the last modified timestamp of a user
+     * Get the last modified timestamp for given users
      *
      * If the $imageIdentifier parameter is set, return when that image was last updated. If not
-     * set, return when the user last updated any image. If the user does not have any images
-     * stored, return the current timestamp.
+     * set, return the most recent date when one of the specified users last updated any image. If
+     * the provided users does not have any images stored, return the current timestamp.
      *
-     * @param string $user The user which the image belongs to
+     * @param array $users The users
      * @param string $imageIdentifier The image identifier
      * @return DateTime Returns an instance of DateTime
      * @throws DatabaseException
      */
-    function getLastModified($user, $imageIdentifier = null);
+    function getLastModified(array $users, $imageIdentifier = null);
 
     /**
      * Fetch the number of images, optionally filtered by a given user

--- a/library/Imbo/Database/MongoDB.php
+++ b/library/Imbo/Database/MongoDB.php
@@ -241,14 +241,12 @@ class MongoDB implements DatabaseInterface {
     /**
      * {@inheritdoc}
      */
-    public function getImages($user, Query $query, Images $model) {
+    public function getImages(array $users, Query $query, Images $model) {
         // Initialize return value
         $images = [];
 
         // Query data
-        $queryData = [
-            'user' => $user,
-        ];
+        $queryData = ['user' => ['$in' => $users]];
 
         $from = $query->from();
         $to = $query->to();
@@ -371,10 +369,10 @@ class MongoDB implements DatabaseInterface {
     /**
      * {@inheritdoc}
      */
-    public function getLastModified($user, $imageIdentifier = null) {
+    public function getLastModified(array $users, $imageIdentifier = null) {
         try {
             // Query on the user
-            $query = ['user' => $user];
+            $query = ['user' => ['$in' => $users]];
 
             if ($imageIdentifier) {
                 // We want information about a single image. Add the identifier to the query

--- a/library/Imbo/EventListener/AccessToken.php
+++ b/library/Imbo/EventListener/AccessToken.php
@@ -94,6 +94,8 @@ class AccessToken implements ListenerInterface {
             'image.head',
             'images.get',
             'images.head',
+            'globalimages.get',
+            'globalimages.head',
             'metadata.get',
             'metadata.head',
             'shorturl.get',

--- a/library/Imbo/EventListener/DatabaseOperations.php
+++ b/library/Imbo/EventListener/DatabaseOperations.php
@@ -160,7 +160,7 @@ class DatabaseOperations implements ListenerInterface {
         $model->setData($database->getMetadata($user, $imageIdentifier));
 
         $response->setModel($model)
-                 ->setLastModified($database->getLastModified($user, $imageIdentifier));
+                 ->setLastModified($database->getLastModified([$user], $imageIdentifier));
     }
 
     /**
@@ -226,7 +226,12 @@ class DatabaseOperations implements ListenerInterface {
             }
         }
 
-        $user = $event->getRequest()->getUser();
+        if ($event->hasArgument('users')) {
+            $users = $event->getArgument('users');
+        } else {
+            $users = $event->getRequest()->getUsers();
+        }
+
         $response = $event->getResponse();
         $database = $event->getDatabase();
 
@@ -235,7 +240,7 @@ class DatabaseOperations implements ListenerInterface {
         $model->setLimit($query->limit())
               ->setPage($query->page());
 
-        $images = $database->getImages($user, $query, $model);
+        $images = $database->getImages($users, $query, $model);
         $modelImages = array();
 
         foreach ($images as $image) {
@@ -243,7 +248,7 @@ class DatabaseOperations implements ListenerInterface {
             $entry->setFilesize($image['size'])
                   ->setWidth($image['width'])
                   ->setHeight($image['height'])
-                  ->setUser($user)
+                  ->setUser($image['user'])
                   ->setImageIdentifier($image['imageIdentifier'])
                   ->setChecksum($image['checksum'])
                   ->setOriginalChecksum(isset($image['originalChecksum']) ? $image['originalChecksum'] : null)
@@ -270,7 +275,7 @@ class DatabaseOperations implements ListenerInterface {
             }
         }
 
-        $lastModified = $database->getLastModified($user);
+        $lastModified = $database->getLastModified($users);
 
         $response->setModel($model)
                  ->setLastModified($lastModified);
@@ -288,7 +293,7 @@ class DatabaseOperations implements ListenerInterface {
         $database = $event->getDatabase();
 
         $numImages = $database->getNumImages($user);
-        $lastModified = $database->getLastModified($user);
+        $lastModified = $database->getLastModified([$user]);
 
         $userModel = new Model\User();
         $userModel->setUserId($user)

--- a/library/Imbo/EventListener/DatabaseOperations.php
+++ b/library/Imbo/EventListener/DatabaseOperations.php
@@ -230,6 +230,10 @@ class DatabaseOperations implements ListenerInterface {
             $users = $event->getArgument('users');
         } else {
             $users = $event->getRequest()->getUsers();
+
+            if (!is_array($users)) {
+                $users = [];
+            }
         }
 
         $response = $event->getResponse();

--- a/library/Imbo/Http/Request/Request.php
+++ b/library/Imbo/Http/Request/Request.php
@@ -87,6 +87,26 @@ class Request extends SymfonyRequest {
     }
 
     /**
+     * Get users specified in the request
+     *
+     * @return array Users specified in the request
+     */
+    public function getUsers() {
+        $routeUser = $this->getUser();
+        $queryUsers = $this->query->get('user', null);
+
+        if (!$routeUser && !$queryUsers) {
+            return [];
+        } elseif (!$queryUsers) {
+            return [$routeUser];
+        } elseif (!$routeUser) {
+            return $queryUsers;
+        }
+
+        return array_merge([$routeUser], $queryUsers);
+    }
+
+    /**
      * Get image transformations from the request
      *
      * @return array

--- a/library/Imbo/Http/Request/Request.php
+++ b/library/Imbo/Http/Request/Request.php
@@ -93,7 +93,7 @@ class Request extends SymfonyRequest {
      */
     public function getUsers() {
         $routeUser = $this->getUser();
-        $queryUsers = $this->query->get('user', null);
+        $queryUsers = $this->query->get('user', []);
 
         if (!$routeUser && !$queryUsers) {
             return [];

--- a/library/Imbo/Resource/GlobalImages.php
+++ b/library/Imbo/Resource/GlobalImages.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Resource;
+
+use Imbo\EventManager\EventInterface,
+    Imbo\Model;
+
+/**
+ * Global images resource
+ *
+ * This resource will let users fetch images based on queries. The following query parameters can
+ * be used:
+ *
+ * page     => Page number. Defaults to 1
+ * limit    => Limit to a number of images pr. page. Defaults to 20
+ * metadata => Whether or not to include metadata pr. image. Set to 1 to enable
+ * from     => Unix timestamp to fetch from
+ * to       => Unit timestamp to fetch to
+ *
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @package Resources
+ */
+class GlobalImages implements ResourceInterface {
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllowedMethods() {
+        return ['GET', 'HEAD'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents() {
+        return [
+            'globalimages.get'    => 'getImages',
+            'globalimages.head'   => 'getImages',
+        ];
+    }
+
+    /**
+     * Handle GET and HEAD requests
+     *
+     * @param EventInterface $event The current event
+     */
+    public function getImages(EventInterface $event) {
+        $acl = $event->getAccessControl();
+
+        // Get intersection between specified users and users which
+        // the public key has access to the given endpoint for
+        $users = array_intersect(
+            $event->getRequest()->getUsers(),
+            $acl->getUsersForResource(
+                $event->getRequest()->getPublicKey(),
+                'images.get'
+            )
+        );
+
+        $event->getManager()->trigger('db.images.load', [
+            'users' => $users
+        ]);
+    }
+}

--- a/library/Imbo/Resource/Index.php
+++ b/library/Imbo/Resource/Index.php
@@ -66,6 +66,7 @@ class Index implements ResourceInterface {
                 'images' => $baseUrl . '/users/{user}/images',
                 'image' => $baseUrl . '/users/{user}/images/{imageIdentifier}',
                 'globalShortImageUrl' => $baseUrl . '/s/{id}',
+                'globalImages' => $baseUrl . '/images',
                 'metadata' => $baseUrl . '/users/{user}/images/{imageIdentifier}/metadata',
                 'shortImageUrls' => $baseUrl . '/users/{user}/images/{imageIdentifier}/shorturls',
                 'shortImageUrl' =>  $baseUrl . '/users/{user}/images/{imageIdentifier}/shorturls/{id}',

--- a/library/Imbo/Router.php
+++ b/library/Imbo/Router.php
@@ -46,6 +46,7 @@ class Router {
         'globalshorturl' => '#^/s/(?<shortUrlId>[a-zA-Z0-9]{7})$#',
         'status'         => '#^/status(/|(\.(?<extension>json|xml)))?$#',
         'images'         => '#^/users/(?<user>[a-z0-9_-]{1,})/images(/|(\.(?<extension>json|xml)))?$#',
+        'globalimages'   => '#^/images(/|(\.(?<extension>json|xml)))?$#',
         'metadata'       => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9-]{32,36})/meta(?:data)?(/|\.(?<extension>json|xml))?$#',
         'user'           => '#^/users/(?<user>[a-z0-9_-]{1,})(/|\.(?<extension>json|xml))?$#',
         'stats'          => '#^/stats(/|(\.(?<extension>json|xml)))?$#',

--- a/tests/behat/bootstrap/ImboContext.php
+++ b/tests/behat/bootstrap/ImboContext.php
@@ -318,10 +318,17 @@ class ImboContext extends RESTContext {
      * @Given /^"([^"]*)" exists in Imbo$/
      */
     public function addImageToImbo($imagePath) {
+        $this->addUserImageToImbo($imagePath, 'user');
+    }
+
+    /**
+     * @Given /^"([^"]*)" exists for user "([^"]*)" in Imbo$/
+     */
+    public function addUserImageToImbo($imagePath, $user) {
         $this->setClientAuth('publickey', 'privatekey');
         $this->signRequest();
         $this->attachFileToRequestBody($imagePath);
-        $this->request('/users/user/images/', 'POST');
+        $this->request('/users/' . $user . '/images/', 'POST');
         $this->imageUrls[$imagePath] = $this->getPreviouslyAddedImageUrl();
         $this->imageIdentifiers[$imagePath] = $this->getPreviouslyAddedImageIdentifier();
     }

--- a/tests/behat/features/access-control-mutable.feature
+++ b/tests/behat/features/access-control-mutable.feature
@@ -22,17 +22,22 @@ Feature: Imbo features access control backed by a MongoDB database
         Then I should get a response with "400 Permission denied (public key)"
         And the Imbo error message is "Permission denied (public key)" and the error code is "0"
 
-    Scenario: Request an access-controlled resource with public key that does not have access to the user
-        Given I use "valid-pubkey" and "foobar" for public and private keys
+    Scenario Outline: Request an access-controlled resource with public key that does not have access to the user
+        Given I use "foobar" and "barfoo" for public and private keys
         And I include an access token in the query
-        When I request "/users/user2.json"
-        Then I should get a response with "400 Permission denied (public key)"
-        And the Imbo error message is "Permission denied (public key)" and the error code is "0"
+        When I request "<url>"
+        Then I should get a response with "<status>"
+        And the Imbo error message is "<message>" and the error code is "<code>"
+
+        Examples:
+            | url                  | status                             | code | message                        |
+            | /users/user2         | 400 Permission denied (public key) | 0    | Permission denied (public key) |
+            | /users/foobar/images | 400 Permission denied (public key) | 0    | Permission denied (public key) |
 
     Scenario: Request an access-controlled resource with valid public key specified
         Given I use "foobar" and "barfoo" for public and private keys
         And I include an access token in the query
-        When I request "/users/foobar/images.json"
+        When I request "/users/barfoo/images.json"
         Then I should get a response with "200 OK"
 
     Scenario: Request an access-controlled resource with group that does not contain the resource

--- a/tests/behat/features/global-images.feature
+++ b/tests/behat/features/global-images.feature
@@ -1,0 +1,56 @@
+Feature: Imbo provides a global images endpoint
+    In order to query images
+    As an HTTP Client
+    I want to make requests against the images endpoint
+
+    Background:
+        Given Imbo starts with an empty database
+        And "tests/phpunit/Fixtures/image1.png" exists for user "user" in Imbo
+        And "tests/phpunit/Fixtures/image.jpg" exists for user "user" in Imbo
+        And "tests/phpunit/Fixtures/image.gif" exists for user "other-user" in Imbo
+        And "tests/phpunit/Fixtures/1024x256.png" exists for user "other-user" in Imbo
+
+    Scenario: Fetch images without specifying any users
+        Given I use "publickey" and "privatekey" for public and private keys
+        And I include an access token in the query
+        When I request "/images.json"
+        Then I should get a response with "200 OK"
+        And the "Content-Type" response header is "application/json"
+        And the response body matches:
+        """
+        #^{"search":{"hits":0#
+        """
+
+    Scenario Outline: Fetch images specifying users
+        Given I use "publickey" and "privatekey" for public and private keys
+        And I include an access token in the query
+        When I request "/images.json<queryString>"
+        Then I should get a response with "200 OK"
+        And the "Content-Type" response header is "application/json"
+        And the response body matches:
+        """
+        <response>
+        """
+
+        Examples:
+            | queryString                    | response               |
+            | ?user[]=user&user[]=other-user | #^{"search":{"hits":4,"page":1,"limit":20,"count":4}# |
+            | ?user[]=user                   | #^{"search":{"hits":2,"page":1,"limit":20,"count":2}# |
+            | ?user[]=other-user             | #^{"search":{"hits":2,"page":1,"limit":20,"count":2}# |
+
+    Scenario Outline: Fetch images specifying a user without having access to it
+        Given I use "unpriviledged" and "privatekey" for public and private keys
+        And I include an access token in the query
+        When I request "/images.json<queryString>"
+        Then I should get a response with "200 OK"
+        And the "Content-Type" response header is "application/json"
+        And the response body matches:
+        """
+        <response>
+        """
+
+        Examples:
+            | queryString                    | response               |
+            | ?user[]=user&user[]=other-user | #^{"search":{"hits":2,"page":1,"limit":20,"count":2}# |
+            | ?user[]=user                   | #^{"search":{"hits":2,"page":1,"limit":20,"count":2}# |
+            | ?user[]=other-user             | #^{"search":{"hits":0,"page":1,"limit":20,"count":0}# |

--- a/tests/behat/fixtures/access-control-mutable.php
+++ b/tests/behat/fixtures/access-control-mutable.php
@@ -33,11 +33,17 @@ return [
         [
             'publicKey' => 'foobar',
             'privateKey' => 'barfoo',
-            'acl' => [[
-                'id' => new MongoId('100000000000000000001337'),
-                'resources' => ['access.get', 'access.head', 'images.get'],
-                'users' => ['foobar']
-            ]]
+            'acl' => [
+                [
+                    'id' => new MongoId('100000000000000000001337'),
+                    'resources' => ['access.get', 'access.head'],
+                    'users' => ['foobar']
+                ], [
+                    'id' => new MongoId('100000000000000000002468'),
+                    'resources' => ['images.get'],
+                    'users' => ['barfoo']
+                ]
+            ]
         ],
         [
             'publicKey' => 'acl-creator',

--- a/tests/behat/imbo-configs/config.testing.php
+++ b/tests/behat/imbo-configs/config.testing.php
@@ -20,6 +20,14 @@ $testConfig = array(
                 'privateKey' => 'privatekey',
                 'acl' => [[
                     'resources' => ArrayAdapter::getReadWriteResources(),
+                    'users' => ['user', 'other-user'],
+                ]]
+            ],
+            [
+                'publicKey' => 'unpriviledged',
+                'privateKey' => 'privatekey',
+                'acl' => [[
+                    'resources' => ArrayAdapter::getReadWriteResources(),
                     'users' => ['user'],
                 ]]
             ],

--- a/tests/behat/imbo-configs/custom-access-control.php
+++ b/tests/behat/imbo-configs/custom-access-control.php
@@ -49,6 +49,10 @@ class StaticAccessControl extends AbstractAdapter implements AdapterInterface {
         return [];
     }
 
+    public function getUsersForResource($publicKey, $resource) {
+        return [];
+    }
+
     public function getAccessRule($publicKey, $accessRuleId) {
         return null;
     }

--- a/tests/phpunit/ImboIntegrationTest/Database/DatabaseTests.php
+++ b/tests/phpunit/ImboIntegrationTest/Database/DatabaseTests.php
@@ -85,12 +85,12 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $image = $this->getImage();
 
         $this->assertTrue($this->adapter->insertImage($user, $imageIdentifier, $image));
-        $lastModified1 = $this->adapter->getLastModified($user, $imageIdentifier);
+        $lastModified1 = $this->adapter->getLastModified([$user], $imageIdentifier);
 
         sleep(1);
 
         $this->assertTrue($this->adapter->insertImage($user, $imageIdentifier, $image));
-        $lastModified2 = $this->adapter->getLastModified($user, $imageIdentifier);
+        $lastModified2 = $this->adapter->getLastModified([$user], $imageIdentifier);
 
         $this->assertTrue($lastModified2 > $lastModified1);
     }
@@ -134,7 +134,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionMessage Image not found
      */
     public function testGetLastModifiedOfImageThatDoesNotExist() {
-        $this->adapter->getLastModified('user', 'id');
+        $this->adapter->getLastModified(['user'], 'id');
     }
 
     public function testGetLastModified() {
@@ -143,11 +143,11 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $image = $this->getImage();
 
         $this->assertTrue($this->adapter->insertImage($user, $imageIdentifier, $image));
-        $this->assertInstanceOf('DateTime', $this->adapter->getLastModified($user, $imageIdentifier));
+        $this->assertInstanceOf('DateTime', $this->adapter->getLastModified([$user], $imageIdentifier));
     }
 
     public function testGetLastModifiedWhenUserHasNoImages() {
-        $this->assertInstanceOf('DateTime', $this->adapter->getLastModified('user'));
+        $this->assertInstanceOf('DateTime', $this->adapter->getLastModified(['user']));
     }
 
     public function testGetNumImages() {
@@ -282,7 +282,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $query = new Query();
         $model = $this->getMock('Imbo\Model\Images');
         $model->expects($this->once())->method('setHits')->with(6);
-        $images = $this->adapter->getImages('user', $query, $model);
+        $images = $this->adapter->getImages(['user'], $query, $model);
         $this->assertCount(6, $images);
     }
 
@@ -295,25 +295,25 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         // Fetch to the timestamp of when the last image was added
         $query = new Query();
         $query->to($end);
-        $this->assertCount(6, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(6, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(6, $model->getHits());
 
         // Fetch until the second the first image was added
         $query = new Query();
         $query->to($start);
-        $this->assertCount(1, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(1, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(1, $model->getHits());
 
         // Fetch from the second the first image was added
         $query = new Query();
         $query->from($start);
-        $this->assertCount(6, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(6, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(6, $model->getHits());
 
         // Fetch from the second the last image was added
         $query = new Query();
         $query->from($end);
-        $this->assertCount(1, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(1, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(1, $model->getHits());
     }
 
@@ -323,7 +323,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $query = new Query();
         $query->returnMetadata(true);
 
-        $images = $this->adapter->getImages('user', $query, $this->getMock('Imbo\Model\Images'));
+        $images = $this->adapter->getImages(['user'], $query, $this->getMock('Imbo\Model\Images'));
 
         foreach ($images as $image) {
             $this->assertArrayHasKey('metadata', $image);
@@ -343,7 +343,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
 
         $model = new Images();
         $query = new Query();
-        $images = $this->adapter->getImages('user', $query, $model);
+        $images = $this->adapter->getImages(['user'], $query, $model);
 
         foreach ($images as $image) {
             $this->assertSame('user', $image['user']);
@@ -355,7 +355,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
     public function testGetImagesReturnsImagesWithDateTimeInstances() {
         $this->insertImages();
 
-        $images = $this->adapter->getImages('user', new Query(), $this->getMock('Imbo\Model\Images'));
+        $images = $this->adapter->getImages(['user'], new Query(), $this->getMock('Imbo\Model\Images'));
 
         foreach (array('added', 'updated') as $dateField) {
             foreach ($images as $image) {
@@ -414,7 +414,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $model = $this->getMock('Imbo\Model\Images');
         $model->expects($this->once())->method('setHits')->with(6);
 
-        $images = $this->adapter->getImages('user', $query, $model);
+        $images = $this->adapter->getImages(['user'], $query, $model);
         $this->assertCount(count($imageIdentifiers), $images);
 
         foreach ($images as $i => $image) {
@@ -567,27 +567,27 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $model = new Images();
 
         $query->imageIdentifiers(array($id1));
-        $this->assertCount(1, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(1, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(1, $model->getHits());
 
         $query->imageIdentifiers(array($id1, $id2));
-        $this->assertCount(2, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(2, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(2, $model->getHits());
 
         $query->imageIdentifiers(array($id1, $id2, $id3));
-        $this->assertCount(3, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(3, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(3, $model->getHits());
 
         $query->imageIdentifiers(array($id1, $id2, $id3, $id4));
-        $this->assertCount(4, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(4, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(4, $model->getHits());
 
         $query->imageIdentifiers(array($id1, $id2, $id3, $id4, $id5));
-        $this->assertCount(5, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(5, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(5, $model->getHits());
 
         $query->imageIdentifiers(array($id1, $id2, $id3, $id4, $id5, str_repeat('f', 32)));
-        $this->assertCount(5, $this->adapter->getImages($user, $query, $model));
+        $this->assertCount(5, $this->adapter->getImages([$user], $query, $model));
         $this->assertSame(5, $model->getHits());
     }
 
@@ -674,7 +674,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
             $query->sort($sort);
         }
 
-        $images = $this->adapter->getImages('user', $query, $this->getMock('Imbo\Model\Images'));
+        $images = $this->adapter->getImages(['user'], $query, $this->getMock('Imbo\Model\Images'));
 
         foreach ($images as $i => $image) {
             $this->assertSame($values[$i], $image[$field]);

--- a/tests/phpunit/ImboUnitTest/Auth/AccessControl/ArrayAdapterTest.php
+++ b/tests/phpunit/ImboUnitTest/Auth/AccessControl/ArrayAdapterTest.php
@@ -55,6 +55,29 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
         );
     }
 
+    public function testReturnsCorrectListOfAllowedUsersForResource() {
+        $accessControl = new ArrayAdapter([
+            [
+                'publicKey' => 'pubKey1',
+                'privateKey' => 'privateKey1',
+                'acl' => [[
+                    'resources' => [ACI::RESOURCE_IMAGES_POST],
+                    'users' => ['user1'],
+                ]]
+            ],
+            [
+                'publicKey' => 'pubKey2',
+                'privateKey' => 'privateKey2',
+                'acl' => [[
+                    'resources' => [ACI::RESOURCE_IMAGES_POST],
+                    'users' => ['user2'],
+                ]]
+            ]
+        ]);
+
+        // Test stuff
+    }
+
     public function testGetPrivateKey() {
         $accessControl = new ArrayAdapter([
             [

--- a/tests/phpunit/ImboUnitTest/Auth/AccessControl/ArrayAdapterTest.php
+++ b/tests/phpunit/ImboUnitTest/Auth/AccessControl/ArrayAdapterTest.php
@@ -61,21 +61,29 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
                 'publicKey' => 'pubKey1',
                 'privateKey' => 'privateKey1',
                 'acl' => [[
-                    'resources' => [ACI::RESOURCE_IMAGES_POST],
-                    'users' => ['user1'],
+                    'resources' => [ACI::RESOURCE_IMAGES_GET],
+                    'users' => ['user1', 'user2'],
                 ]]
             ],
             [
                 'publicKey' => 'pubKey2',
                 'privateKey' => 'privateKey2',
                 'acl' => [[
-                    'resources' => [ACI::RESOURCE_IMAGES_POST],
-                    'users' => ['user2'],
+                    'resources' => [ACI::RESOURCE_IMAGES_GET],
+                    'users' => ['user2', 'user3', '*'],
                 ]]
             ]
         ]);
 
-        // Test stuff
+        $this->assertEquals(
+            ['user1', 'user2'],
+            $accessControl->getUsersForResource('pubKey1', ACI::RESOURCE_IMAGES_GET)
+        );
+
+        $this->assertEquals(
+            ['user1', 'user2'],
+            $accessControl->getUsersForResource('pubKey1', ACI::RESOURCE_IMAGES_GET)
+        );
     }
 
     public function testGetPrivateKey() {
@@ -130,6 +138,25 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($ac->hasAccess('pubkey', ACI::RESOURCE_USER_GET, 'user2'));
         $this->assertTrue($ac->hasAccess('pubkey', ACI::RESOURCE_USER_HEAD, 'user1'));
         $this->assertTrue($ac->hasAccess('pubkey', ACI::RESOURCE_USER_GET, 'user1'));
+    }
+
+    public function testCanReadResourcesGrantedUsingWildcard() {
+        $accessControl = new ArrayAdapter([
+            [
+                'publicKey'  => 'pubkey',
+                'privateKey' => 'privkey',
+                'acl' => [
+                    [
+                        'resources' => [ACI::RESOURCE_IMAGES_GET],
+                        'users' => '*'
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->assertTrue($accessControl->hasAccess('pubkey', ACI::RESOURCE_IMAGES_GET, 'user1'));
+        $this->assertTrue($accessControl->hasAccess('pubkey', ACI::RESOURCE_IMAGES_GET, 'user2'));
+        $this->assertFalse($accessControl->hasAccess('pubkey', ACI::RESOURCE_IMAGES_POST, 'user2'));
     }
 
     /**

--- a/tests/phpunit/ImboUnitTest/Database/MongoDBTest.php
+++ b/tests/phpunit/ImboUnitTest/Database/MongoDBTest.php
@@ -186,7 +186,7 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
                               ->method('find')
                               ->will($this->throwException(new MongoException()));
 
-        $this->driver->getImages('key', $this->getMock('Imbo\Resource\Images\Query'), $this->getMock('Imbo\Model\Images'));
+        $this->driver->getImages(['key'], $this->getMock('Imbo\Resource\Images\Query'), $this->getMock('Imbo\Model\Images'));
     }
 
     /**
@@ -214,7 +214,7 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
                               ->method('find')
                               ->will($this->throwException(new MongoException()));
 
-        $this->driver->getLastModified('key');
+        $this->driver->getLastModified(['key']);
     }
 
     /**

--- a/tests/phpunit/ImboUnitTest/EventListener/DatabaseOperationsTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/DatabaseOperationsTest.php
@@ -131,7 +131,7 @@ class DatabaseOperationsTest extends ListenerTests {
     public function testCanLoadMetadata() {
         $date = new DateTime();
         $this->database->expects($this->once())->method('getMetadata')->with($this->user, $this->imageIdentifier)->will($this->returnValue(array('key' => 'value')));
-        $this->database->expects($this->once())->method('getLastModified')->with($this->user, $this->imageIdentifier)->will($this->returnValue($date));
+        $this->database->expects($this->once())->method('getLastModified')->with([$this->user], $this->imageIdentifier)->will($this->returnValue($date));
         $this->response->expects($this->once())->method('setModel')->with($this->isInstanceOf('Imbo\Model\Metadata'))->will($this->returnSelf());
         $this->response->expects($this->once())->method('setLastModified')->with($date);
 
@@ -210,8 +210,8 @@ class DatabaseOperationsTest extends ListenerTests {
         $imagesQuery = $this->getMock('Imbo\Resource\Images\Query');
         $this->listener->setImagesQuery($imagesQuery);
 
-        $this->database->expects($this->once())->method('getImages')->with($this->user, $imagesQuery)->will($this->returnValue($images));
-        $this->database->expects($this->once())->method('getLastModified')->with($this->user)->will($this->returnValue($date));
+        $this->database->expects($this->once())->method('getImages')->with([$this->user], $imagesQuery)->will($this->returnValue($images));
+        $this->database->expects($this->once())->method('getLastModified')->with([$this->user])->will($this->returnValue($date));
 
         $this->response->expects($this->once())->method('setModel')->with($this->isInstanceOf('Imbo\Model\Images'))->will($this->returnSelf());
         $this->response->expects($this->once())->method('setLastModified')->with($date);
@@ -226,7 +226,7 @@ class DatabaseOperationsTest extends ListenerTests {
     public function testCanLoadUser() {
         $date = new DateTime();
         $this->database->expects($this->once())->method('getNumImages')->with($this->user)->will($this->returnValue(123));
-        $this->database->expects($this->once())->method('getLastModified')->with($this->user)->will($this->returnValue($date));
+        $this->database->expects($this->once())->method('getLastModified')->with([$this->user])->will($this->returnValue($date));
         $this->response->expects($this->once())->method('setModel')->with($this->isInstanceOf('Imbo\Model\User'))->will($this->returnSelf());
         $this->response->expects($this->once())->method('setLastModified')->with($date);
 

--- a/tests/phpunit/ImboUnitTest/EventListener/DatabaseOperationsTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/DatabaseOperationsTest.php
@@ -46,6 +46,7 @@ class DatabaseOperationsTest extends ListenerTests {
         $this->image = $this->getMock('Imbo\Model\Image');
 
         $this->request->expects($this->any())->method('getUser')->will($this->returnValue($this->user));
+        $this->request->expects($this->any())->method('getUsers')->will($this->returnValue([$this->user]));
         $this->request->expects($this->any())->method('getImageIdentifier')->will($this->returnValue($this->imageIdentifier));
 
         $this->event = $this->getMock('Imbo\EventManager\Event');
@@ -154,6 +155,7 @@ class DatabaseOperationsTest extends ListenerTests {
                 'originalChecksum' => 'checksum1',
                 'mime' => 'image/png',
                 'extension' => 'png',
+                'user' => $this->user,
                 'metadata' => array(),
             ),
             array(
@@ -167,6 +169,7 @@ class DatabaseOperationsTest extends ListenerTests {
                 'originalChecksum' => 'checksum2',
                 'mime' => 'image/png',
                 'extension' => 'png',
+                'user' => $this->user,
                 'metadata' => array(),
             ),
             array(
@@ -180,6 +183,7 @@ class DatabaseOperationsTest extends ListenerTests {
                 'originalChecksum' => 'checksum3',
                 'mime' => 'image/png',
                 'extension' => 'png',
+                'user' => $this->user,
                 'metadata' => array(),
             ),
         );


### PR DESCRIPTION
This PR adds a global image endpoint providing a way of listing images across multiple users at once. In addition to adding the resource a few other changes had to be made to make the global image endpoint work;

* `getImages` and `getLastModified` in the Doctrine and MongoDB database adapters now take an array of users instead of a single user as before. Code and tests affected by this has been updated.

* `getUsersForResource` has been added to the ACL AdapterInterface to have a way of looking up what users the publicKey has access to a given resource for; for instance listing all users `pubkey` can access `images.get` for.

Closes #261.