### PR TITLE
Metadata formatting and CDATA wrapping

### DIFF
--- a/library/Imbo/Http/Response/Formatter/Formatter.php
+++ b/library/Imbo/Http/Response/Formatter/Formatter.php
@@ -54,7 +54,7 @@ abstract class Formatter implements FormatterInterface {
         } else if ($model instanceof Model\Images) {
             return $this->formatImages($model);
         } else if ($model instanceof Model\Metadata) {
-            return $this->formatMetadata($model);
+            return $this->formatMetadataModel($model);
         } else if ($model instanceof Model\Groups) {
             return $this->formatGroups($model);
         } else if ($model instanceof Model\Group) {

--- a/library/Imbo/Http/Response/Formatter/FormatterInterface.php
+++ b/library/Imbo/Http/Response/Formatter/FormatterInterface.php
@@ -67,7 +67,7 @@ interface FormatterInterface {
      * @param Model\Metadata $model The model to format
      * @return string Formatted data
      */
-    function formatMetadata(Model\Metadata $model);
+    function formatMetadataModel(Model\Metadata $model);
 
     /**
      * Format a groups model

--- a/library/Imbo/Http/Response/Formatter/JSON.php
+++ b/library/Imbo/Http/Response/Formatter/JSON.php
@@ -135,7 +135,7 @@ class JSON extends Formatter implements FormatterInterface {
     /**
      * {@inheritdoc}
      */
-    public function formatMetadata(Model\Metadata $model) {
+    public function formatMetadataModel(Model\Metadata $model) {
         return $this->encode($model->getData() ?: new stdClass());
     }
 

--- a/library/Imbo/Http/Response/Formatter/XML.php
+++ b/library/Imbo/Http/Response/Formatter/XML.php
@@ -145,13 +145,7 @@ USER;
             $metadata = $image->getMetadata();
 
             if (is_array($metadata) && (empty($fields) || isset($fields['metadata']))) {
-                $images .= '<metadata>';
-
-                foreach ($metadata as $key => $value) {
-                    $images .= '<tag key="' . $key . '">' . $value . '</tag>';
-                }
-
-                $images .= '</metadata>';
+                $images .= '<metadata>' . $this->formatMetadata($metadata) . '</metadata>';
             }
 
             $images .= '</image>';
@@ -174,34 +168,8 @@ IMAGES;
     /**
      * {@inheritdoc}
      */
-    public function formatMetadata(Model\Metadata $model) {
-        $metadata = '';
-
-        foreach ($model->getData() as $key => $value) {
-            if (is_array($value)) {
-                $metadata .= '<tag key="' . $key . '">';
-                $metadata .= $this->formatArray($value);
-                $metadata .= '</tag>';
-
-                continue;
-            }
-
-            $containsSpecialCharacter = (
-                strpos($value, '<') !== false ||
-                strpos($value, '>') !== false ||
-                strpos($value, '&') !== false ||
-                strpos($value, '"') !== false ||
-                strpos($value, '\'') !== false
-            );
-
-            if ($containsSpecialCharacter) {
-                $metadata .= '<tag key="' . $key . '"><![CDATA[' . $value . ']]></tag>';
-
-                continue;
-            }
-
-            $metadata .= '<tag key="' . $key . '">' . $value . '</tag>';
-        }
+    public function formatMetadataModel(Model\Metadata $model) {
+        $metadata = $this->formatMetadata($model->getData());
 
         return <<<METADATA
 <?xml version="1.0" encoding="UTF-8"?>
@@ -235,7 +203,7 @@ DATA;
         $list = $model->getList();
 
         foreach ($list as $element) {
-            $entries .= '<' . $entry . '>' . $element . '</' . $entry . '>';
+            $entries .= '<' . $entry . '>' . $this->formatValue($element) . '</' . $entry . '>';
         }
 
         $data = '<' . $container . '>' . $entries . '</' . $container . '>';
@@ -254,10 +222,12 @@ DATA;
 
         $entries = '';
         foreach ($data['groups'] as $group) {
+            $resources = array_map(array($this, 'formatValue'), $group['resources']);
+
             $entries .= '<group>';
-            $entries .= '  <name>' . $group['name'] . '</name>';
+            $entries .= '  <name>' . $this->formatValue($group['name']) . '</name>';
             $entries .= '  <resources>';
-            $entries .= '    <resource>' . implode($group['resources'], '</resource><resource>') . '</resource>';
+            $entries .= '    <resource>' . implode($resources, '</resource><resource>') . '</resource>';
             $entries .= '  </resources>';
             $entries .= '</group>';
         }
@@ -278,7 +248,7 @@ DATA;
 
         $entries = '';
         foreach ($data['resources'] as $resource) {
-            $entries .= '<resource>' . $resource . '</resource>';
+            $entries .= '<resource>' . $this->formatValue($resource) . '</resource>';
         }
 
         return <<<DATA
@@ -344,6 +314,54 @@ DATA;
 DATA;
     }
 
+    private function formatValue($value) {
+        $containsSpecialCharacter = (
+            strpos($value, '<') !== false ||
+            strpos($value, '>') !== false ||
+            strpos($value, '&') !== false ||
+            strpos($value, '"') !== false ||
+            strpos($value, '\'') !== false
+        );
+
+        if ($containsSpecialCharacter) {
+            return '<![CDATA[' . $value . ']]>';
+        }
+
+        return $value;
+    }
+
+    /**
+     * Format dataset containing metadata
+     *
+     * @param array $data
+     * @return string
+     */
+    private function formatMetadata(array $data) {
+        $metadata = '';
+
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $metadata .= '<tag key="' . $key . '">';
+                $metadata .= $this->formatArray($value);
+                $metadata .= '</tag>';
+
+                continue;
+            }
+
+            $containsSpecialCharacter = (
+                strpos($value, '<') !== false ||
+                strpos($value, '>') !== false ||
+                strpos($value, '&') !== false ||
+                strpos($value, '"') !== false ||
+                strpos($value, '\'') !== false
+            );
+
+            $metadata .= '<tag key="' . $key . '">' . $this->formatValue($value) . '</tag>';
+        }
+
+        return $metadata;
+    }
+
     /**
      * Format a nested dataset
      *
@@ -362,7 +380,7 @@ DATA;
                 if (is_array($value)) {
                     $xml .= $this->formatArray($value);
                 } else {
-                    $xml .= $value;
+                    $xml .= $this->formatValue($value);
                 }
 
                 $xml .= '</value>';
@@ -376,7 +394,7 @@ DATA;
                 if (is_array($value)) {
                     $xml .= $this->formatArray($value);
                 } else {
-                    $xml .= $value;
+                    $xml .= $this->formatValue($value);
                 }
 
                 $xml .= '</' . $key . '>';
@@ -398,19 +416,19 @@ DATA;
         if (isset($accessRule['resources']) && !!$accessRule['resources']) {
             $rule .= '<resources>';
             foreach ($accessRule['resources'] as $resource) {
-                $rule .= '<resource>' . $resource . '</resource>';
+                $rule .= '<resource>' . $this->formatValue($resource) . '</resource>';
             }
             $rule .= '</resources>';
         }
 
         if (isset($accessRule['group'])) {
-            $rule .= '<group>' . $accessRule['group'] . '</group>';
+            $rule .= '<group>' . $this->formatValue($accessRule['group']) . '</group>';
         }
 
         if (isset($accessRule['users']) && !!$accessRule['users']) {
             $rule .= '<users>';
             foreach ($accessRule['users'] as $user) {
-                $rule .= '<user>' . $user . '</user>';
+                $rule .= '<user>' . $this->formatValue($user) . '</user>';
             }
             $rule .= '</users>';
         }

--- a/library/Imbo/Http/Response/Formatter/XML.php
+++ b/library/Imbo/Http/Response/Formatter/XML.php
@@ -314,16 +314,14 @@ DATA;
 DATA;
     }
 
+    /**
+     * Format a value, and CDATA wrap it if it contains special characters
+     *
+     * @param string $value
+     * @return string
+     */
     private function formatValue($value) {
-        $containsSpecialCharacter = (
-            strpos($value, '<') !== false ||
-            strpos($value, '>') !== false ||
-            strpos($value, '&') !== false ||
-            strpos($value, '"') !== false ||
-            strpos($value, '\'') !== false
-        );
-
-        if ($containsSpecialCharacter) {
+        if (strpbrk($value, '<>&"\'') !== false) {
             return '<![CDATA[' . $value . ']]>';
         }
 
@@ -347,14 +345,6 @@ DATA;
 
                 continue;
             }
-
-            $containsSpecialCharacter = (
-                strpos($value, '<') !== false ||
-                strpos($value, '>') !== false ||
-                strpos($value, '&') !== false ||
-                strpos($value, '"') !== false ||
-                strpos($value, '\'') !== false
-            );
 
             $metadata .= '<tag key="' . $key . '">' . $this->formatValue($value) . '</tag>';
         }

--- a/library/Imbo/Http/Response/Formatter/XML.php
+++ b/library/Imbo/Http/Response/Formatter/XML.php
@@ -335,7 +335,15 @@ DATA;
             $xml .= '<list>';
 
             foreach ($data as $value) {
-                $xml .= '<value>' . $value . '</value>';
+                $xml .= '<value>';
+
+                if (is_array($value)) {
+                    $xml .= $this->formatArray($value);
+                } else {
+                    $xml .= $value;
+                }
+
+                $xml .= '</value>';
             }
 
             $xml .= '</list>';

--- a/library/Imbo/Http/Response/Formatter/XML.php
+++ b/library/Imbo/Http/Response/Formatter/XML.php
@@ -178,6 +178,28 @@ IMAGES;
         $metadata = '';
 
         foreach ($model->getData() as $key => $value) {
+            if (is_array($value)) {
+                $metadata .= '<tag key="' . $key . '">';
+                $metadata .= $this->formatArray($value);
+                $metadata .= '</tag>';
+
+                continue;
+            }
+
+            $containsSpecialCharacter = (
+                strpos($value, '<') !== false ||
+                strpos($value, '>') !== false ||
+                strpos($value, '&') !== false ||
+                strpos($value, '"') !== false ||
+                strpos($value, '\'') !== false
+            );
+
+            if ($containsSpecialCharacter) {
+                $metadata .= '<tag key="' . $key . '"><![CDATA[' . $value . ']]></tag>';
+
+                continue;
+            }
+
             $metadata .= '<tag key="' . $key . '">' . $value . '</tag>';
         }
 

--- a/tests/phpunit/ImboUnitTest/Http/Response/Formatter/XMLTest.php
+++ b/tests/phpunit/ImboUnitTest/Http/Response/Formatter/XMLTest.php
@@ -281,15 +281,22 @@ class XMLTest extends \PHPUnit_Framework_TestCase {
         $metadata = [
             'some key' => 'some value',
             'some other key' => 'some other value',
+            'poi' => [['x' => 810, 'y' => 568]],
+            'location' => ['city' => 'Oslo'],
+            'dangerous stuff' => [
+                'greater than' => '4 > 2',
+                'less than' => '1 < 2',
+                'ampersand' => 'this & that',
+                'quote' => 'Everyone is "working"..',
+                'apostrophe' => 'I\'m backing up, backing up, backing up',
+            ],
         ];
         $model = $this->getMock('Imbo\Model\Metadata');
         $model->expects($this->once())->method('getData')->will($this->returnValue($metadata));
 
         $xml = $this->formatter->format($model);
 
-        foreach ($metadata as $key => $value) {
-            $this->assertXPathMatches('/imbo/metadata/tag[@key="' . $key . '" and .="' . $value . '"]', $xml);
-        }
+        $this->assertContains('<metadata><tag key="some key">some value</tag><tag key="some other key">some other value</tag><tag key="poi"><list><value><x>810</x><y>568</y></value></list></tag><tag key="location"><city>Oslo</city></tag><tag key="dangerous stuff"><greater than><![CDATA[4 > 2]]></greater than><less than><![CDATA[1 < 2]]></less than><ampersand><![CDATA[this & that]]></ampersand><quote><![CDATA[Everyone is "working"..]]></quote><apostrophe><![CDATA[I\'m backing up, backing up, backing up]]></apostrophe></tag></metadata>', $xml);
     }
 
     /**
@@ -339,6 +346,23 @@ class XMLTest extends \PHPUnit_Framework_TestCase {
         $xml = $this->formatter->format($model);
 
         $this->assertContains('<imbo><key><list><value>1</value><value>2</value><value>3</value></list></key></imbo>', $xml);
+    }
+
+    /**
+     * @covers Imbo\Http\Response\Formatter\Formatter::format
+     * @covers Imbo\Http\Response\Formatter\XML::formatArrayModel
+     * @covers Imbo\Http\Response\Formatter\XML::formatArray
+     */
+    public function testCanFormatArrayModelWithNestedLists() {
+        $data = [
+            'key' => [[1, 2], [3, 4]],
+        ];
+        $model = $this->getMock('Imbo\Model\ArrayModel');
+        $model->expects($this->once())->method('getData')->will($this->returnValue($data));
+
+        $xml = $this->formatter->format($model);
+
+        $this->assertContains('<imbo><key><list><value><list><value>1</value><value>2</value></list></value><value><list><value>3</value><value>4</value></list></value></list></key></imbo>', $xml);
     }
 
     /**


### PR DESCRIPTION
This PR implements XML formatting of nested metadata. It also adds a `formatValue` in the XML formatter that ensures that values with characters with a special function in XML (', ", < and >) is wrapped in CDATA to ensure that the output is valid XML.