### PR TITLE
Change `user` query parameter to `users` to match other filters

### DIFF
--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -651,12 +651,12 @@ The global images resource is used to search for images across users, given that
 
 This resource is read only, and behaves in the same way as described in the `Get image collections` section of :ref:`images-resource`. In addition to the parameters specified for `Get image collections`, the following query parameter must be specified:
 
-``user[]``
+``users[]``
     An array of users to get images for.
 
 .. code-block:: bash
 
-    curl "http://imbo/images?user[]=foo&user[]=bar"
+    curl "http://imbo/images?users[]=foo&users[]=bar"
 
 results in a response with the exact same format as shown under `Get image collections`.
 

--- a/library/Imbo/Http/Request/Request.php
+++ b/library/Imbo/Http/Request/Request.php
@@ -93,7 +93,7 @@ class Request extends SymfonyRequest {
      */
     public function getUsers() {
         $routeUser = $this->getUser();
-        $queryUsers = $this->query->get('user', []);
+        $queryUsers = $this->query->get('users', []);
 
         if (!$routeUser && !$queryUsers) {
             return [];

--- a/library/Imbo/Resource/GlobalImages.php
+++ b/library/Imbo/Resource/GlobalImages.php
@@ -56,8 +56,9 @@ class GlobalImages implements ResourceInterface {
         $acl = $event->getAccessControl();
 
         $missingAccess = [];
+        $users = $event->getRequest()->getUsers();
 
-        foreach ($event->getRequest()->getUsers() as $user) {
+        foreach ($users as $user) {
             $hasAccess = $acl->hasAccess(
                 $event->getRequest()->getPublicKey(),
                 'images.get',
@@ -79,7 +80,7 @@ class GlobalImages implements ResourceInterface {
         }
 
         $event->getManager()->trigger('db.images.load', [
-            'users' => $event->getRequest()->getUsers()
+            'users' => $users
         ]);
     }
 }

--- a/tests/behat/features/global-images.feature
+++ b/tests/behat/features/global-images.feature
@@ -24,7 +24,7 @@ Feature: Imbo provides a global images endpoint
     Scenario: Fetch images for user with wildcard access
         Given I use "wildcard" and "*" for public and private keys
         And I include an access token in the query
-        When I request "/images.json?user[]=user&user[]=other-user"
+        When I request "/images.json?users[]=user&users[]=other-user"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "application/json"
         And the response body matches:
@@ -44,14 +44,14 @@ Feature: Imbo provides a global images endpoint
         """
 
         Examples:
-            | queryString                    | response               |
-            | ?user[]=user&user[]=other-user | #^{"search":{"hits":4,"page":1,"limit":20,"count":4}# |
-            | ?user[]=user                   | #^{"search":{"hits":2,"page":1,"limit":20,"count":2}# |
-            | ?user[]=other-user             | #^{"search":{"hits":2,"page":1,"limit":20,"count":2}# |
+            | queryString                      | response                                              |
+            | ?users[]=user&users[]=other-user | #^{"search":{"hits":4,"page":1,"limit":20,"count":4}# |
+            | ?users[]=user                    | #^{"search":{"hits":2,"page":1,"limit":20,"count":2}# |
+            | ?users[]=other-user              | #^{"search":{"hits":2,"page":1,"limit":20,"count":2}# |
 
     Scenario: Fetch images specifying users that the publickey does not have access to
         Given I use "unpriviledged" and "privatekey" for public and private keys
         And I include an access token in the query
-        When I request "/images.json?user[]=foo&user[]=bar"
+        When I request "/images.json?users[]=foo&users[]=bar"
         Then I should get a response with "400 Public key does not have access to the users: [foo, bar]"
         And the "Content-Type" response header is "application/json"


### PR DESCRIPTION
The `user` query parameter for the global image endpoint currently doesn't match the other plural fields (`checksums`, `fields` et all).

This fixes that.