### PR TITLE
Fix issue when all origins are allowed but none is specified

### DIFF
--- a/library/Imbo/EventListener/Cors.php
+++ b/library/Imbo/EventListener/Cors.php
@@ -144,7 +144,7 @@ class Cors implements ListenerInterface {
     public function options(EventInterface $event) {
         $request = $event->getRequest();
         $response = $event->getResponse();
-        $origin = $request->headers->get('Origin', '*');
+        $origin = $request->headers->get('Origin');
 
         // This is an OPTIONS request, send 204 since no more content will follow
         $response->setStatusCode(204);
@@ -153,7 +153,7 @@ class Cors implements ListenerInterface {
         $event->getResponse()->setVary('Origin', false);
 
         // Fall back if the passed origin is not allowed
-        if (!$this->originIsAllowed($origin)) {
+        if (!$origin || !$this->originIsAllowed($origin)) {
             return;
         }
 
@@ -203,13 +203,13 @@ class Cors implements ListenerInterface {
             return;
         }
 
-        $origin = $request->headers->get('Origin', '*');
+        $origin = $request->headers->get('Origin');
 
         // Vary on Origin to prevent caching allowed/disallowed requests
         $event->getResponse()->setVary('Origin', false);
 
         // Fall back if the passed origin is not allowed
-        if (!$this->originIsAllowed($origin)) {
+        if (!$origin || !$this->originIsAllowed($origin)) {
             return;
         }
 

--- a/tests/behat/features/cors-event-listener.feature
+++ b/tests/behat/features/cors-event-listener.feature
@@ -92,3 +92,29 @@ Feature: Imbo provides an event listener for CORS
         """
         Access-Control-Allow-Origin
         """
+
+    Scenario: Request a resource using HTTP OPTIONS without an Origin header when all origins are accepted
+        Given Imbo uses the "cors-wildcard.php" configuration
+        When I request "/" using HTTP "OPTIONS"
+        Then I should get a response with "204 No Content"
+        And the "Vary" response header contains "Origin"
+        And the following response headers should not be present:
+        """
+        Access-Control-Allow-Origin
+        Access-Control-Allow-Methods
+        Access-Control-Allow-Headers
+        Access-Control-Max-Age
+        """
+
+    Scenario: Request a resource without an Origin header when all origins are accepted
+        Given Imbo uses the "cors-wildcard.php" configuration
+        When I request "/" using HTTP "GET"
+        Then I should get a response with "200 Hell Yeah"
+        And the "Vary" response header contains "Origin"
+        And the following response headers should not be present:
+        """
+        Access-Control-Allow-Origin
+        Access-Control-Allow-Methods
+        Access-Control-Allow-Headers
+        Access-Control-Max-Age
+        """

--- a/tests/behat/imbo-configs/cors-wildcard.php
+++ b/tests/behat/imbo-configs/cors-wildcard.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+/**
+ * CORS-config with wildcard origin
+ */
+return [
+    'eventListeners' => [
+        'cors' => [
+            'listener' => 'Imbo\EventListener\Cors',
+            'params' => [
+                'allowedOrigins' => ['*'],
+                'allowedMethods' => [
+                    'index' => ['GET', 'HEAD']
+                ],
+            ],
+        ],
+    ],
+];

--- a/tests/phpunit/ImboUnitTest/EventListener/CorsTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/CorsTest.php
@@ -34,7 +34,7 @@ class CorsTest extends ListenerTests {
      */
     public function setUp() {
         $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
-        $requestHeaders->expects($this->any())->method('get')->with('Origin', '*')->will($this->returnValue('http://imbo-project.org'));
+        $requestHeaders->expects($this->any())->method('get')->with('Origin')->will($this->returnValue('http://imbo-project.org'));
 
         $this->request = $this->getMock('Imbo\Http\Request\Request');
         $this->request->headers = $requestHeaders;
@@ -219,7 +219,7 @@ class CorsTest extends ListenerTests {
         $this->request->headers
             ->expects($this->at(0))
             ->method('get')
-            ->with('Origin', '*')
+            ->with('Origin')
             ->will($this->returnValue('http://imbo-project.org'));
 
         $this->request->headers
@@ -258,7 +258,7 @@ class CorsTest extends ListenerTests {
         $route->expects($this->once())->method('__toString')->will($this->returnValue('image'));
 
         $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
-        $requestHeaders->expects($this->any())->method('get')->with('Origin', '*')->will($this->returnValue('http://somehost'));
+        $requestHeaders->expects($this->any())->method('get')->with('Origin')->will($this->returnValue('http://somehost'));
 
         $request = $this->getMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getRoute')->will($this->returnValue($route));


### PR DESCRIPTION
See #385. The problem was limited to when all origins were allowed and the client did not specify an `Origin` header. Imbo would default it to a wildcard and match it as a valid CORS-request, when in truth no headers should be sent.
