### PR TITLE
Use new POI-format

### DIFF
--- a/library/Imbo/Image/Transformation/SmartSize.php
+++ b/library/Imbo/Image/Transformation/SmartSize.php
@@ -176,11 +176,22 @@ class SmartSize extends Transformation implements ListenerInterface {
             $image->getImageIdentifier()
         );
 
+        $poi = isset($metadata['poi'][0]) ? $metadata['poi'][0] : false;
+
         // Fetch POI from metadata. Array used if we want to expand with multiple POIs in the future
-        if (isset($metadata['poi'][0]['x']) && isset($metadata['poi'][0]['y'])) {
+        if ($poi && isset($poi['cx']) && isset($poi['cy'])) {
             return [
-                (int) $metadata['poi'][0]['x'],
-                (int) $metadata['poi'][0]['y']
+                (int) $poi['cx'],
+                (int) $poi['cy']
+            ];
+        } else if (
+            $poi &&
+            isset($poi['x']) && isset($poi['y']) &&
+            isset($poi['width']) && isset($poi['height'])
+        ) {
+            return [
+                (int) $poi['x'] + ($poi['width']  / 2),
+                (int) $poi['y'] + ($poi['height'] / 2)
             ];
         }
 

--- a/tests/behat/features/smartsize-transformation.feature
+++ b/tests/behat/features/smartsize-transformation.feature
@@ -8,7 +8,7 @@ Feature: Imbo can crop images using smart size and POIs
         And I use "publickey" and "privatekey" for public and private keys
         And the request body contains:
           """
-          {"poi": [{"x": 810, "y": 568}]}
+          {"poi": [{"cx": 810, "cy": 568}]}
           """
         And I sign the request
         When I request the metadata of the test image using HTTP "PUT"
@@ -39,9 +39,27 @@ Feature: Imbo can crop images using smart size and POIs
             | smartsize:width=250,height=600,poi=810,568,crop=wide   | 0, 0  | #fafff3 | 250   | 600    |
 
     Scenario: Smart size based on POI stored in metadata
+        Given I specify "smartsize:width=250,height=250" as transformation
         And I include an access token in the query
-        And I specify "smartsize:width=250,height=250" as transformation
         When I request the test image as a "png"
+        Then I should get a response with "200 OK"
+        And the width of the image is "250"
+        And the height of the image is "250"
+        And the pixel at coordinate "0, 0" should have a color of "#355170"
+        And the "X-Imbo-POIs-Used" response header is "1"
+
+    Scenario: Smart size based on POI without center coordinates stored in metadata
+        Given I use "publickey" and "privatekey" for public and private keys
+        And the request body contains:
+          """
+          {"poi": [{"x": 800, "y": 558, "width": 20, "height": 20}]}
+          """
+        And I sign the request
+        And I request the metadata of the test image using HTTP "PUT"
+        Then I should get a response with "200 OK"
+        When I specify "smartsize:width=250,height=250" as transformation
+        And I include an access token in the query
+        And I request the test image as a "png"
         Then I should get a response with "200 OK"
         And the width of the image is "250"
         And the height of the image is "250"

--- a/tests/behat/features/smartsize-transformation.feature
+++ b/tests/behat/features/smartsize-transformation.feature
@@ -15,7 +15,7 @@ Feature: Imbo can crop images using smart size and POIs
         Then I should get a response with "200 OK"
 
     Scenario Outline: Smart size image
-        And I include an access token in the query
+        Given I include an access token in the query
         And I specify "<transformation>" as transformation
         When I request the test image as a "png"
         Then I should get a response with "200 OK"


### PR DESCRIPTION
As proposed in #378, this changes the POI-format to either use `cx` and `cy` *or* `x` and `y` paired with `width` and `height`. Obviously, all 6 are able to co-exist without any problems.