### PR TITLE
Pluggable image identifier generation

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -75,6 +75,19 @@ $config = [
     },
 
     /**
+     * Image identifier generator
+     *
+     * See the different adapter implementations for possible configuration parameters.
+     * The value must be set to a closure returning an instance of
+     * Imbo\Image\Identifier\Generator\GeneratorInterface, or an implementation of said interface.
+     *
+     * @var Imbo\Image\Identifier\Generator\GeneratorInterface|Closure
+     */
+    'imageIdentifierGenerator' => function() {
+        return new Image\Identifier\Generator\RandomString();
+    },
+
+    /**
      * Whether to content negotiate images or not. If set to true, Imbo will try to find a
      * suitable image format based on the Accept-header received. If set to false, it will
      * deliver the image in the format it was originally added as. Note that this does not

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -570,6 +570,46 @@ If you need to create your own storage adapter you need to create a class that i
 
 You can read more about how to achieve this in the :doc:`../develop/custom_adapters` chapter.
 
+.. _image-identifier-generation:
+
+Image identifier generation - ``imageIdentifierGenerator``
+----------------------------------------------------------
+
+By default, Imbo will generate a random string of characters as the image identifier for added images. These are in the RegExp range ``[A-Za-z0-9_-]`` and by default, the identifier will be 12 characters long.
+
+You can easily change the generation process to a different method. Imbo currently ships with two generators:
+
+RandomString
+++++++++++++
+
+The default, as stated above. This generator has the following parameters:
+
+``length``
+    The length of the randomly generated string. Defaults to ``12``.
+
+Uuid
+++++
+
+Generates 36-character v4 UUIDs, for instance ``f47ac10b-58cc-4372-a567-0e02b2c3d479``. This generator does not have any parameters.
+
+Usage:
+
+.. code-block:: php
+
+    <?php
+    return [
+        // ...
+
+        'imageIdentifierGenerator' => new Imbo\Image\Identifier\Generator\Uuid(),
+
+        // ...
+    ];
+
+Custom generators
++++++++++++++++++
+
+To create your own custom image identifier generators, simply create a class that implements ``Imbo\Image\Identifier\Generator\GeneratorInterface`` and ensure that the identifiers generated are in the character range ``[A-Za-z0-9_-]`` and are between one and 255 characters long.
+
 .. _configuration-content-negotiation:
 
 Content negotiation for images - ``contentNegotiateImages``

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -74,7 +74,7 @@ If you use the GridFS adapter, you will need to rename the ``publicKey`` field w
 Image identifiers are no longer MD5-sums
 ++++++++++++++++++++++++++++++++++++++++
 
-Previously, Imbo used the MD5 algorithm to generate the image identifier for an image. In Imbo 2.0.0 and onwards, image identifiers are simply randomly generated strings (currently using UUIDs, but this might change in the future). This means that the same image can exist multiple times within the same user. If this is not what you want, you can check if the image already exists by querying the :ref:`images resource <images-resource>` and specifying the MD5-sum of the image as an ``originalChecksum``-filter. Most Imbo-clients implement this already, as ``imageExists()`` or similar.
+Previously, Imbo used the MD5 algorithm to generate the image identifier for an image. In Imbo 2.0.0 and onwards, image identifiers are simply randomly generated strings. This means that the same image can exist multiple times within the same user. If this is not what you want, you can check if the image already exists by querying the :ref:`images resource <images-resource>` and specifying the MD5-sum of the image as an ``originalChecksum``-filter. Most Imbo-clients implement this already, as ``imageExists()`` or similar.
 
 To accommodate the new image identifiers and the possibility of future changes in how they are represented, databases should be able to store an image identifier of up to 255 characters. If you are using the :ref:`Doctrine database adapter <doctrine-database-adapter>` with the suggested schema on a MySQL database, this will require some changes:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -36,3 +36,4 @@ Imagick
 Behat
 Lighttpd
 ETag
+Uuid

--- a/library/Imbo/Exception.php
+++ b/library/Imbo/Exception.php
@@ -31,12 +31,13 @@ interface Exception {
     const AUTH_TIMESTAMP_EXPIRED  = 104;
 
     // Image resource errors
-    const IMAGE_ALREADY_EXISTS       = 200;
-    const IMAGE_NO_IMAGE_ATTACHED    = 201;
-    const IMAGE_HASH_MISMATCH        = 202;
-    const IMAGE_UNSUPPORTED_MIMETYPE = 203;
-    const IMAGE_BROKEN_IMAGE         = 204;
-    const IMAGE_INVALID_IMAGE        = 205;
+    const IMAGE_ALREADY_EXISTS               = 200;
+    const IMAGE_NO_IMAGE_ATTACHED            = 201;
+    const IMAGE_HASH_MISMATCH                = 202;
+    const IMAGE_UNSUPPORTED_MIMETYPE         = 203;
+    const IMAGE_BROKEN_IMAGE                 = 204;
+    const IMAGE_INVALID_IMAGE                = 205;
+    const IMAGE_IDENTIFIER_GENERATION_FAILED = 206;
     /**#@-*/
 
     /**

--- a/library/Imbo/Image/Identifier/Generator/GeneratorInterface.php
+++ b/library/Imbo/Image/Identifier/Generator/GeneratorInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Image\Identifier\Generator;
+
+use Imbo\Model\Image;
+
+/**
+ * Image identifier generator interface
+ *
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @package Core\Image\Identifier\Generator
+ */
+interface GeneratorInterface {
+    /**
+     * Generate an image identifier
+     *
+     * @param Imbo\Model\Image $image The image to generate an image identifier for
+     * @return string A valid image identifier, between 1 and 255 characters
+     */
+    function generate(Image $image);
+}

