### PR TITLE
Simple array access control adapter

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -24,60 +24,28 @@ $config = [
     /**
      * Access Control adapter
      *
-     * See the different adapter implementations for possible configuration parameters. The value
-     * must be set to a closure returning an instance of Imbo\Auth\AccessControl\Adapter\AdapterInterface,
-     * or an implementation of said interface.
+     * See the different adapter implementations for possible configuration parameters.
+     * The value must be set to a closure returning an instance of
+     * Imbo\Auth\AccessControl\Adapter\AdapterInterface, or an implementation of said interface.
      *
-     * The default ArrayAdapter takes an array of access control rules, in the following form:
-     *
-     * [
-     *     [
-     *         // A unique public key matching the following regular expression: [A-Za-z0-9_-]{1,}
-     *         'publicKey'  => 'some-public-key',
-     *
-     *         // Some form of private key
-     *         'privateKey' => 'some-private-key',
-     *
-     *         // Array of rules for this public key
-     *         'acl' => [
-     *             [
-     *                 // An array of different resource names that the public key should have
-     *                 // access to - see AdapterInterface::RESOURCE_* for available options.
-     *                 'resources' => ArrayAdapter::getReadOnlyResources(),
-     *
-     *                 // Names of the users which the public key should have access to.
-     *                 'users' => ['some', 'users'],
-     *             ],
-     *
-     *             // Multiple rules can be applied in order to make a single public key have
-     *             // different access rights on different users
-     *             [
-     *                 'resources' => ArrayAdapter::getReadWriteResources(),
-     *                 'users' => ['different-users'],
-     *             ],
-     *
-     *             // You can also specify resource groups instead of explicitly setting them like
-     *             // in the above examples. Note that you cannot specify both resources and group
-     *             // in the same rule.
-     *             [
-     *                 'group' => 'read-stats',
-     *                 'users' => ['user1', 'user2']
-     *             ]
-     *         ]
-     *     ]
-     * ]
-     *
-     * The second argument to ArrayAdapter specifies the available resource groups. For example:
+     * The default SimpleArrayAdapter takes an array keyed by user (which will also be used as the
+     * public key) and a private key, in the following form:
      *
      * [
-     *     'group-name' => ['image.get', 'image.head'],
-     *     'read-stats' => ['user.get', 'user.head', 'user.options'],
+     *     'some-user' => 'some-private-key',
+     *     'other-user' => 'different-private-key'
      * ]
+     *
+     * This is the absolute simplest access control implementation - for instance, there is a
+     * 1:1 correlation between a user and a public key. The public key will have read and write
+     * access to all resources belonging to that user. Should you require more fine-grained access
+     * control, please take a look at the other adapters available, many of which are mutable -
+     * meaning you can use the Imbo API to alter access control on the fly.
      *
      * @var Auth\AccessControl\Adapter\AdapterInterface|Closure
      */
     'accessControl' => function() {
-        return new Auth\AccessControl\Adapter\ArrayAdapter();
+        return new Auth\AccessControl\Adapter\SimpleArrayAdapter([]);
     },
 
     /**

--- a/library/Imbo/Application.php
+++ b/library/Imbo/Application.php
@@ -18,7 +18,7 @@ use Imbo\Http\Request\Request,
     Imbo\Model\Error,
     Imbo\Auth\AccessControl,
     Imbo\Auth\AccessControl\Adapter\AdapterInterface as AccessControlInterface,
-    Imbo\Auth\AccessControl\Adapter\ArrayAdapter as AccessControlArrayAdapter,
+    Imbo\Auth\AccessControl\Adapter\SimpleArrayAdapter as SimpleAclArrayAdapter,
     Imbo\Exception\RuntimeException,
     Imbo\Exception\InvalidArgumentException,
     Imbo\Database\DatabaseInterface,
@@ -79,8 +79,10 @@ class Application {
         }
 
         // Check if we have an auth array present in the configuration
-        if (isset($config['auth']) && is_array($config['auth']) && $accessControl instanceof AccessControlArrayAdapter) {
-            $accessControl->setAccessListFromAuth($config['auth']);
+        if (isset($config['auth']) && is_array($config['auth']) &&
+            $accessControl instanceof SimpleAclArrayAdapter &&
+            $accessControl->isEmpty()) {
+            $accessControl = new SimpleAclArrayAdapter($config['auth']);
         }
 
         // Create a router based on the routes in the configuration and internal routes

--- a/library/Imbo/Auth/AccessControl/Adapter/ArrayAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/ArrayAdapter.php
@@ -25,7 +25,7 @@ class ArrayAdapter extends AbstractAdapter implements AdapterInterface {
      *
      * @var array
      */
-    private $accessList = [];
+    protected $accessList = [];
 
     /**
      * Public => private key pairs
@@ -200,32 +200,6 @@ class ArrayAdapter extends AbstractAdapter implements AdapterInterface {
         }
 
         return null;
-    }
-
-    /**
-     * For compatibility reasons, where the configuration for Imbo has a set of
-     * 'public key' => 'private key' pairs - this method converts that config
-     * to an AccessControl-compatible format. Public key will equal the user.
-     *
-     * @param array $authDetails
-     */
-    public function setAccessListFromAuth(array $authDetails) {
-        foreach ($authDetails as $publicKey => $privateKey) {
-            if (is_array($privateKey)) {
-                throw new InvalidArgumentException('A public key can only have a single private key (as of 2.0.0)');
-            }
-
-            $this->accessList[] = [
-                'publicKey'  => $publicKey,
-                'privateKey' => $privateKey,
-                'acl' => [[
-                    'resources' => $this->getReadWriteResources(),
-                    'users' => [$publicKey]
-                ]]
-            ];
-
-            $this->keys[$publicKey] = $privateKey;
-        }
     }
 
     /**

--- a/library/Imbo/Auth/AccessControl/Adapter/SimpleArrayAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/SimpleArrayAdapter.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Auth\AccessControl\Adapter;
+
+use Imbo\Exception\InvalidArgumentException,
+    Imbo\Auth\AccessControl\GroupQuery;
+
+/**
+ * Simple array-backed access control adapter
+ *
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @package Core\Auth\AccessControl\Adapter
+ */
+class SimpleArrayAdapter extends ArrayAdapter implements AdapterInterface {
+    /**
+     * Class constructor
+     *
+     * @param array $accessList Array defining the available public/private keys
+     */
+    public function __construct(array $accessList = []) {
+        parent::__construct($this->getExpandedAclList($accessList));
+    }
+
+    /**
+     * Returns whether the access control list is empty or not
+     *
+     * @return boolean True if list is empty, false otherwise
+     */
+    public function isEmpty() {
+        return empty($this->accessList);
+    }
+
+    /**
+     * Converts public => private key pairs into the array format accepted by ArrayAdapter
+     *
+     * @param array $accessList
+     */
+    public function getExpandedAclList(array $accessList) {
+        $entries = [];
+
+        foreach ($accessList as $publicKey => $privateKey) {
+            if (is_array($privateKey)) {
+                throw new InvalidArgumentException('A public key can only have a single private key (as of 2.0.0)');
+            }
+
+            $entries[] = [
+                'publicKey'  => $publicKey,
+                'privateKey' => $privateKey,
+                'acl' => [[
+                    'resources' => $this->getReadWriteResources(),
+                    'users' => [$publicKey]
+                ]]
+            ];
+        }
+
+        return $entries;
+    }
+}

--- a/tests/phpunit/ImboUnitTest/Auth/AccessControl/ArrayAdapterTest.php
+++ b/tests/phpunit/ImboUnitTest/Auth/AccessControl/ArrayAdapterTest.php
@@ -19,42 +19,6 @@ use Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
  * @group unit
  */
 class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
-    /**
-     * @dataProvider getAuthConfig
-     */
-    public function testCanSetKeysFromLegacyConfig(array $users, $publicKey, $privateKey) {
-        $accessControl = new ArrayAdapter();
-        $accessControl->setAccessListFromAuth($users);
-
-        $this->assertSame($privateKey, $accessControl->getPrivateKey($publicKey));
-    }
-
-    /**
-     * @expectedException Imbo\Exception\InvalidArgumentException
-     * @expectedExceptionMessage A public key can only have a single private key (as of 2.0.0)
-     */
-    public function testThrowsOnMultiplePrivateKeysPerPublicKey() {
-        $accessControl = new ArrayAdapter();
-        $accessControl->setAccessListFromAuth([
-            'publicKey' => ['key1', 'key2']
-        ]);
-    }
-
-    public function testLegacyConfigKeysHaveWriteAccess() {
-        $accessControl = new ArrayAdapter();
-        $accessControl->setAccessListFromAuth([
-            'publicKey' => 'privateKey',
-        ]);
-
-        $this->assertTrue(
-            $accessControl->hasAccess(
-                'publicKey',
-                ACI::RESOURCE_IMAGES_POST,
-                'publicKey'
-            )
-        );
-    }
-
     public function testReturnsCorrectListOfAllowedUsersForResource() {
         $accessControl = new ArrayAdapter([
             [

--- a/tests/phpunit/ImboUnitTest/Auth/AccessControl/SimpleArrayAdapterTest.php
+++ b/tests/phpunit/ImboUnitTest/Auth/AccessControl/SimpleArrayAdapterTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboUnitTest\Auth;
+
+use Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
+    Imbo\Auth\AccessControl\Adapter\SimpleArrayAdapter,
+    Imbo\Auth\AccessControl\Adapter\AdapterInterface as ACI;
+
+/**
+ * @covers Imbo\Auth\AccessControl\Adapter\SimpleArrayAdapter
+ * @group unit
+ */
+class SimpleArrayAdapterTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @dataProvider getAuthConfig
+     */
+    public function testCanSetKeys(array $users, $publicKey, $privateKey) {
+        $accessControl = new SimpleArrayAdapter($users);
+
+        $this->assertSame($privateKey, $accessControl->getPrivateKey($publicKey));
+    }
+
+    /**
+     * @expectedException Imbo\Exception\InvalidArgumentException
+     * @expectedExceptionMessage A public key can only have a single private key (as of 2.0.0)
+     */
+    public function testThrowsOnMultiplePrivateKeysPerPublicKey() {
+        $accessControl = new SimpleArrayAdapter([
+            'publicKey' => ['key1', 'key2']
+        ]);
+    }
+
+    public function testLegacyConfigKeysHaveWriteAccess() {
+        $accessControl = new SimpleArrayAdapter([
+            'publicKey' => 'privateKey',
+        ]);
+
+        $this->assertTrue(
+            $accessControl->hasAccess(
+                'publicKey',
+                ACI::RESOURCE_IMAGES_POST,
+                'publicKey'
+            )
+        );
+    }
+
+    public function testExtendsArrayAdapter() {
+        $accessControl = new SimpleArrayAdapter(['publicKey' => 'key']);
+        $this->assertTrue($accessControl instanceof ArrayAdapter);
+    }
+
+    public function testIsEmpty() {
+        $accessControl = new SimpleArrayAdapter();
+        $this->assertTrue($accessControl->isEmpty());
+
+        $accessControl = new SimpleArrayAdapter(['foo' => 'bar']);
+        $this->assertFalse($accessControl->isEmpty());
+    }
+
+    /**
+     * Data provider for testing the legacy auth compatibility
+     *
+     * @return array
+     */
+    public function getAuthConfig() {
+        $users = [
+            'publicKey1' => 'key1',
+            'publicKey2' => 'key2',
+        ];
+
+        return [
+            'no public keys exists' => [[], 'public', null],
+            'public key exists' => [$users, 'publicKey2', 'key2'],
+            'public key does not exist' => [$users, 'publicKey3', null],
+        ];
+    }
+}


### PR DESCRIPTION
This PR addresses #354 and adds a "simple" access control adapter. It takes the Imbo 1.0-style array of public => private keys and translates it to the new format used by the array adapter. This makes it easier for people to migrate and get started with Imbo, but allows the full flexibility of the ACL implementation to be used as long as users choose a different access control adapter.

