### PR TITLE
ACL rule checker

### DIFF
--- a/library/Imbo/Resource/AccessRules.php
+++ b/library/Imbo/Resource/AccessRules.php
@@ -11,6 +11,7 @@
 namespace Imbo\Resource;
 
 use Imbo\EventManager\EventInterface,
+    Imbo\Exception\InvalidArgumentException,
     Imbo\Exception\RuntimeException,
     Imbo\Exception\ResourceException,
     Imbo\Auth\AccessControl\Adapter\MutableAdapterInterface,
@@ -67,7 +68,6 @@ class AccessRules implements ResourceInterface {
         $acl = $event->getAccessControl();
 
         $allowedProperties = ['resources', 'group', 'users'];
-
         $unknownProperties = array_diff(array_keys($rule), $allowedProperties);
 
         if (count($unknownProperties)) {
@@ -83,7 +83,7 @@ class AccessRules implements ResourceInterface {
         }
 
         if (isset($rule['resources']) && !$this->isStringArray($rule['resources'])) {
-            throw new RuntimeException('Illegal value in resources array. Strings only', 400);
+            throw new RuntimeException('Illegal value in resources array. String array expected', 400);
         }
 
         if (isset($rule['group'])) {
@@ -92,7 +92,7 @@ class AccessRules implements ResourceInterface {
             }
 
             if (!$acl->getGroup($rule['group'])) {
-                throw new RuntimeException('Group "' . $rule['group'] . '" does not exist', 400);
+                throw new RuntimeException('Group \'' . $rule['group'] . '\' does not exist', 400);
             }
         }
 
@@ -101,7 +101,7 @@ class AccessRules implements ResourceInterface {
         }
 
         if ($rule['users'] !== '*' && !$this->isStringArray($rule['users'])) {
-            throw new RuntimeException('Illegal value for users property. Allowed: "*" or array with users', 400);
+            throw new RuntimeException('Illegal value for users property. Allowed: \'*\' or array with users', 400);
         }
     }
 
@@ -147,6 +147,11 @@ class AccessRules implements ResourceInterface {
 
         if (!is_array($data)) {
             throw new InvalidArgumentException('No access rule data provided', 400);
+        }
+
+        // If a single rule was provided, wrap it in an array
+        if (!count($data) || !isset($data[0])) {
+            $data = [$data];
         }
 
         $accessControl = $event->getAccessControl();

--- a/library/Imbo/Resource/AccessRules.php
+++ b/library/Imbo/Resource/AccessRules.php
@@ -43,69 +43,6 @@ class AccessRules implements ResourceInterface {
     }
 
     /**
-     * Checks if this is an array containing only strings
-     *
-     * @param Mixed Values to test
-     * @return boolean True if all values are strings
-     */
-    private function isStringArray($values) {
-        if (!is_array($values)) {
-            return false;
-        }
-
-        return array_reduce($values, function($res, $value) {
-            return $res && is_string($value);
-        }, true);
-    }
-
-    /**
-     * Validate the contents of an access rule.
-     *
-     * @param array $rule Access rule to check
-     * @throws RuntimeException
-     */
-    private function validateRule(EventInterface $event, array $rule) {
-        $acl = $event->getAccessControl();
-
-        $allowedProperties = ['resources', 'group', 'users'];
-        $unknownProperties = array_diff(array_keys($rule), $allowedProperties);
-
-        if (count($unknownProperties)) {
-            throw new RuntimeException('Found unknown properties in rule: [' . implode(', ', $unknownProperties) . ']', 400);
-        }
-
-        if (isset($rule['resources']) && isset($rule['group'])) {
-            throw new RuntimeException('Both resources and group found in rule', 400);
-        }
-
-        if (!isset($rule['resources']) && !isset($rule['group'])) {
-            throw new RuntimeException('Neither group nor resources found in rule', 400);
-        }
-
-        if (isset($rule['resources']) && !$this->isStringArray($rule['resources'])) {
-            throw new RuntimeException('Illegal value in resources array. String array expected', 400);
-        }
-
-        if (isset($rule['group'])) {
-            if (!is_string($rule['group'])) {
-                throw new RuntimeException('Group must be specified as a string value', 400);
-            }
-
-            if (!$acl->getGroup($rule['group'])) {
-                throw new RuntimeException('Group \'' . $rule['group'] . '\' does not exist', 400);
-            }
-        }
-
-        if (!isset($rule['users'])) {
-            throw new RuntimeException('Users not specified in rule', 400);
-        }
-
-        if ($rule['users'] !== '*' && !$this->isStringArray($rule['users'])) {
-            throw new RuntimeException('Illegal value for users property. Allowed: \'*\' or array with users', 400);
-        }
-    }
-
-    /**
      * Get access rules for the specified public key
      *
      * @param EventInterface $event The current event
@@ -164,6 +101,69 @@ class AccessRules implements ResourceInterface {
         // Insert the rules
         foreach ($data as $rule) {
             $accessControl->addAccessRule($publicKey, $rule);
+        }
+    }
+
+    /**
+     * Checks if this is an array containing only strings
+     *
+     * @param Mixed Values to test
+     * @return boolean True if all values are strings
+     */
+    private function isStringArray($values) {
+        if (!is_array($values)) {
+            return false;
+        }
+
+        return array_reduce($values, function($res, $value) {
+            return $res && is_string($value);
+        }, true);
+    }
+
+    /**
+     * Validate the contents of an access rule.
+     *
+     * @param array $rule Access rule to check
+     * @throws RuntimeException
+     */
+    private function validateRule(EventInterface $event, array $rule) {
+        $acl = $event->getAccessControl();
+
+        $allowedProperties = ['resources', 'group', 'users'];
+        $unknownProperties = array_diff(array_keys($rule), $allowedProperties);
+
+        if (!empty($unknownProperties)) {
+            throw new RuntimeException('Found unknown properties in rule: [' . implode(', ', $unknownProperties) . ']', 400);
+        }
+
+        if (isset($rule['resources']) && isset($rule['group'])) {
+            throw new RuntimeException('Both resources and group found in rule', 400);
+        }
+
+        if (!isset($rule['resources']) && !isset($rule['group'])) {
+            throw new RuntimeException('Neither group nor resources found in rule', 400);
+        }
+
+        if (isset($rule['resources']) && !$this->isStringArray($rule['resources'])) {
+            throw new RuntimeException('Illegal value in resources array. String array expected', 400);
+        }
+
+        if (isset($rule['group'])) {
+            if (!is_string($rule['group'])) {
+                throw new RuntimeException('Group must be specified as a string value', 400);
+            }
+
+            if (!$acl->getGroup($rule['group'])) {
+                throw new RuntimeException('Group \'' . $rule['group'] . '\' does not exist', 400);
+            }
+        }
+
+        if (!isset($rule['users'])) {
+            throw new RuntimeException('Users not specified in rule', 400);
+        }
+
+        if ($rule['users'] !== '*' && !$this->isStringArray($rule['users'])) {
+            throw new RuntimeException('Illegal value for users property. Allowed: \'*\' or array with users', 400);
         }
     }
 }

--- a/library/Imbo/Resource/Group.php
+++ b/library/Imbo/Resource/Group.php
@@ -84,7 +84,7 @@ class Group implements ResourceInterface {
         $resources = json_decode($request->getContent(), true);
 
         if (!is_array($resources)) {
-            throw new ResourceException('Invalid data. Array of resources strings is expected', 400);
+            throw new ResourceException('Invalid data. Array of resource strings is expected', 400);
         }
 
         foreach ($resources as $resource) {

--- a/library/Imbo/Resource/Group.php
+++ b/library/Imbo/Resource/Group.php
@@ -83,6 +83,16 @@ class Group implements ResourceInterface {
 
         $resources = json_decode($request->getContent(), true);
 
+        if (!is_array($resources)) {
+            throw new ResourceException('Invalid data. Array of resources strings is expected', 400);
+        }
+
+        foreach ($resources as $resource) {
+            if (!is_string($resource)) {
+               throw new ResourceException('Invalid value in the resources array. Only strings are allowed', 400);
+            }
+        }
+
         if ($groupExists) {
             $accessControl->updateResourceGroup($groupName, $resources);
         } else {

--- a/tests/behat/features/access-control-keys.feature
+++ b/tests/behat/features/access-control-keys.feature
@@ -56,7 +56,7 @@ Feature: Imbo provides a keys endpoint
         Given I use "master-pubkey" and "master-privkey" for public and private keys
         And the request body contains:
           """
-          [{"resources":["images.get"],"users":["user1"]},{"group":"read-images","users":["user1", "user5"]}]
+          [{"resources":["images.get"],"users":["user1"]},{"group":"existing-group","users":["user1", "user5"]}]
           """
         And I sign the request
         When I request "/keys/foobar/access" using HTTP "POST"

--- a/tests/behat/features/access-control.feature
+++ b/tests/behat/features/access-control.feature
@@ -106,13 +106,3 @@ Feature: Imbo provides a way to access control resources on a per-public key bas
             | url          | status           | response |
             | /            | 200 Hell Yeah    | #^{"version":".*?",.*}$# |
             | /status.json | 200 OK           | #^{"date":".*?","database":true,"storage":true}$# |
-
-    Scenario: Request shortUrl with no public key or access token provided
-        Given "tests/phpunit/Fixtures/1024x256.png" exists in Imbo
-        And I generate a short URL with the following parameters:
-            """
-            {"user": "user", "query": "t[]=thumbnail"}
-            """
-        When I request the image using the generated short URL
-        Then I should get a response with "200 OK"
-        And the "Content-Type" response header is "image/png"

--- a/tests/behat/features/group.feature
+++ b/tests/behat/features/group.feature
@@ -34,9 +34,9 @@ Feature: Imbo provides a group endpoint
         Then I should get a response with "<response>"
         Examples:
             | data               | response                                                           |
-            |                    | 400 Invalid data. Array of resources strings is expected           |
-            | true               | 400 Invalid data. Array of resources strings is expected           |
-            | "string"           | 400 Invalid data. Array of resources strings is expected           |
+            |                    | 400 Invalid data. Array of resource strings is expected            |
+            | true               | 400 Invalid data. Array of resource strings is expected            |
+            | "string"           | 400 Invalid data. Array of resource strings is expected            |
             | [123]              | 400 Invalid value in the resources array. Only strings are allowed |
             | [123,"images.get"] | 400 Invalid value in the resources array. Only strings are allowed |
 

--- a/tests/behat/features/group.feature
+++ b/tests/behat/features/group.feature
@@ -21,6 +21,25 @@ Feature: Imbo provides a group endpoint
             | json      | application/json | #^{"resources":\["groups\.get","groups\.head"]}$# |
             | xml       | application/xml  | #^<\?xml version="1\.0" encoding="UTF-8"\?>\s*<imbo>\s*<resources>\s*<resource>groups\.get</resource>\s*<resource>groups\.head</resource>\s*</resources>\s*</imbo>$#ms |
 
+    Scenario Outline: Create a resource group with invalid data
+        Given Imbo uses the "access-control-mutable.php" configuration
+        And I prime the database with "access-control-mutable.php"
+        And I use "acl-creator" and "someprivkey" for public and private keys
+        And the request body contains:
+          """
+          <data>
+          """
+        And I sign the request
+        When I request "/groups/read-images" using HTTP "PUT"
+        Then I should get a response with "<response>"
+        Examples:
+            | data               | response                                                           |
+            |                    | 400 Invalid data. Array of resources strings is expected           |
+            | true               | 400 Invalid data. Array of resources strings is expected           |
+            | "string"           | 400 Invalid data. Array of resources strings is expected           |
+            | [123]              | 400 Invalid value in the resources array. Only strings are allowed |
+            | [123,"images.get"] | 400 Invalid value in the resources array. Only strings are allowed |
+
     Scenario: Create a resource group
         Given Imbo uses the "access-control-mutable.php" configuration
         And I prime the database with "access-control-mutable.php"


### PR DESCRIPTION
Adds checking of the ACL rules before adding, ensuring that the rules has the correct properties, that rubbish is not inserted into the DB and that it's possible for the client to know what's wrong.