### PR TITLE
Make crop transformation stricter

### DIFF
--- a/library/Imbo/Image/Transformation/Crop.php
+++ b/library/Imbo/Image/Transformation/Crop.php
@@ -71,15 +71,6 @@ class Crop extends Transformation implements ListenerInterface {
         $imageWidth = $image->getWidth();
         $imageHeight = $image->getHeight();
 
-        // Fix too large values for width and/or height
-        if ($width > $imageWidth) {
-            $width = $imageWidth;
-        }
-
-        if ($height > $imageHeight) {
-            $height = $imageHeight;
-        }
-
         // Set correct x and/or y values based on the crop mode
         if ($mode === 'center' || $mode === 'center-x') {
             $x = (int) ($imageWidth - $width) / 2;
@@ -87,6 +78,13 @@ class Crop extends Transformation implements ListenerInterface {
 
         if ($mode === 'center' || $mode === 'center-y') {
             $y = (int) ($imageHeight - $height) / 2;
+        }
+
+        // Throw exception on X/Y values that are out of bounds
+        if ($x + $width > $imageWidth) {
+            throw new TransformationException('Crop area is out of bounds (`x` + `width` > image width)', 400);
+        } else if ($y + $height > $imageHeight) {
+            throw new TransformationException('Crop area is out of bounds (`y` + `height` > image height)', 400);
         }
 
         // Return if there is no need for cropping

--- a/tests/behat/features/image-transformations.feature
+++ b/tests/behat/features/image-transformations.feature
@@ -34,9 +34,9 @@ Feature: Imbo enables dynamic transformations of images
             | contrast:sharpen:-1                                                                               | 599   | 417    |
             | contrast:sharpen:1                                                                                | 599   | 417    |
             | crop:width=50,height=60,x=1,y=10                                                                  | 50    | 60     |
-            | crop:width=5000,height=6000,x=0,y=0                                                               | 599   | 417    |
+            | crop:width=599,height=417,x=0,y=0                                                                 | 599   | 417    |
             | crop:mode=center,width=100,height=100                                                             | 100   | 100    |
-            | crop:mode=center,width=6000,height=5000                                                           | 599   | 417    |
+            | crop:mode=center,width=599,height=417                                                             | 599   | 417    |
             | crop:mode=center-x,y=10,width=123,height=20                                                       | 123   | 20     |
             | crop:mode=center-y,x=10,width=234,height=30                                                       | 234   | 30     |
             | desaturate                                                                                        | 599   | 417    |
@@ -105,7 +105,7 @@ Feature: Imbo enables dynamic transformations of images
             | canvas:width=700,height=600                                                                       |
             | contrast:sharpen=1                                                                                |
             | crop:width=50,height=60,x=1,y=10                                                                  |
-            | crop:width=5000,height=6000,x=0,y=0                                                               |
+            | crop:width=599,height=417,x=0,y=0                                                                 |
             | desaturate                                                                                        |
             | drawPois                                                                                          |
             | flipHorizontally                                                                                  |

--- a/tests/phpunit/ImboIntegrationTest/Image/Transformation/CropTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Image/Transformation/CropTest.php
@@ -33,13 +33,11 @@ class CropTest extends TransformationTests {
      */
     public function getCropParams() {
         return [
-            'cropped area larger than the image' => [['width' => 1000, 'height' => 1000], 665, 463, false],
             'cropped area smaller than the image' => [['width' => 100, 'height' => 50], 100, 50, true],
-            'cropped area smaller than the image with x and y offset' => [['width' => 100, 'height' => 100, 'x' => 600, 'y' => 400], 65, 63, true],
+            'cropped area smaller than the image with x and y offset' => [['width' => 100, 'height' => 63, 'x' => 565, 'y' => 400], 100, 63, true],
             'center mode' => [['mode' => 'center', 'width' => 150, 'height' => 100], 150, 100, true],
             'center-x mode' => [['mode' => 'center-x', 'y' => 10, 'width' => 50, 'height' => 40], 50, 40, true],
             'center-y mode' => [['mode' => 'center-y', 'x' => 10, 'width' => 50, 'height' => 40], 50, 40, true],
-            'center mode with cropped area larger than the image' => [['mode' => 'center', 'width' => 1000, 'height' => 1000], 665, 463, false],
         ];
     }
 

--- a/tests/phpunit/ImboUnitTest/Image/Transformation/CropTest.php
+++ b/tests/phpunit/ImboUnitTest/Image/Transformation/CropTest.php
@@ -55,10 +55,9 @@ class CropTest extends \PHPUnit_Framework_TestCase {
      */
     public function getImageParams() {
         return [
-            'Do not perform work when cropping same sized images' => [['width' => 123, 'height' => 234], 123, 234, 0, 0, false],
-            'Do not perform work when getting a larger crop than image' => [['width' => 5123, 'height' => 5234], 123, 234, 0, 0, false],
-            'Create new cropped image #1' => [['width' => 123, 'height' => 234, 'y' => 10], 123, 234, 0, 10],
-            'Create new cropped image #2' => [['width' => 123, 'height' => 234, 'x' => 10, 'y' => 20], 123, 234, 10, 20],
+            'Do not perform work when cropping same sized images' => [['width' => 123, 'height' => 234], 123, 234, 123, 234, 0, 0, false],
+            'Create new cropped image #1' => [['width' => 100, 'height' => 200, 'y' => 10], 100, 400, 100, 200, 0, 10],
+            'Create new cropped image #2' => [['width' => 123, 'height' => 234, 'x' => 10, 'y' => 20], 200, 260, 123, 234, 10, 20],
         ];
     }
 
@@ -66,12 +65,12 @@ class CropTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider getImageParams
      * @covers Imbo\Image\Transformation\Crop::transform
      */
-    public function testUsesAllParamsWithImagick($params, $width, $height, $x = 0, $y = 0, $shouldCrop = true) {
+    public function testUsesAllParams($params, $originalWidth, $originalHeight, $width, $height, $x = 0, $y = 0, $shouldCrop = true) {
         $image = $this->getMock('Imbo\Model\Image');
         $imagick = $this->getMock('Imagick');
 
-        $image->expects($this->any())->method('getWidth')->will($this->returnValue($width));
-        $image->expects($this->any())->method('getHeight')->will($this->returnValue($height));
+        $image->expects($this->any())->method('getWidth')->will($this->returnValue($originalWidth));
+        $image->expects($this->any())->method('getHeight')->will($this->returnValue($originalHeight));
 
         if ($shouldCrop) {
             $image->expects($this->once())->method('setWidth')->with($width)->will($this->returnSelf());
@@ -81,6 +80,53 @@ class CropTest extends \PHPUnit_Framework_TestCase {
             $imagick->expects($this->once())->method('getImageGeometry')->will($this->returnValue(['width' => $width, 'height' => $height]));
         } else {
             $imagick->expects($this->never())->method('cropImage');
+        }
+
+        $event = $this->getMock('Imbo\EventManager\Event');
+        $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
+        $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue($params));
+
+        $crop = new Crop();
+        $crop->setImagick($imagick)->transform($event);
+    }
+
+    /**
+     * Fetch different invalid image parameters
+     *
+     * @return array[]
+     */
+    public function getInvalidImageParams() {
+        return [
+            'Dont throw if width/height are within bounds (no coords)' => [['width' => 100, 'height' => 100], 200, 200, false],
+            'Dont throw if coords are within bounds' => [['width' => 100, 'height' => 100, 'x' => 100, 'y' => 100], 200, 200, false],
+            'Throw if width is out of bounds'  => [['width' => 300, 'height' => 100], 200, 200, '#image width#i'],
+            'Throw if height is out of bounds' => [['width' => 100, 'height' => 300], 200, 200, '#image height#i'],
+            'Throw if X is out of bounds'  => [['width' => 100, 'height' => 100, 'x' => 500], 200, 200, '#image width#i'],
+            'Throw if Y is out of bounds'  => [['width' => 100, 'height' => 100, 'y' => 500], 200, 200, '#image height#i'],
+            'Throw if X + width is out of bounds'  => [['width' => 100, 'height' => 100, 'x' => 105], 200, 200, '#image width#i'],
+            'Throw if Y + height is out of bounds' => [['width' => 100, 'height' => 100, 'y' => 105], 200, 200, '#image height#i'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidImageParams
+     * @covers Imbo\Image\Transformation\Crop::transform
+     */
+    public function testThrowsOnInvalidCropParams($params, $originalWidth, $originalHeight, $errRegex) {
+        $image = $this->getMock('Imbo\Model\Image');
+        $imagick = $this->getMock('Imagick');
+
+        $image->expects($this->any())->method('getWidth')->will($this->returnValue($originalWidth));
+        $image->expects($this->any())->method('getHeight')->will($this->returnValue($originalHeight));
+
+        if ($errRegex) {
+            $this->setExpectedExceptionRegExp('Imbo\Exception\TransformationException', $errRegex);
+            $imagick->expects($this->never())->method('cropImage');
+        } else {
+            $image->expects($this->once())->method('setWidth')->will($this->returnSelf());
+            $image->expects($this->once())->method('setHeight')->will($this->returnSelf());
+
+            $imagick->expects($this->once())->method('cropImage');
         }
 
         $event = $this->getMock('Imbo\EventManager\Event');


### PR DESCRIPTION
Currently, the crop transformation is very "forgiving". It doesn't let you know if what you are doing makes no sense. I think this is a bit confusing. An example:

If I have an image that is 1024x768, and I ask for a crop that is 2048x1536, with an `x`-offset of `300` and a `y` offset of `20`, what will it return to me? I don't actually know. Most likely it will return me an image that is 724x748 pixels large. Is this what I wanted? Probably not.

In my humble opinion, it's better to be strict. With this pull request (which is not backwards compatible, obviously), crops performed out of bounds will throw an error. That includes:

* Crops that are too large (width and height)
* X and Y that are outside of the image size
* Crops that is larger than the image when combining the offsets with the dimensions of the image

I think this makes it much easier to debug any problems that occur, since it might be hard to spot the error when you get back some fairly random image from the server.

Don't want to merge this without having cleared it with the team first, though.
@christeredvartsen ?
@kbrabrand ?
@matslindh ?
@androa ?