--- a/library/Imbo/Image/Identifier/Generator/RandomString.php
+++ b/library/Imbo/Image/Identifier/Generator/RandomString.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Image\Identifier\Generator;
+
+use Imbo\Model\Image,
+    Ramsey\Uuid\Uuid as UuidFactory;
+
+/**
+ * Random string image identifier generator
+ *
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @package Core\Image\Identifier\Generator
+ */
+class RandomString implements GeneratorInterface {
+    /**
+     * Class constructor
+     *
+     * @param integer $length The length of the randomly generated string
+     */
+    public function __construct($length = 12) {
+        $this->stringLength = $length;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(Image $image) {
+        $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-';
+        $charsLen = 64;
+        $key = '';
+
+        for ($i = 0; $i < $this->stringLength; $i++) {
+            $key .= $chars[mt_rand() % $charsLen];
+        }
+
+        return $key;
+    }
+}

--- a/library/Imbo/Image/Identifier/Generator/RandomString.php
+++ b/library/Imbo/Image/Identifier/Generator/RandomString.php
@@ -34,11 +34,11 @@ class RandomString implements GeneratorInterface {
      */
     public function generate(Image $image) {
         $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-';
-        $charsLen = 64;
+        $charsLen = strlen($chars);
         $key = '';
 
         for ($i = 0; $i < $this->stringLength; $i++) {
-            $key .= $chars[mt_rand() % $charsLen];
+            $key .= $chars[mt_rand(0, $charsLen - 1)];
         }
 
         return $key;

--- a/library/Imbo/Image/Identifier/Generator/Uuid.php
+++ b/library/Imbo/Image/Identifier/Generator/Uuid.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Image\Identifier\Generator;
+
+use Imbo\Model\Image,
+    Ramsey\Uuid\Uuid as UuidFactory;
+
+/**
+ * UUID image identifier generator
+ *
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @package Core\Image\Identifier\Generator
+ */
+class Uuid implements GeneratorInterface {
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(Image $image) {
+        return (string) UuidFactory::uuid4();
+    }
+}

--- a/library/Imbo/Image/ImagePreparation.php
+++ b/library/Imbo/Image/ImagePreparation.php
@@ -16,8 +16,7 @@ use Imbo\EventManager\EventInterface,
     Imbo\Exception,
     Imbo\Model\Image,
     Imagick,
-    ImagickException,
-    Ramsey\Uuid\Uuid;
+    ImagickException;
 
 /**
  * Image preparation
@@ -85,9 +84,54 @@ class ImagePreparation implements ListenerInterface {
               ->setBlob($imageBlob)
               ->setWidth($size['width'])
               ->setHeight($size['height'])
-              ->setOriginalChecksum(md5($imageBlob))
-              ->setImageIdentifier((string) Uuid::uuid4());
+              ->setOriginalChecksum(md5($imageBlob));
+
+        $imageIdentifier = $this->generateImageIdentifier($event, $image);
+        $image->setImageIdentifier($imageIdentifier);
 
         $request->setImage($image);
+    }
+
+    /**
+     * Using the configured image identifier generator, attempt to generate a unique image
+     * identifier for the given image until we either have found a unique ID or we hit the maximum
+     * allowed attempts.
+     *
+     * @param EventInterface $event The current event
+     * @param Image $image The event to generate the image identifier for
+     * @return string
+     * @throws ImageException
+     */
+    private function generateImageIdentifier(EventInterface $event, Image $image) {
+        $database = $event->getDatabase();
+        $config = $event->getConfig();
+        $user = $event->getRequest()->getUser();
+        $imageIdentifierGenerator = $config['imageIdentifierGenerator'];
+
+        if (is_callable($imageIdentifierGenerator) &&
+            !($imageIdentifierGenerator instanceof ImageIdentifierGeneratorInterface)) {
+            $imageIdentifierGenerator = $imageIdentifierGenerator();
+        }
+
+        // Continue generating image identifiers until we get one that does not already exist
+        $maxAttempts = 100;
+        $attempts = 0;
+        do {
+            $imageIdentifier = $imageIdentifierGenerator->generate($image);
+            $attempts++;
+        } while ($attempts < $maxAttempts && $database->imageExists($user, $imageIdentifier));
+
+        // Did we reach our max attempts limit?
+        if ($attempts === $maxAttempts) {
+            $e = new ImageException('Failed to generate unique image identifier', 503);
+            $e->setImboErrorCode(Exception::IMAGE_IDENTIFIER_GENERATION_FAILED);
+
+            // Tell the client it's OK to retry later
+            $event->getResponse()->headers->set('Retry-After', 1);
+
+            throw $e;
+        }
+
+        return $imageIdentifier;
     }
 }

--- a/library/Imbo/Router.php
+++ b/library/Imbo/Router.php
@@ -42,17 +42,17 @@ class Router {
      * @var array
      */
     private $routes = [
-        'image'          => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9-]{32,36})(\.(?<extension>gif|jpg|png))?$#',
+        'image'          => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[A-Za-z0-9_-]{1,255})(\.(?<extension>gif|jpg|png))?$#',
         'globalshorturl' => '#^/s/(?<shortUrlId>[a-zA-Z0-9]{7})$#',
         'status'         => '#^/status(/|(\.(?<extension>json|xml)))?$#',
         'images'         => '#^/users/(?<user>[a-z0-9_-]{1,})/images(/|(\.(?<extension>json|xml)))?$#',
         'globalimages'   => '#^/images(/|(\.(?<extension>json|xml)))?$#',
-        'metadata'       => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9-]{32,36})/meta(?:data)?(/|\.(?<extension>json|xml))?$#',
+        'metadata'       => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[A-Za-z0-9_-]{1,255})/meta(?:data)?(/|\.(?<extension>json|xml))?$#',
         'user'           => '#^/users/(?<user>[a-z0-9_-]{1,})(/|\.(?<extension>json|xml))?$#',
         'stats'          => '#^/stats(/|(\.(?<extension>json|xml)))?$#',
         'index'          => '#^/?$#',
