### PR TITLE
Public key generation CLI command

### DIFF
--- a/library/ImboCli/Application.php
+++ b/library/ImboCli/Application.php
@@ -29,6 +29,7 @@ class Application extends BaseApplication {
         // Register commands
         $this->addCommands(array(
             new Command\GeneratePrivateKey(),
+            new Command\AddPublicKey(),
         ));
     }
 }

--- a/library/ImboCli/Command/AddPublicKey.php
+++ b/library/ImboCli/Command/AddPublicKey.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboCli\Command;
+
+use Symfony\Component\Console\Command\Command as BaseCommand,
+    Symfony\Component\Console\Input\InputArgument,
+    Symfony\Component\Console\Input\InputInterface,
+    Symfony\Component\Console\Question\Question,
+    Symfony\Component\Console\Question\ChoiceQuestion,
+    Symfony\Component\Console\Question\ConfirmationQuestion,
+    Symfony\Component\Console\Output\OutputInterface,
+    Imbo\Auth\AccessControl\Adapter\AdapterInterface,
+    Imbo\Auth\AccessControl\Adapter\AbstractAdapter,
+    Imbo\Auth\AccessControl\Adapter\MutableAdapterInterface,
+    RuntimeException;
+
+/**
+ * Add a public key to the configured access control adapter
+ *
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @package Cli
+ */
+class AddPublicKey extends Command {
+    const RESOURCES_READ_ONLY = 'Read-only on user resources';
+    const RESOURCES_READ_WRITE = 'Read+write on user resources';
+    const RESOURCES_SPECIFIC = 'Specific resources';
+    const RESOURCES_ALL = 'All resources (master user)';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct() {
+        parent::__construct('add-public-key');
+
+        $this
+            ->setDescription('Add a public key')
+            ->setHelp('Add a public key to the configured access control adapter')
+            ->addArgument(
+                'publicKey',
+                InputArgument::REQUIRED,
+                'What should be the name of this public key?'
+            )
+            ->addArgument(
+                'privateKey',
+                InputArgument::OPTIONAL,
+                'What should be the private key for this public key?'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output) {
+        $adapter = $this->getAclAdapter();
+        $publicKey = $input->getArgument('publicKey');
+
+        if ($adapter->publicKeyExists($publicKey)) {
+            throw new RuntimeException('Public key with that name already exists');
+        }
+
+        // Use an interactive prompt to get a private key from the user,
+        // unless it is already specified as a command line argument
+        $privateKey = $input->getArgument('privateKey');
+        if (empty($privateKey)) {
+            $privateKey = $this->askForPrivateKey($input, $output);
+        }
+
+        // Continue asking for ACL rules until the user tells us otherwise
+        $aclRules = [];
+        $isFinished = false;
+        do {
+            $aclRules[] = [
+                'resources' => $this->askForResources($input, $output),
+                'users' => $this->askForUsers($input, $output)
+            ];
+
+            $isFinished = !$this->askForAnotherAclRule($input, $output);
+        } while (!$isFinished);
+
+        // Add key pair and ACL rules to database
+        $adapter->addKeyPair($publicKey, $privateKey);
+
+        foreach ($aclRules as $rule) {
+            $adapter->addAccessRule($publicKey, $rule);
+        }
+
+        // Write success information
+        $output->writeln('Successfully added new key pair');
+        $output->writeln('Public key:  ' . $publicKey);
+        $output->writeln('Private key: ' . $privateKey);
+        $output->writeln('ACL rules added: ' . count($aclRules));
+    }
+
+    /**
+     * Ask user which resources the public key should have access to
+     *
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return array
+     */
+    private function askForResources(InputInterface $input, OutputInterface $output) {
+        $question = new ChoiceQuestion(
+            'Which resources should the public key have access to? ',
+            [
+                self::RESOURCES_READ_ONLY,
+                self::RESOURCES_READ_WRITE,
+                self::RESOURCES_ALL,
+                self::RESOURCES_SPECIFIC,
+            ],
+            self::RESOURCES_SPECIFIC
+        );
+
+        $type = $this->getHelper('question')->ask($input, $output, $question);
+        switch ($type) {
+            case self::RESOURCES_READ_ONLY:
+                return AbstractAdapter::getReadOnlyResources();
+            case self::RESOURCES_READ_WRITE:
+                return AbstractAdapter::getReadWriteResources();
+            case self::RESOURCES_ALL:
+                return AbstractAdapter::getAllResources();
+        }
+
+        return $this->askForSpecificResources($input, $output);
+    }
+
+    /**
+     * Ask user which specific resources the public key should have access to
+     *
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return array
+     */
+    private function askForSpecificResources(InputInterface $input, OutputInterface $output) {
+        $question = new ChoiceQuestion(
+            'Which resources should the public key have access to? (comma-separated) ',
+            AbstractAdapter::getAllResources()
+        );
+        $question->setMultiselect(true);
+
+        return $this->getHelper('question')->ask($input, $output, $question);
+    }
+
+    /**
+     * Ask the user which users the public key should have access to (for the current ACL-rule)
+     *
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return array|string
+     */
+    private function askForUsers(InputInterface $input, OutputInterface $output) {
+        $question = new Question(
+            'On which users should the public key have access to these resources?' . PHP_EOL .
+            '(comma-separated, specify "*" for all users) '
+        );
+        $question->setValidator(function($answer) {
+            $users = array_filter(array_map('trim', explode(',', $answer)));
+            if (empty($users)) {
+                throw new RuntimeException(
+                    'You must specify at least one user, alternatively a wildcard character (*)'
+                );
+            }
+
+            return array_search('*', $users) === false ? $users : '*';
+        });
+
+        return $this->getHelper('question')->ask($input, $output, $question);
+    }
+
+    /**
+     * Ask the user if she wants to add more ACL-rules
+     *
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return boolean
+     */
+    private function askForAnotherAclRule(InputInterface $input, OutputInterface $output) {
+        return $this->getHelper('question')->ask($input, $output, new ConfirmationQuestion(
+            'Create more ACL-rules for this public key? (y/N) ',
+            false
+        ));
+    }
+
+    /**
+     * Ask the user for a private key (or generate one if user does not specify)
+     *
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return string
+     */
+    private function askForPrivateKey(InputInterface $input, OutputInterface $output) {
+        $privateKeyGenerator = new GeneratePrivateKey();
+
+        $question = new Question(
+            'What do you want the private key to be (leave blank to generate)',
+            $privateKeyGenerator->generate()
+        );
+
+        return $this->getHelper('question')->ask($input, $output, $question);
+    }
+
+    /**
+     * Get the configured ACL adapter and ensure it is mutable
+     *
+     * @return MutableAdapterInterface
+     */
+    private function getAclAdapter() {
+        $config = $this->getConfig();
+
+        // Access control adapter
+        $accessControl = $config['accessControl'];
+
+        if (is_callable($accessControl) && !($accessControl instanceof AdapterInterface)) {
+            $accessControl = $accessControl();
+        }
+
+        if (!$accessControl instanceof AdapterInterface) {
+            throw new RuntimeException('Invalid access control adapter');
+        }
+
+        if (!$accessControl instanceof MutableAdapterInterface) {
+            throw new RuntimeException('The configured access control adapter is not mutable');
+        }
+
+        return $accessControl;
+    }
+}

--- a/library/ImboCli/Command/GeneratePrivateKey.php
+++ b/library/ImboCli/Command/GeneratePrivateKey.php
@@ -43,6 +43,15 @@ class GeneratePrivateKey extends BaseCommand {
      * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output) {
+        $output->writeln($this->generate());
+    }
+
+    /**
+     * Generate a private key
+     *
+     * @return string
+     */
+    public function generate() {
         $strong = false;
         $i = 0;
 
@@ -53,13 +62,11 @@ class GeneratePrivateKey extends BaseCommand {
         if (!$strong) {
             throw new RuntimeException('Could not generate private key');
         }
-        
+
         // base64_encode to get a decent ascii compatible format, and trim ending ='s.
         $key = rtrim(base64_encode($data), '=');
-        
-        // We change +/ into -_ to avoid any human confusion with paths
-        $key = strtr($key, '+/', '-_');
 
-        $output->writeln($key);
+        // We change +/ into -_ to avoid any human confusion with paths
+        return strtr($key, '+/', '-_');
     }
 }

--- a/tests/phpunit/ImboCliUnitTest/Command/AddPublicKeyTest.php
+++ b/tests/phpunit/ImboCliUnitTest/Command/AddPublicKeyTest.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboCliUnitTest\Command;
+
+use ImboCli\Command\AddPublicKey,
+    Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
+    Imbo\Auth\AccessControl\Adapter\AbstractAdapter,
+    Symfony\Component\Console\Application,
+    Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @covers ImboCli\Command\AddPublicKey
+ * @group unit-cli
+ * @group cli-commands
+ */
+class AddPublicKeyTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @var ImboCli\Command\AddPublicKey
+     */
+    private $command;
+
+    /**
+     * @var Imbo\Auth\AccessControl\Adapter\MutableAdapterInterface
+     */
+    private $adapter;
+
+    /**
+     * Set up the command
+     *
+     * @covers ImboCli\Command\AddPublicKey::__construct
+     */
+    public function setUp() {
+        $this->adapter = $this->getMock('Imbo\Auth\AccessControl\Adapter\MutableAdapterInterface');
+
+        $this->command = new AddPublicKey();
+        $this->command->setConfig([
+            'accessControl' => $this->adapter
+        ]);
+
+        $application = new Application();
+        $application->add($this->command);
+    }
+
+    /**
+     * Tear down the command
+     */
+    public function tearDown() {
+        $this->command = null;
+        $this->adapter = null;
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Invalid access control adapter
+     * @covers ImboCli\Command\AddPublicKey::getAclAdapter
+     */
+    public function testThrowsWhenAccessControlIsNotValid() {
+        $command = new AddPublicKey();
+        $command->setConfig([
+            'accessControl' => new \Exception()
+        ]);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['publicKey' => 'foo']);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Invalid access control adapter
+     * @covers ImboCli\Command\AddPublicKey::getAclAdapter
+     */
+    public function testThrowsWhenCallableReturnsInvalidAccessControl() {
+        $command = new AddPublicKey();
+        $command->setConfig([
+            'accessControl' => function() {
+                return new \Exception();
+            }
+        ]);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['publicKey' => 'foo']);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The configured access control adapter is not mutable
+     * @covers ImboCli\Command\AddPublicKey::getAclAdapter
+     */
+    public function testThrowsOnImmutableAdapter() {
+        $command = new AddPublicKey();
+        $command->setConfig([
+            'accessControl' => $this->getMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface')
+        ]);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['publicKey' => 'foo']);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Public key with that name already exists
+     * @covers ImboCli\Command\AddPublicKey::execute
+     */
+    public function testThrowsOnDuplicatePublicKeyName() {
+        $this->adapter
+            ->expects($this->once())
+            ->method('publicKeyExists')
+            ->with('foo')
+            ->will($this->returnValue(true));
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['publicKey' => 'foo']);
+    }
+
+    /**
+     * @covers ImboCli\Command\AddPublicKey::askForPrivateKey
+     */
+    public function testWillAskForPrivateKeyIfNotSpecified() {
+        $this->adapter
+            ->expects($this->once())
+            ->method('addKeyPair')
+            ->with('foo', 'ZiePublicKey');
+
+        $helper = $this->command->getHelper('question');
+        $helper->setInputStream($this->getInputStream([
+            'ZiePublicKey',
+            '0',
+            'rexxars',
+            'n'
+        ]));
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['publicKey' => 'foo']);
+    }
+
+    /**
+     * @covers ImboCli\Command\AddPublicKey::askForUsers
+     */
+    public function testWillNotAcceptEmptyUserSpecification() {
+        $helper = $this->command->getHelper('question');
+        $helper->setInputStream($this->getInputStream([
+            '0',
+            '',
+            '*',
+            'n',
+        ]));
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['publicKey' => 'foo', 'privateKey' => 'bar']);
+
+        $this->assertRegExp('/at least one user/', $commandTester->getDisplay(true));
+    }
+
+    /**
+     * @covers ImboCli\Command\AddPublicKey::execute
+     * @covers ImboCli\Command\AddPublicKey::askForAnotherAclRule
+     * @covers ImboCli\Command\AddPublicKey::askForResources
+     * @covers ImboCli\Command\AddPublicKey::askForUsers
+     */
+    public function testContinuesAskingForAclRulesIfUserSaysThereAreMoreRulesToAdd() {
+        $this->adapter
+            ->expects($this->exactly(3))
+            ->method('addAccessRule')
+            ->withConsecutive(
+                [$this->equalTo('foo'), $this->callback(function($rule) {
+                    return (
+                        count($rule['users']) === 2 &&
+                        in_array('espenh', $rule['users']) &&
+                        in_array('kribrabr', $rule['users']) &&
+                        empty(array_diff($rule['resources'], AbstractAdapter::getReadOnlyResources()))
+                    );
+                })],
+                [$this->equalTo('foo'), $this->callback(function($rule) {
+                    return (
+                        count($rule['users']) === 2 &&
+                        in_array('rexxars', $rule['users']) &&
+                        in_array('kbrabrand', $rule['users']) &&
+                        empty(array_diff($rule['resources'], AbstractAdapter::getReadWriteResources()))
+                    );
+                })],
+                [$this->equalTo('foo'), $this->callback(function($rule) {
+                    return (
+                        $rule['users'] === '*' &&
+                        empty(array_diff($rule['resources'], AbstractAdapter::getAllResources()))
+                    );
+                })]
+            );
+
+        $helper = $this->command->getHelper('question');
+        $helper->setInputStream($this->getInputStream([
+            '0', 'espenh,kribrabr',    'y',
+            '1', 'rexxars, kbrabrand', 'y',
+            '2', '*',                  'n',
+        ]));
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['publicKey' => 'foo', 'privateKey' => 'bar']);
+
+        $this->assertSame(
+            3,
+            substr_count(
+                $commandTester->getDisplay(true),
+                'Create more ACL-rules for this public key?'
+            )
+        );
+    }
+
+    /**
+     * @covers ImboCli\Command\AddPublicKey::execute
+     * @covers ImboCli\Command\AddPublicKey::askForAnotherAclRule
+     * @covers ImboCli\Command\AddPublicKey::askForResources
+     * @covers ImboCli\Command\AddPublicKey::askForUsers
+     */
+    public function testPromptsForListOfSpecificResourcesIfOptionIsSelected() {
+        $allResources = AbstractAdapter::getAllResources();
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('addAccessRule')
+            ->with('foo', $this->callback(function($rule) use ($allResources) {
+                return (
+                    $rule['users'] === '*' &&
+                    $rule['resources'][0] === $allResources[0] &&
+                    $rule['resources'][1] === $allResources[5]
+                );
+            }));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('addKeyPair')
+            ->with('foo', 'bar');
+
+        $helper = $this->command->getHelper('question');
+        $helper->setInputStream($this->getInputStream(['3', '0,5', '*', 'n']));
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['publicKey' => 'foo', 'privateKey' => 'bar']);
+    }
+
+    protected function getInputStream($input) {
+        if (is_array($input)) {
+            $input = implode("\n", $input) . "\n";
+        }
+
+        $stream = fopen('php://memory', 'r+', false);
+        fputs($stream, $input);
+        rewind($stream);
+
+        return $stream;
+    }
+}


### PR DESCRIPTION
This PR adds a command to the CLI tool which adds public keys to the configured, mutable access control adapter. Can either specify private key by hand or have Imbo generate one. Resources and users can be specified interactively.

Closes #352.