### PR TITLE
Move resource constants out of access control

### DIFF
--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -63,7 +63,8 @@ It's usually a good idea to have separate public keys for read-only and read+wri
 .. code-block:: php
 
     <?php
-    use Imbo\Auth\AccessControl\Adapter\ArrayAdapter;
+    use Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
+        Imbo\Resource;
 
     return [
         // ...
@@ -74,7 +75,7 @@ It's usually a good idea to have separate public keys for read-only and read+wri
                     'publicKey'  => 'some-read-only-pubkey',
                     'privateKey' => 'some-private-key',
                     'acl' => [[
-                        'resources' => ArrayAdapter::getReadOnlyResources(),
+                        'resources' => Resource::getReadOnlyResources(),
                         'users' => ['some-user']
                     ]]
                 ],
@@ -82,7 +83,7 @@ It's usually a good idea to have separate public keys for read-only and read+wri
                     'publicKey'  => 'some-read-write-pubkey',
                     'privateKey' => 'some-other-private-key',
                     'acl' => [[
-                        'resources' => ArrayAdapter::getReadWriteResources(),
+                        'resources' => Resource::getReadWriteResources(),
                         'users' => ['some-user']
                     ]]
                 ]
@@ -97,7 +98,8 @@ As you can see, the ``ArrayAdapter`` is much more flexible than the ``SimpleArra
 .. code-block:: php
 
     <?php