-        'shorturls'      => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9-]{32,36})/shorturls(/|\.(?<extension>json|xml))?$#',
-        'shorturl'       => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[a-f0-9-]{32,36})/shorturls/(?<shortUrlId>[a-zA-Z0-9]{7})$#',
+        'shorturls'      => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[A-Za-z0-9_-]{1,255})/shorturls(/|\.(?<extension>json|xml))?$#',
+        'shorturl'       => '#^/users/(?<user>[a-z0-9_-]{1,})/images/(?<imageIdentifier>[A-Za-z0-9_-]{1,255})/shorturls/(?<shortUrlId>[a-zA-Z0-9]{7})$#',
         'groups'         => '#^/groups(/|(\.(?<extension>json|xml)))?$#',
         'group'          => '#^/groups/(?<group>[a-z0-9_-]{1,})(/|\.(?<extension>json|xml))?$#',
         'keys'           => '#^/keys/(?<publickey>[a-z0-9_-]{1,})$#',

--- a/tests/behat/features/varnish-hashtwo-listener.feature
+++ b/tests/behat/features/varnish-hashtwo-listener.feature
@@ -13,7 +13,7 @@ Feature: Imbo provides an event listener for the hashtwo Varnish module
         And Imbo uses the "varnish-hashtwo.php" configuration
         When I request the previously added image as a "png"
         Then I should get a response with "200 OK"
