### PR TITLE
Sort resource choices in add-public-key command

### DIFF
--- a/library/ImboCli/Command/AddPublicKey.php
+++ b/library/ImboCli/Command/AddPublicKey.php
@@ -139,9 +139,12 @@ class AddPublicKey extends Command {
      * @return array
      */
     private function askForSpecificResources(InputInterface $input, OutputInterface $output) {
+        $resources = AbstractAdapter::getAllResources();
+        sort($resources);
+
         $question = new ChoiceQuestion(
             'Which resources should the public key have access to? (comma-separated) ',
-            AbstractAdapter::getAllResources()
+            $resources
         );
         $question->setMultiselect(true);
 

--- a/tests/phpunit/ImboCliUnitTest/Command/AddPublicKeyTest.php
+++ b/tests/phpunit/ImboCliUnitTest/Command/AddPublicKeyTest.php
@@ -221,6 +221,7 @@ class AddPublicKeyTest extends \PHPUnit_Framework_TestCase {
      */
     public function testPromptsForListOfSpecificResourcesIfOptionIsSelected() {
         $allResources = AbstractAdapter::getAllResources();
+        sort($allResources);
 
         $this->adapter
             ->expects($this->once())


### PR DESCRIPTION
Small annoyance: When choosing resources a public key should have access to, the list is currently not sorted. This makes it harder to find what you are looking for.

This PR sorts the list.