-    use Imbo\Auth\AccessControl\Adapter\ArrayAdapter;
+    use Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
+        Imbo\Resource
 
     return [
         // ...
@@ -116,7 +118,7 @@ As you can see, the ``ArrayAdapter`` is much more flexible than the ``SimpleArra
                         [
                             // An array of different resource names that the public key should have
                             // access to - see AdapterInterface::RESOURCE_* for available options.
-                            'resources' => ArrayAdapter::getReadOnlyResources(),
+                            'resources' => Resource::getReadOnlyResources(),
 
                             // Names of the users which the public key should have access to.
                             'users' => ['some', 'users'],
@@ -125,7 +127,7 @@ As you can see, the ``ArrayAdapter`` is much more flexible than the ``SimpleArra
                         // Multiple rules can be applied in order to make a single public key have
                         // different access rights on different users
                         [
-                            'resources' => ArrayAdapter::getReadWriteResources(),
+                            'resources' => Resource::getReadWriteResources(),
                             'users' => ['different-user'],
                         ],
 

--- a/library/Imbo/Auth/AccessControl/Adapter/AbstractAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/AbstractAdapter.php
@@ -10,7 +10,7 @@
 
 namespace Imbo\Auth\AccessControl\Adapter;
 
-use Imbo\Auth\AccessControl\Adapter\AdapterInterface as ACI,
+use Imbo\Auth\AccessControl\Adapter\AdapterInterface,
     Imbo\Auth\AccessControl\GroupQuery,
     Imbo\Model\Groups as GroupsModel;
 
@@ -21,7 +21,6 @@ use Imbo\Auth\AccessControl\Adapter\AdapterInterface as ACI,
  * @package Core\Auth\AccessControl
  */
 abstract class AbstractAdapter implements AdapterInterface {
-
     /**
      * {@inheritdoc}
      */
@@ -36,86 +35,4 @@ abstract class AbstractAdapter implements AdapterInterface {
      * {@inheritdoc}
      */
     abstract public function getGroup($groupName);
-
-    /**
-     * {@inheritdoc}
-     */
-    final public static function getReadOnlyResources() {
-        return [
-            ACI::RESOURCE_USER_GET,
-            ACI::RESOURCE_USER_HEAD,
-            ACI::RESOURCE_USER_OPTIONS,
-
-            ACI::RESOURCE_IMAGE_GET,
-            ACI::RESOURCE_IMAGE_HEAD,
-            ACI::RESOURCE_IMAGE_OPTIONS,
-
-            ACI::RESOURCE_GROUPS_GET,
-            ACI::RESOURCE_GROUPS_HEAD,
-            ACI::RESOURCE_GROUPS_OPTIONS,
-
-            ACI::RESOURCE_IMAGES_GET,
-            ACI::RESOURCE_IMAGES_HEAD,
-            ACI::RESOURCE_IMAGES_OPTIONS,
-
-            ACI::RESOURCE_METADATA_GET,
-            ACI::RESOURCE_METADATA_HEAD,
-            ACI::RESOURCE_METADATA_OPTIONS,
-
-            ACI::RESOURCE_SHORTURL_GET,
-            ACI::RESOURCE_SHORTURL_HEAD,
-            ACI::RESOURCE_SHORTURL_OPTIONS,
-
-            ACI::RESOURCE_GLOBAL_IMAGES_GET,
-            ACI::RESOURCE_GLOBAL_IMAGES_HEAD,
-            ACI::RESOURCE_GLOBAL_IMAGES_OPTIONS,
-
-            ACI::RESOURCE_SHORTURLS_OPTIONS,
-        ];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    final public static function getReadWriteResources() {
-        return array_merge(
-            self::getReadOnlyResources(), [
-                ACI::RESOURCE_IMAGE_DELETE,
-                ACI::RESOURCE_IMAGES_POST,
-
-                ACI::RESOURCE_METADATA_POST,
-                ACI::RESOURCE_METADATA_DELETE,
-                ACI::RESOURCE_METADATA_PUT,
-
-                ACI::RESOURCE_SHORTURL_DELETE,
-
-                ACI::RESOURCE_SHORTURLS_POST,
-                ACI::RESOURCE_SHORTURLS_DELETE,
-            ]
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    final public static function getAllResources() {
-        return array_merge(
-            self::getReadWriteResources(), [
-                ACI::RESOURCE_KEYS_PUT,
-                ACI::RESOURCE_KEYS_HEAD,
-                ACI::RESOURCE_KEYS_DELETE,
-                ACI::RESOURCE_KEYS_OPTIONS,
-
-                ACI::RESOURCE_ACCESS_RULE_GET,
-                ACI::RESOURCE_ACCESS_RULE_HEAD,
-                ACI::RESOURCE_ACCESS_RULE_DELETE,
-                ACI::RESOURCE_ACCESS_RULE_OPTIONS,
-
-                ACI::RESOURCE_ACCESS_RULES_GET,
-                ACI::RESOURCE_ACCESS_RULES_HEAD,
-                ACI::RESOURCE_ACCESS_RULES_POST,
-                ACI::RESOURCE_ACCESS_RULES_OPTIONS,
-            ]
-        );
-    }
 }

--- a/library/Imbo/Auth/AccessControl/Adapter/AdapterInterface.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/AdapterInterface.php
@@ -20,65 +20,6 @@ use Imbo\Auth\AccessControl\GroupQuery,
  * @package Core\Auth\AccessControl
  */
 interface AdapterInterface {
-    const RESOURCE_GROUPS_GET              = 'groups.get';
-    const RESOURCE_GROUPS_HEAD             = 'groups.head';
-    const RESOURCE_GROUPS_OPTIONS          = 'groups.options';
-
-    const RESOURCE_GROUP_GET               = 'group.get';
-    const RESOURCE_GROUP_HEAD              = 'group.head';
-    const RESOURCE_GROUP_PUT               = 'group.put';
-    const RESOURCE_GROUP_DELETE            = 'group.delete';
-    const RESOURCE_GROUP_OPTIONS           = 'group.options';
-
-    const RESOURCE_KEYS_PUT                = 'keys.put';
-    const RESOURCE_KEYS_HEAD               = 'keys.head';
-    const RESOURCE_KEYS_DELETE             = 'keys.delete';
-    const RESOURCE_KEYS_OPTIONS            = 'keys.options';
-
-    const RESOURCE_ACCESS_RULE_GET         = 'accessrule.get';
-    const RESOURCE_ACCESS_RULE_HEAD        = 'accessrule.head';
-    const RESOURCE_ACCESS_RULE_DELETE      = 'accessrule.delete';
-    const RESOURCE_ACCESS_RULE_OPTIONS     = 'accessrule.options';
-
-    const RESOURCE_ACCESS_RULES_GET        = 'accessrules.get';
-    const RESOURCE_ACCESS_RULES_HEAD       = 'accessrules.head';
-    const RESOURCE_ACCESS_RULES_POST       = 'accessrules.post';
-    const RESOURCE_ACCESS_RULES_OPTIONS    = 'accessrules.options';
-
-    const RESOURCE_USER_GET                = 'user.get';
-    const RESOURCE_USER_HEAD               = 'user.head';
-    const RESOURCE_USER_OPTIONS            = 'user.options';
-
-    const RESOURCE_IMAGE_GET               = 'image.get';
-    const RESOURCE_IMAGE_HEAD              = 'image.head';
-    const RESOURCE_IMAGE_DELETE            = 'image.delete';
-    const RESOURCE_IMAGE_OPTIONS           = 'image.options';
-
-    const RESOURCE_IMAGES_GET              = 'images.get';
-    const RESOURCE_IMAGES_HEAD             = 'images.head';
-    const RESOURCE_IMAGES_POST             = 'images.post';
-    const RESOURCE_IMAGES_OPTIONS          = 'images.options';
-
-    const RESOURCE_GLOBAL_IMAGES_GET       = 'globalimages.get';
-    const RESOURCE_GLOBAL_IMAGES_HEAD      = 'globalimages.head';
-    const RESOURCE_GLOBAL_IMAGES_OPTIONS   = 'globalimages.options';
-
-    const RESOURCE_METADATA_GET            = 'metadata.get';
-    const RESOURCE_METADATA_HEAD           = 'metadata.head';
-    const RESOURCE_METADATA_PUT            = 'metadata.put';
-    const RESOURCE_METADATA_POST           = 'metadata.post';
-    const RESOURCE_METADATA_DELETE         = 'metadata.delete';
-    const RESOURCE_METADATA_OPTIONS        = 'metadata.options';
-
-    const RESOURCE_SHORTURL_GET            = 'shorturl.get';
-    const RESOURCE_SHORTURL_HEAD           = 'shorturl.head';
-    const RESOURCE_SHORTURL_DELETE         = 'shorturl.delete';
-    const RESOURCE_SHORTURL_OPTIONS        = 'shorturl.options';
-
-    const RESOURCE_SHORTURLS_POST          = 'shorturls.post';
-    const RESOURCE_SHORTURLS_DELETE        = 'shorturls.delete';
-    const RESOURCE_SHORTURLS_OPTIONS       = 'shorturls.options';
-
     /**
      * Get a list of users the public key has access for on a given resource
      *
@@ -146,25 +87,4 @@ interface AdapterInterface {
      * @return array Access rule
      */
     function getAccessRule($publicKey, $accessRuleId);
-
-    /**
-     * Returns a list of resources which should be accessible for read-only public keys
-     *
-     * @return array
-     */
-    static function getReadOnlyResources();
-
-    /**
-     * Returns a list of resources which should be accessible for read+write public keys
-     *
-     * @return array
-     */
-    static function getReadWriteResources();
-
-    /**
-     * Returns a list of all resources available, including those which involves access control
-     *
-     * @return array
-     */
-    static function getAllResources();
 }

--- a/library/Imbo/Auth/AccessControl/Adapter/SimpleArrayAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/SimpleArrayAdapter.php
@@ -11,7 +11,8 @@
 namespace Imbo\Auth\AccessControl\Adapter;
 
 use Imbo\Exception\InvalidArgumentException,
-    Imbo\Auth\AccessControl\GroupQuery;
+    Imbo\Auth\AccessControl\GroupQuery,
+    Imbo\Resource;
 
 /**
  * Simple array-backed access control adapter
@@ -55,7 +56,7 @@ class SimpleArrayAdapter extends ArrayAdapter implements AdapterInterface {
                 'publicKey'  => $publicKey,
                 'privateKey' => $privateKey,
                 'acl' => [[
-                    'resources' => $this->getReadWriteResources(),
+                    'resources' => Resource::getReadWriteResources(),
                     'users' => [$publicKey]
                 ]]
             ];

--- a/library/Imbo/EventListener/AccessControl.php
+++ b/library/Imbo/EventListener/AccessControl.php
@@ -15,7 +15,8 @@ use Imbo\EventManager\EventInterface,
     Imbo\Exception\RuntimeException,
     Imbo\Auth\AccessControl\AccessControlAdapter,
     Imbo\Auth\AccessControl\GroupQuery,
-    Imbo\Model\Groups as GroupsModel;
+    Imbo\Model\Groups as GroupsModel,
+    Imbo\Resource;
 
 /**
  * Access control event listener
@@ -65,7 +66,7 @@ class AccessControl implements ListenerInterface {
      * @param EventInterface $event
      */
     public function subscribe(EventInterface $event) {
-        $resources = $event->getAccessControl()->getAllResources();
+        $resources = Resource::getAllResources();
 
         if ($this->params['additionalResources']) {
             $resources = array_merge($resources, $this->params['additionalResources']);

--- a/library/Imbo/Resource.php
+++ b/library/Imbo/Resource.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo;
+
+/**
+ * Resource class
+ *
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @package Core
+ */
+class Resource {
+    const GROUPS_GET              = 'groups.get';
+    const GROUPS_HEAD             = 'groups.head';
+    const GROUPS_OPTIONS          = 'groups.options';
+
+    const GROUP_GET               = 'group.get';
+    const GROUP_HEAD              = 'group.head';
+    const GROUP_PUT               = 'group.put';
+    const GROUP_DELETE            = 'group.delete';
+    const GROUP_OPTIONS           = 'group.options';
+
+    const KEYS_PUT                = 'keys.put';
+    const KEYS_HEAD               = 'keys.head';
+    const KEYS_DELETE             = 'keys.delete';
+    const KEYS_OPTIONS            = 'keys.options';
+
+    const ACCESS_RULE_GET         = 'accessrule.get';
+    const ACCESS_RULE_HEAD        = 'accessrule.head';
+    const ACCESS_RULE_DELETE      = 'accessrule.delete';
+    const ACCESS_RULE_OPTIONS     = 'accessrule.options';
+
+    const ACCESS_RULES_GET        = 'accessrules.get';
+    const ACCESS_RULES_HEAD       = 'accessrules.head';
+    const ACCESS_RULES_POST       = 'accessrules.post';
+    const ACCESS_RULES_OPTIONS    = 'accessrules.options';
+
+    const USER_GET                = 'user.get';
+    const USER_HEAD               = 'user.head';
+    const USER_OPTIONS            = 'user.options';
+
+    const IMAGE_GET               = 'image.get';
+    const IMAGE_HEAD              = 'image.head';
+    const IMAGE_DELETE            = 'image.delete';
+    const IMAGE_OPTIONS           = 'image.options';
+
+    const IMAGES_GET              = 'images.get';
+    const IMAGES_HEAD             = 'images.head';
+    const IMAGES_POST             = 'images.post';
+    const IMAGES_OPTIONS          = 'images.options';
+
+    const GLOBAL_IMAGES_GET       = 'globalimages.get';
+    const GLOBAL_IMAGES_HEAD      = 'globalimages.head';
+    const GLOBAL_IMAGES_OPTIONS   = 'globalimages.options';
+
+    const METADATA_GET            = 'metadata.get';
+    const METADATA_HEAD           = 'metadata.head';
+    const METADATA_PUT            = 'metadata.put';
+    const METADATA_POST           = 'metadata.post';
+    const METADATA_DELETE         = 'metadata.delete';
+    const METADATA_OPTIONS        = 'metadata.options';
+
+    const SHORTURL_GET            = 'shorturl.get';
+    const SHORTURL_HEAD           = 'shorturl.head';
+    const SHORTURL_DELETE         = 'shorturl.delete';
+    const SHORTURL_OPTIONS        = 'shorturl.options';
+
+    const SHORTURLS_POST          = 'shorturls.post';
+    const SHORTURLS_DELETE        = 'shorturls.delete';
+    const SHORTURLS_OPTIONS       = 'shorturls.options';
+
+    /**
+     * Returns a list of resources which should be accessible for read-only public keys
+     *
+     * @return array
+     */
+    final public static function getReadOnlyResources() {
+        return [
+            self::USER_GET,
+            self::USER_HEAD,
+            self::USER_OPTIONS,
+
+            self::IMAGE_GET,
+            self::IMAGE_HEAD,
+            self::IMAGE_OPTIONS,
+
+            self::GROUPS_GET,
+            self::GROUPS_HEAD,
+            self::GROUPS_OPTIONS,
+
+            self::IMAGES_GET,
+            self::IMAGES_HEAD,
+            self::IMAGES_OPTIONS,
+
+            self::METADATA_GET,
+            self::METADATA_HEAD,
+            self::METADATA_OPTIONS,
+
+            self::SHORTURL_GET,
+            self::SHORTURL_HEAD,
+            self::SHORTURL_OPTIONS,
+
+            self::GLOBAL_IMAGES_GET,
+            self::GLOBAL_IMAGES_HEAD,
+            self::GLOBAL_IMAGES_OPTIONS,
+
+            self::SHORTURLS_OPTIONS,
+        ];
+    }
+
+    /**
+     * Returns a list of resources which should be accessible for read+write public keys
+     *
+     * @return array
+     */
+    final public static function getReadWriteResources() {
+        return array_merge(
+            self::getReadOnlyResources(), [
+                self::IMAGE_DELETE,
+                self::IMAGES_POST,
+
+                self::METADATA_POST,
+                self::METADATA_DELETE,
+                self::METADATA_PUT,
+
+                self::SHORTURL_DELETE,
+
+                self::SHORTURLS_POST,
+                self::SHORTURLS_DELETE,
+            ]
+        );
+    }
+
+    /**
+     * Returns a list of all resources available, including those which involves access control
+     *
+     * @return array
+     */
+    final public static function getAllResources() {
+        return array_merge(
+            self::getReadWriteResources(), [
+                self::KEYS_PUT,
+                self::KEYS_HEAD,
+                self::KEYS_DELETE,
+                self::KEYS_OPTIONS,
+
+                self::ACCESS_RULE_GET,
+                self::ACCESS_RULE_HEAD,
+                self::ACCESS_RULE_DELETE,
+                self::ACCESS_RULE_OPTIONS,
+
+                self::ACCESS_RULES_GET,
+                self::ACCESS_RULES_HEAD,
+                self::ACCESS_RULES_POST,
+                self::ACCESS_RULES_OPTIONS,
+            ]
+        );
+    }
+}

--- a/library/ImboCli/Command/AddPublicKey.php
+++ b/library/ImboCli/Command/AddPublicKey.php
@@ -18,8 +18,8 @@ use Symfony\Component\Console\Command\Command as BaseCommand,
     Symfony\Component\Console\Question\ConfirmationQuestion,
     Symfony\Component\Console\Output\OutputInterface,
     Imbo\Auth\AccessControl\Adapter\AdapterInterface,
-    Imbo\Auth\AccessControl\Adapter\AbstractAdapter,
     Imbo\Auth\AccessControl\Adapter\MutableAdapterInterface,
+    Imbo\Resource,
     RuntimeException;
 
 /**
@@ -121,11 +121,11 @@ class AddPublicKey extends Command {
         $type = $this->getHelper('question')->ask($input, $output, $question);
         switch ($type) {
             case self::RESOURCES_READ_ONLY:
-                return AbstractAdapter::getReadOnlyResources();
+                return Resource::getReadOnlyResources();
             case self::RESOURCES_READ_WRITE:
-                return AbstractAdapter::getReadWriteResources();
+                return Resource::getReadWriteResources();
             case self::RESOURCES_ALL:
-                return AbstractAdapter::getAllResources();
+                return Resource::getAllResources();
         }
 
         return $this->askForSpecificResources($input, $output);
@@ -139,7 +139,7 @@ class AddPublicKey extends Command {
      * @return array
      */
     private function askForSpecificResources(InputInterface $input, OutputInterface $output) {
-        $resources = AbstractAdapter::getAllResources();
+        $resources = Resource::getAllResources();
         sort($resources);
 
         $question = new ChoiceQuestion(

--- a/tests/behat/fixtures/access-control-mutable.php
+++ b/tests/behat/fixtures/access-control-mutable.php
@@ -1,5 +1,5 @@
 <?php
-use Imbo\Auth\AccessControl\Adapter\AdapterInterface as ACI;
+use Imbo\Resource;
 
 return [
     'accesscontrol' => [
@@ -10,17 +10,17 @@ return [
                 [
                     'id' => new MongoId(),
                     'resources' => [
-                        ACI::RESOURCE_KEYS_PUT,
-                        ACI::RESOURCE_KEYS_HEAD,
-                        ACI::RESOURCE_KEYS_DELETE,
+                        Resource::KEYS_PUT,
+                        Resource::KEYS_HEAD,
+                        Resource::KEYS_DELETE,
 
-                        ACI::RESOURCE_ACCESS_RULE_GET,
-                        ACI::RESOURCE_ACCESS_RULE_HEAD,
-                        ACI::RESOURCE_ACCESS_RULE_DELETE,
+                        Resource::ACCESS_RULE_GET,
+                        Resource::ACCESS_RULE_HEAD,
+                        Resource::ACCESS_RULE_DELETE,
 
-                        ACI::RESOURCE_ACCESS_RULES_GET,
-                        ACI::RESOURCE_ACCESS_RULES_HEAD,
-                        ACI::RESOURCE_ACCESS_RULES_POST,
+                        Resource::ACCESS_RULES_GET,
+                        Resource::ACCESS_RULES_HEAD,
+                        Resource::ACCESS_RULES_POST,
                     ],
                     'users' => []
                 ],
@@ -83,7 +83,7 @@ return [
             'privateKey' => 'foobar',
             'acl' => [[
                 'id' => new MongoId(),
-                'resources' => [ACI::RESOURCE_ACCESS_RULE_GET],
+                'resources' => [Resource::ACCESS_RULE_GET],
                 'users' => [],
             ]]
         ]

--- a/tests/behat/imbo-configs/access-control.php
+++ b/tests/behat/imbo-configs/access-control.php
@@ -8,11 +8,11 @@
  * distributed with this source code.
  */
 
-use Imbo\Auth\AccessControl\Adapter\AdapterInterface as ACI,
-    Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
+use Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
     Imbo\Resource\ResourceInterface,
     Imbo\EventManager\EventInterface,
-    Imbo\Model\ListModel;
+    Imbo\Model\ListModel,
+    Imbo\Resource;
 
 class Foobar implements ResourceInterface {
     public function getAllowedMethods() {
@@ -45,16 +45,16 @@ return [
                     'resources' => [
                         'foobar.get',
 
-                        ACI::RESOURCE_USER_GET,
-                        ACI::RESOURCE_KEYS_PUT,
-                        ACI::RESOURCE_KEYS_HEAD,
-                        ACI::RESOURCE_KEYS_DELETE,
-                        ACI::RESOURCE_ACCESS_RULE_GET,
-                        ACI::RESOURCE_ACCESS_RULE_HEAD,
-                        ACI::RESOURCE_ACCESS_RULE_DELETE,
-                        ACI::RESOURCE_ACCESS_RULES_GET,
-                        ACI::RESOURCE_ACCESS_RULES_HEAD,
-                        ACI::RESOURCE_ACCESS_RULES_POST
+                        Resource::USER_GET,
+                        Resource::KEYS_PUT,
+                        Resource::KEYS_HEAD,
+                        Resource::KEYS_DELETE,
+                        Resource::ACCESS_RULE_GET,
+                        Resource::ACCESS_RULE_HEAD,
+                        Resource::ACCESS_RULE_DELETE,
+                        Resource::ACCESS_RULES_GET,
+                        Resource::ACCESS_RULES_HEAD,
+                        Resource::ACCESS_RULES_POST
                     ],
                 ]]
             ],
@@ -63,7 +63,7 @@ return [
                 'publicKey' => 'valid-pubkey-with-wildcard',
                 'privateKey' => 'foobar',
                 'acl' => [[
-                    'resources' => [ACI::RESOURCE_USER_GET, 'foobar.get'],
+                    'resources' => [Resource::USER_GET, 'foobar.get'],
                     'users' => '*',
                 ]]
             ],
@@ -84,15 +84,15 @@ return [
                 'publicKey' => 'acl-checker',
                 'privateKey' => 'foobar',
                 'acl' => [[
-                    'resources' => [ACI::RESOURCE_ACCESS_RULE_GET],
+                    'resources' => [Resource::ACCESS_RULE_GET],
                     'users' => [],
                 ]]
             ]
         ], [
-            'images-read' => [ACI::RESOURCE_IMAGES_GET],
+            'images-read' => [Resource::IMAGES_GET],
             'groups-read' => [
-                ACI::RESOURCE_GROUPS_GET,
-                ACI::RESOURCE_GROUPS_HEAD
+                Resource::GROUPS_GET,
+                Resource::GROUPS_HEAD
             ],
         ]);
     },

--- a/tests/behat/imbo-configs/config.testing.php
+++ b/tests/behat/imbo-configs/config.testing.php
@@ -8,8 +8,8 @@
  * distributed with this source code.
  */
 
-use Imbo\Auth\AccessControl\Adapter\AdapterInterface as ACI,
-    Imbo\Auth\AccessControl\Adapter\ArrayAdapter;
+use Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
+    Imbo\Resource;
 
 // Default config for testing
 $testConfig = [
@@ -19,7 +19,7 @@ $testConfig = [
                 'publicKey' => 'publickey',
                 'privateKey' => 'privatekey',
                 'acl' => [[
-                    'resources' => ArrayAdapter::getReadWriteResources(),
+                    'resources' => Resource::getReadWriteResources(),
                     'users' => ['user', 'other-user'],
                 ]]
             ],
@@ -27,7 +27,7 @@ $testConfig = [
                 'publicKey' => 'unpriviledged',
                 'privateKey' => 'privatekey',
                 'acl' => [[
-                    'resources' => ArrayAdapter::getReadWriteResources(),
+                    'resources' => Resource::getReadWriteResources(),
                     'users' => ['user'],
                 ]]
             ],
@@ -35,7 +35,7 @@ $testConfig = [
                 'publicKey' => 'wildcard',
                 'privateKey' => '*',
                 'acl' => [[
-                    'resources' => ArrayAdapter::getReadWriteResources(),
+                    'resources' => Resource::getReadWriteResources(),
                     'users' => '*'
                 ]]
             ]

--- a/tests/behat/imbo-configs/ro-rw-auth.php
+++ b/tests/behat/imbo-configs/ro-rw-auth.php
@@ -8,7 +8,8 @@
  * distributed with this source code.
  */
 
-use Imbo\Auth\AccessControl\Adapter\ArrayAdapter;
+use Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
+    Imbo\Resource;
 
 /**
  * Use individual read-only/read+write keys
@@ -20,7 +21,7 @@ return [
                 'publicKey'  => 'ro-pubkey',
                 'privateKey' => 'read-only-key',
                 'acl' => [[
-                    'resources' => ArrayAdapter::getReadOnlyResources(),
+                    'resources' => Resource::getReadOnlyResources(),
                     'users' => ['someuser'],
                 ]]
             ],
@@ -29,7 +30,7 @@ return [
                 'publicKey'  => 'rw-pubkey',
                 'privateKey' => 'read+write-key',
                 'acl' => [[
-                    'resources' => ArrayAdapter::getReadWriteResources(),
+                    'resources' => Resource::getReadWriteResources(),
                     'users' => ['someuser'],
                 ]]
             ],
@@ -38,7 +39,7 @@ return [
                 'publicKey'  => 'foo',
                 'privateKey' => 'bar',
                 'acl' => [[
-                    'resources' => ArrayAdapter::getReadOnlyResources(),
+                    'resources' => Resource::getReadOnlyResources(),
                     'users' => ['user'],
                 ]]
             ]

--- a/tests/phpunit/ImboCliUnitTest/Command/AddPublicKeyTest.php
+++ b/tests/phpunit/ImboCliUnitTest/Command/AddPublicKeyTest.php
@@ -12,7 +12,7 @@ namespace ImboCliUnitTest\Command;
 
 use ImboCli\Command\AddPublicKey,
     Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
-    Imbo\Auth\AccessControl\Adapter\AbstractAdapter,
+    Imbo\Resource,
     Symfony\Component\Console\Application,
     Symfony\Component\Console\Tester\CommandTester;
 
@@ -175,7 +175,7 @@ class AddPublicKeyTest extends \PHPUnit_Framework_TestCase {
                         count($rule['users']) === 2 &&
                         in_array('espenh', $rule['users']) &&
                         in_array('kribrabr', $rule['users']) &&
-                        empty(array_diff($rule['resources'], AbstractAdapter::getReadOnlyResources()))
+                        empty(array_diff($rule['resources'], Resource::getReadOnlyResources()))
                     );
                 })],
                 [$this->equalTo('foo'), $this->callback(function($rule) {
@@ -183,13 +183,13 @@ class AddPublicKeyTest extends \PHPUnit_Framework_TestCase {
                         count($rule['users']) === 2 &&
                         in_array('rexxars', $rule['users']) &&
                         in_array('kbrabrand', $rule['users']) &&
-                        empty(array_diff($rule['resources'], AbstractAdapter::getReadWriteResources()))
+                        empty(array_diff($rule['resources'], Resource::getReadWriteResources()))
                     );
                 })],
                 [$this->equalTo('foo'), $this->callback(function($rule) {
                     return (
                         $rule['users'] === '*' &&
-                        empty(array_diff($rule['resources'], AbstractAdapter::getAllResources()))
+                        empty(array_diff($rule['resources'], Resource::getAllResources()))
                     );
                 })]
             );
@@ -220,7 +220,7 @@ class AddPublicKeyTest extends \PHPUnit_Framework_TestCase {
      * @covers ImboCli\Command\AddPublicKey::askForUsers
      */
     public function testPromptsForListOfSpecificResourcesIfOptionIsSelected() {
-        $allResources = AbstractAdapter::getAllResources();
+        $allResources = Resource::getAllResources();
         sort($allResources);
 
         $this->adapter

--- a/tests/phpunit/ImboUnitTest/Auth/AccessControl/Adapter/ArrayAdapterTest.php
+++ b/tests/phpunit/ImboUnitTest/Auth/AccessControl/Adapter/ArrayAdapterTest.php
@@ -11,7 +11,7 @@
 namespace ImboUnitTest\Auth\AccessControl\Adapter;
 
 use Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
-    Imbo\Auth\AccessControl\Adapter\AdapterInterface as ACI;
+    Imbo\Resource;
 
 /**
  * @covers Imbo\Auth\AccessControl\Adapter\ArrayAdapter
@@ -24,7 +24,7 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
                 'publicKey' => 'pubKey1',
                 'privateKey' => 'privateKey1',
                 'acl' => [[
-                    'resources' => [ACI::RESOURCE_IMAGES_GET],
+                    'resources' => [Resource::IMAGES_GET],
                     'users' => ['user1', 'user2'],
                 ]]
             ],
@@ -32,7 +32,7 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
                 'publicKey' => 'pubKey2',
                 'privateKey' => 'privateKey2',
                 'acl' => [[
-                    'resources' => [ACI::RESOURCE_IMAGES_GET],
+                    'resources' => [Resource::IMAGES_GET],
                     'users' => ['user2', 'user3', '*'],
                 ]]
             ]
@@ -40,12 +40,12 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEquals(
             ['user1', 'user2'],
-            $accessControl->getUsersForResource('pubKey1', ACI::RESOURCE_IMAGES_GET)
+            $accessControl->getUsersForResource('pubKey1', Resource::IMAGES_GET)
         );
 
         $this->assertEquals(
             ['user1', 'user2'],
-            $accessControl->getUsersForResource('pubKey1', ACI::RESOURCE_IMAGES_GET)
+            $accessControl->getUsersForResource('pubKey1', Resource::IMAGES_GET)
         );
     }
 
@@ -55,7 +55,7 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
                 'publicKey' => 'pubKey1',
                 'privateKey' => 'privateKey1',
                 'acl' => [[
-                    'resources' => [ACI::RESOURCE_IMAGES_POST],
+                    'resources' => [Resource::IMAGES_POST],
                     'users' => ['user1'],
                 ]]
             ],
@@ -63,7 +63,7 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
                 'publicKey' => 'pubKey2',
                 'privateKey' => 'privateKey2',
                 'acl' => [[
-                    'resources' => [ACI::RESOURCE_IMAGES_POST],
+                    'resources' => [Resource::IMAGES_POST],
                     'users' => ['user2'],
                 ]]
             ]
@@ -89,18 +89,18 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
 
         $groups = [
             'user-stats' => [
-                ACI::RESOURCE_USER_GET,
-                ACI::RESOURCE_USER_HEAD
+                Resource::USER_GET,
+                Resource::USER_HEAD
             ]
         ];
 
         $ac = new ArrayAdapter($acl, $groups);
 
-        $this->assertFalse($ac->hasAccess('pubkey', ACI::RESOURCE_IMAGES_POST, 'user1'));
-        $this->assertFalse($ac->hasAccess('pubkey', ACI::RESOURCE_IMAGES_POST));
-        $this->assertFalse($ac->hasAccess('pubkey', ACI::RESOURCE_USER_GET, 'user2'));
-        $this->assertTrue($ac->hasAccess('pubkey', ACI::RESOURCE_USER_HEAD, 'user1'));
-        $this->assertTrue($ac->hasAccess('pubkey', ACI::RESOURCE_USER_GET, 'user1'));
+        $this->assertFalse($ac->hasAccess('pubkey', Resource::IMAGES_POST, 'user1'));
+        $this->assertFalse($ac->hasAccess('pubkey', Resource::IMAGES_POST));
+        $this->assertFalse($ac->hasAccess('pubkey', Resource::USER_GET, 'user2'));
+        $this->assertTrue($ac->hasAccess('pubkey', Resource::USER_HEAD, 'user1'));
+        $this->assertTrue($ac->hasAccess('pubkey', Resource::USER_GET, 'user1'));
     }
 
     public function testCanReadResourcesGrantedUsingWildcard() {
@@ -110,16 +110,16 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
                 'privateKey' => 'privkey',
                 'acl' => [
                     [
-                        'resources' => [ACI::RESOURCE_IMAGES_GET],
+                        'resources' => [Resource::IMAGES_GET],
                         'users' => '*'
                     ]
                 ]
             ]
         ]);
 
-        $this->assertTrue($accessControl->hasAccess('pubkey', ACI::RESOURCE_IMAGES_GET, 'user1'));
-        $this->assertTrue($accessControl->hasAccess('pubkey', ACI::RESOURCE_IMAGES_GET, 'user2'));
-        $this->assertFalse($accessControl->hasAccess('pubkey', ACI::RESOURCE_IMAGES_POST, 'user2'));
+        $this->assertTrue($accessControl->hasAccess('pubkey', Resource::IMAGES_GET, 'user1'));
+        $this->assertTrue($accessControl->hasAccess('pubkey', Resource::IMAGES_GET, 'user2'));
+        $this->assertFalse($accessControl->hasAccess('pubkey', Resource::IMAGES_POST, 'user2'));
     }
 
     /**

--- a/tests/phpunit/ImboUnitTest/Auth/AccessControl/Adapter/SimpleArrayAdapterTest.php
+++ b/tests/phpunit/ImboUnitTest/Auth/AccessControl/Adapter/SimpleArrayAdapterTest.php
@@ -12,7 +12,7 @@ namespace ImboUnitTest\Auth\AccessControl\Adapter;
 
 use Imbo\Auth\AccessControl\Adapter\ArrayAdapter,
     Imbo\Auth\AccessControl\Adapter\SimpleArrayAdapter,
-    Imbo\Auth\AccessControl\Adapter\AdapterInterface as ACI;
+    Imbo\Resource;
 
 /**
  * @covers Imbo\Auth\AccessControl\Adapter\SimpleArrayAdapter
@@ -46,7 +46,7 @@ class SimpleArrayAdapterTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue(
             $accessControl->hasAccess(
                 'publicKey',
-                ACI::RESOURCE_IMAGES_POST,
+                Resource::IMAGES_POST,
                 'publicKey'
             )
         );


### PR DESCRIPTION
It suddenly dawned on me today that the constants defining the different resources have no business in the access control part of Imbo. They are merely names of events that trigger the corresponding resource to do their thing. This PR moves the constants and the corresponding getters to a separate class, `Resource` that basically does the exact same thing.

Important to get this in before 2.0 lands to prevent breaking peoples configuration files etc.