-        And the "X-HashTwo" response header matches "imbo;image;user;[a-f0-9-]{32,36}, imbo;user;user"
+        And the "X-HashTwo" response header matches "imbo;image;user;[A-Za-z0-9_-]{1,255}, imbo;user;user"
 
         Examples:
             | transformation   |
@@ -31,7 +31,7 @@ Feature: Imbo provides an event listener for the hashtwo Varnish module
         And Imbo uses the "varnish-hashtwo.php" configuration
         When I request the previously added image as a "png"
         Then I should get a response with "200 OK"
-        And the "X-Imbo-HashTwo" response header matches "imbo;image;user;[a-f0-9-]{32,36}, imbo;user;user"
+        And the "X-Imbo-HashTwo" response header matches "imbo;image;user;[A-Za-z0-9_-]{1,255}, imbo;user;user"
 
         Examples:
             | transformation   |

--- a/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/RandomStringTest.php
+++ b/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/RandomStringTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboUnitTest\Image\Identifier\Generator;
+
+use Imbo\Image\Identifier\Generator\RandomString as RandomStringGenerator,
+    ImagickException;
+
+/**
+ * @covers Imbo\Image\Identifier\Generator\RandomString
+ * @group unit
+ */
+class RandomStringTest extends \PHPUnit_Framework_TestCase {
+    public function testGeneratesUniqueStrings() {
+        $stringLength = 15;
+
+        $image = $this->getMock('Imbo\Model\Image');
+        $generator = new RandomStringGenerator($stringLength);
+        $generated = [];
+
+        for ($i = 0; $i < 15; $i++) {
+            $imageIdentifier = $generator->generate($image);
+
+            // Does it have the right format?
+            $this->assertRegExp(
+                '/^[A-Za-z0-9_-]{' . $stringLength . '}$/',
+                $imageIdentifier
+            );
+
+            // Make sure it doesn't generate any duplicates
+            $this->assertFalse(in_array($imageIdentifier, $generated));
+            $generated[] = $imageIdentifier;
+        }
+    }
+}

--- a/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/UuidTest.php
+++ b/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/UuidTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboUnitTest\Image\Identifier\Generator;
+
+use Imbo\Image\Identifier\Generator\Uuid as UuidGenerator,
+    ImagickException;
+
+/**
+ * @covers Imbo\Image\Identifier\Generator\Uuid
+ * @group unit
+ */
+class UuidTest extends \PHPUnit_Framework_TestCase {
+    public function testGeneratesUniqueUuidV4() {
+        $image = $this->getMock('Imbo\Model\Image');
+        $generator = new UuidGenerator();
+        $generated = [];
+
+        for ($i = 0; $i < 15; $i++) {
+            $imageIdentifier = $generator->generate($image);
+
+            // Does it have the right format?
+            $this->assertRegExp(
+                '/^[a-f0-9]{8}\-[a-f0-9]{4}\-4[a-f0-9]{3}\-[89ab][a-f0-9]{3}\-[a-f0-9]{12}$/',
+                $imageIdentifier
+            );
+
+            // Make sure it doesn't generate any duplicates
+            $this->assertFalse(in_array($imageIdentifier, $generated));
+            $generated[] = $imageIdentifier;
+        }
+    }
+}

--- a/tests/phpunit/ImboUnitTest/Image/ImagePreparationTest.php
+++ b/tests/phpunit/ImboUnitTest/Image/ImagePreparationTest.php
@@ -20,18 +20,32 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
     /**
      * @var ImagePreparation
      */
