### PR TITLE
Add short url resource to access control

### DIFF
--- a/library/Imbo/Auth/AccessControl/Adapter/AbstractAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/AbstractAdapter.php
@@ -42,14 +42,35 @@ abstract class AbstractAdapter implements AdapterInterface {
      */
     final public static function getReadOnlyResources() {
         return [
-            ACI::RESOURCE_USER_GET,     ACI::RESOURCE_USER_HEAD,     ACI::RESOURCE_USER_OPTIONS,
-            ACI::RESOURCE_IMAGE_GET,    ACI::RESOURCE_IMAGE_HEAD,    ACI::RESOURCE_IMAGE_OPTIONS,
-            ACI::RESOURCE_GROUPS_GET,   ACI::RESOURCE_GROUPS_HEAD,   ACI::RESOURCE_GROUPS_OPTIONS,
-            ACI::RESOURCE_IMAGES_GET,   ACI::RESOURCE_IMAGES_HEAD,   ACI::RESOURCE_IMAGES_OPTIONS,
-            ACI::RESOURCE_METADATA_GET, ACI::RESOURCE_METADATA_HEAD, ACI::RESOURCE_METADATA_OPTIONS,
-            ACI::RESOURCE_SHORTURL_GET, ACI::RESOURCE_SHORTURL_HEAD, ACI::RESOURCE_SHORTURL_OPTIONS,
-            ACI::RESOURCE_GLOBAL_IMAGES_GET, ACI::RESOURCE_GLOBAL_IMAGES_HEAD,
-            ACI::RESOURCE_GLOBAL_IMAGES_OPTIONS, ACI::RESOURCE_SHORTURLS_OPTIONS
+            ACI::RESOURCE_USER_GET,
+            ACI::RESOURCE_USER_HEAD,
+            ACI::RESOURCE_USER_OPTIONS,
+
+            ACI::RESOURCE_IMAGE_GET,
+            ACI::RESOURCE_IMAGE_HEAD,
+            ACI::RESOURCE_IMAGE_OPTIONS,
+
+            ACI::RESOURCE_GROUPS_GET,
+            ACI::RESOURCE_GROUPS_HEAD,
+            ACI::RESOURCE_GROUPS_OPTIONS,
+
+            ACI::RESOURCE_IMAGES_GET,
+            ACI::RESOURCE_IMAGES_HEAD,
+            ACI::RESOURCE_IMAGES_OPTIONS,
+
+            ACI::RESOURCE_METADATA_GET,
+            ACI::RESOURCE_METADATA_HEAD,
+            ACI::RESOURCE_METADATA_OPTIONS,
+
+            ACI::RESOURCE_SHORTURL_GET,
+            ACI::RESOURCE_SHORTURL_HEAD,
+            ACI::RESOURCE_SHORTURL_OPTIONS,
+
+            ACI::RESOURCE_GLOBAL_IMAGES_GET,
+            ACI::RESOURCE_GLOBAL_IMAGES_HEAD,
+            ACI::RESOURCE_GLOBAL_IMAGES_OPTIONS,
+
+            ACI::RESOURCE_SHORTURLS_OPTIONS,
         ];
     }
 
@@ -61,10 +82,14 @@ abstract class AbstractAdapter implements AdapterInterface {
             self::getReadOnlyResources(), [
                 ACI::RESOURCE_IMAGE_DELETE,
                 ACI::RESOURCE_IMAGES_POST,
+
                 ACI::RESOURCE_METADATA_POST,
                 ACI::RESOURCE_METADATA_DELETE,
                 ACI::RESOURCE_METADATA_PUT,
+
                 ACI::RESOURCE_SHORTURL_DELETE,
+
+                ACI::RESOURCE_SHORTURLS_POST,
                 ACI::RESOURCE_SHORTURLS_DELETE,
             ]
         );
@@ -76,11 +101,19 @@ abstract class AbstractAdapter implements AdapterInterface {
     final public static function getAllResources() {
         return array_merge(
             self::getReadWriteResources(), [
-                ACI::RESOURCE_KEYS_PUT, ACI::RESOURCE_KEYS_DELETE, ACI::RESOURCE_KEYS_OPTIONS,
-                ACI::RESOURCE_ACCESS_RULE_GET, ACI::RESOURCE_ACCESS_RULE_HEAD,
-                ACI::RESOURCE_ACCESS_RULE_DELETE, ACI::RESOURCE_ACCESS_RULE_OPTIONS,
-                ACI::RESOURCE_ACCESS_RULES_GET, ACI::RESOURCE_ACCESS_RULES_HEAD,
-                ACI::RESOURCE_ACCESS_RULES_POST, ACI::RESOURCE_ACCESS_RULES_OPTIONS,
+                ACI::RESOURCE_KEYS_PUT,
+                ACI::RESOURCE_KEYS_DELETE,
+                ACI::RESOURCE_KEYS_OPTIONS,
+
+                ACI::RESOURCE_ACCESS_RULE_GET,
+                ACI::RESOURCE_ACCESS_RULE_HEAD,
+                ACI::RESOURCE_ACCESS_RULE_DELETE,
+                ACI::RESOURCE_ACCESS_RULE_OPTIONS,
+
+                ACI::RESOURCE_ACCESS_RULES_GET,
+                ACI::RESOURCE_ACCESS_RULES_HEAD,
+                ACI::RESOURCE_ACCESS_RULES_POST,
+                ACI::RESOURCE_ACCESS_RULES_OPTIONS,
             ]
         );
     }

--- a/tests/behat/bootstrap/ImboContext.php
+++ b/tests/behat/bootstrap/ImboContext.php
@@ -569,17 +569,20 @@ class ImboContext extends RESTContext {
      * @Given /^I generate a short URL with the following parameters:$/
      */
     public function generateShortImageUrl(PyStringNode $params) {
-        $imageIdentifier = $this->getLastResponse()->json()['imageIdentifier'];
+        $lastResponse = $this->getLastResponse();
+
+        preg_match('/\/users\/([^\/]+)/', $lastResponse->getInfo('url'), $matches);
+        $user = $matches[1];
+
+        $imageIdentifier = $lastResponse->json()['imageIdentifier'];
         $params = array_merge(json_decode((string) $params, true), [
             'imageIdentifier' => $imageIdentifier,
         ]);
 
-        return array(
-            new Given('I use "publickey" and "privatekey" for public and private keys'),
-            new Given('I sign the request'),
+        return [
             new Given('the request body contains:', new PyStringNode(json_encode($params))),
-            new Given('I request "/users/user/images/' . $imageIdentifier . '/shorturls" using HTTP "POST"'),
-        );
+            new Given('I request "/users/' . $user . '/images/' . $imageIdentifier . '/shorturls" using HTTP "POST"'),
+        ];
     }
 
     /**

--- a/tests/behat/bootstrap/ImboContext.php
+++ b/tests/behat/bootstrap/ImboContext.php
@@ -146,10 +146,10 @@ class ImboContext extends RESTContext {
      * @Given /^the database and the storage is down$/
      */
     public function forceBothAdapterFailure() {
-        return array(
+        return [
             new Given('the storage is down'),
             new Given('the database is down'),
-        );
+        ];
     }
 
     /**
@@ -240,11 +240,11 @@ class ImboContext extends RESTContext {
             $signature = hash_hmac('sha256', $data, $this->privateKey);
 
             if ($useHeaders) {
-                $request->addHeaders(array(
+                $request->addHeaders([
                     'X-Imbo-PublicKey'              => $this->publicKey,
                     'X-Imbo-Authenticate-Signature' => $signature,
                     'X-Imbo-Authenticate-Timestamp' => $timestamp,
-                ));
+                ]);
             } else {
                 $query->set('signature', $signature);
                 $query->set('timestamp', $timestamp);
@@ -257,7 +257,7 @@ class ImboContext extends RESTContext {
      */
     public function applyTransformation($transformation) {
         $this->client->getEventDispatcher()->addListener('request.before_send', function($event) use ($transformation) {
-            $event['request']->getQuery()->set('t', array($transformation));
+            $event['request']->getQuery()->set('t', [$transformation]);
         });
     }
 
@@ -588,10 +588,10 @@ class ImboContext extends RESTContext {
     public function requestImageUsingShortUrl() {
         $shortUrlId = $this->getLastResponse()->json()['id'];
 
-        return array(
+        return [
             new Given('the "Accept" request header is "image/*"'),
             new Given('I request "/s/' . $shortUrlId . '"'),
-        );
+        ];
     }
 
     /**

--- a/tests/behat/features/shorturls.feature
+++ b/tests/behat/features/shorturls.feature
@@ -5,6 +5,8 @@ Feature: Imbo can generate short URLs for images on demand
 
     Scenario: Generate a short URL
         Given "tests/phpunit/Fixtures/image.png" exists in Imbo
+        And I use "publickey" and "privatekey" for public and private keys
+        And I sign the request
         And I generate a short URL with the following parameters:
             """
             {"user": "user", "extension": "gif"}
@@ -16,8 +18,25 @@ Feature: Imbo can generate short URLs for images on demand
            #^{"id":"[a-zA-Z0-9]{7}"}$#
            """
 
+    Scenario: Generate a short URL without having access to the user
+        Given "tests/phpunit/Fixtures/image.png" exists for user "other-user" in Imbo
+        And I use "unpriviledged" and "privatekey" for public and private keys
+        And I sign the request
+        And I generate a short URL with the following parameters:
+            """
+            {"user": "other-user", "extension": "gif"}
+            """
+        Then I should get a response with "201 Created"
+        And the "Content-Type" response header is "application/json"
+        And the response body matches:
+           """
+           #^{"id":"[a-zA-Z0-9]{7}"}$#
+           """
+
     Scenario Outline: Request an image using the short URL
         Given "tests/phpunit/Fixtures/image.png" exists in Imbo
+        And I use "publickey" and "privatekey" for public and private keys
+        And I sign the request
         And I generate a short URL with the following parameters:
             """
             <params>

--- a/tests/behat/features/shorturls.feature
+++ b/tests/behat/features/shorturls.feature
@@ -26,12 +26,7 @@ Feature: Imbo can generate short URLs for images on demand
             """
             {"user": "other-user", "extension": "gif"}
             """
-        Then I should get a response with "201 Created"
-        And the "Content-Type" response header is "application/json"
-        And the response body matches:
-           """
-           #^{"id":"[a-zA-Z0-9]{7}"}$#
-           """
+        Then I should get a response with "400 Permission denied (public key)"
 
     Scenario Outline: Request an image using the short URL
         Given "tests/phpunit/Fixtures/image.png" exists in Imbo


### PR DESCRIPTION
This PR adds missing constants to the ACL abstract adapter to enable access control checking for the `shorturl` resource. It also adds a test ensuring that public keys can't create shorturls for images unless they have been granted access for the specific user.