-    private $preparation;
+    private $prepare;
 
     private $request;
+    private $response;
     private $event;
+    private $config;
+    private $database;
+    private $headers;
+    private $imageIdentifierGenerator;
 
     /**
      * Set up the image preparation instance
      */
     public function setUp() {
         $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->response = $this->getMock('Imbo\Http\Response\Response');
         $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
+        $this->headers = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $this->response->headers = $this->headers;
+        $this->imageIdentifierGenerator = $this->getMock('Imbo\Image\Identifier\Generator\GeneratorInterface');
+        $this->config = ['imageIdentifierGenerator' => $this->imageIdentifierGenerator];
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
+        $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
+        $this->event->expects($this->any())->method('getConfig')->will($this->returnValue($this->config));
+        $this->event->expects($this->any())->method('getDatabase')->will($this->returnValue($this->database));
 
         $this->prepare = new ImagePreparation();
     }
@@ -40,8 +54,13 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
      * Tear down the image prepration instance
      */
     public function tearDown() {
-        $this->preparation = null;
+        $this->imageIdentifierGenerator = null;
+        $this->database = null;
+        $this->response = null;
+        $this->prepare = null;
+        $this->headers = null;
         $this->request = null;
+        $this->config = null;
         $this->event = null;
     }
 
@@ -104,6 +123,23 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @covers Imbo\Image\ImagePreparation::prepareImage
+     * @covers Imbo\Image\ImagePreparation::generateImageIdentifier
+     * @expectedException Imbo\Exception\ImageException
+     * @expectedExceptionMessage Failed to generate unique image identifier
+     * @expectedExceptionCode 503
+     */
+    public function testThrowsExceptionWhenItFailsToGenerateUniqueImageIdentifier() {
+        $imagePath = FIXTURES_DIR . '/image.png';
+        $imageData = file_get_contents($imagePath);
+
+        $this->request->expects($this->once())->method('getContent')->will($this->returnValue($imageData));
+        $this->database->expects($this->any())->method('imageExists')->will($this->returnValue(true));
+        $this->headers->expects($this->once())->method('set')->with('Retry-After', 1);
+        $this->prepare->prepareImage($this->event);
+    }
+
+    /**
+     * @covers Imbo\Image\ImagePreparation::prepareImage
      */
     public function testPopulatesRequestWhenImageIsValid() {
         $imagePath = FIXTURES_DIR . '/image.png';
@@ -112,5 +148,29 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
         $this->request->expects($this->once())->method('getContent')->will($this->returnValue($imageData));
         $this->request->expects($this->once())->method('setImage')->with($this->isInstanceOf('Imbo\Model\Image'));
         $this->prepare->prepareImage($this->event);
+    }
+
+    /**
+     * @covers Imbo\Image\ImagePreparation::prepareImage
+     * @covers Imbo\Image\ImagePreparation::generateImageIdentifier
+     */
+    public function testInstantiatesImageIdentifierGeneratorOnCallable() {
+        $imagePath = FIXTURES_DIR . '/image.png';
+        $imageData = file_get_contents($imagePath);
+
+        $generator = $this->imageIdentifierGenerator;
+        $config['imageIdentifierGenerator'] = function() use ($generator) {
+            return $generator;
+        };
+
+        $event = $this->getMock('Imbo\EventManager\Event');
+        $event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
+        $event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
+        $event->expects($this->any())->method('getConfig')->will($this->returnValue($config));
+        $event->expects($this->any())->method('getDatabase')->will($this->returnValue($this->database));
+
+        $this->request->expects($this->once())->method('getContent')->will($this->returnValue($imageData));
+        $this->request->expects($this->once())->method('setImage')->with($this->isInstanceOf('Imbo\Model\Image'));
+        $this->prepare->prepareImage($event);
     }
 }


### PR DESCRIPTION
This PR makes the image identifier generation customizable. 

By default, it will now use a 12-character long random string (open to improvements to this one, where it could potentially start with a lower number of characters).

Moved the UUID generator to it's own adapter and documented both of them.

This changes the shape of the allowed image identifiers to ``[A-Za-z0-9_-]{1,255}``

Open to comments, suggestions and improvements.