### PR TITLE
Move `hasAccess()` to abstract ACL adapter

### DIFF
--- a/library/Imbo/Auth/AccessControl/Adapter/AbstractAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/AbstractAdapter.php
@@ -24,15 +24,51 @@ abstract class AbstractAdapter implements AdapterInterface {
     /**
      * {@inheritdoc}
      */
-    abstract public function hasAccess($publicKey, $resource, $user = null);
-
-    /**
-     * {@inheritdoc}
-     */
     abstract public function getGroups(GroupQuery $query = null, GroupsModel $model);
 
     /**
      * {@inheritdoc}
      */
     abstract public function getGroup($groupName);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAccess($publicKey, $resource, $user = null) {
+        $accessList = $this->getAccessListForPublicKey($publicKey) ?: [];
+
+        foreach ($accessList as $acl) {
+            // If the group specified has not been defined, throw an exception to help the user
+            if (!isset($acl['users'])) {
+                throw new InvalidArgumentException('Missing property "users" in access rule', 500);
+            }
+
+            // If a user is specified, ensure the public key has access to the user
+            $userAccess = !$user || $acl['users'] === '*' || in_array($user, $acl['users']);
+            if (!$userAccess) {
+                continue;
+            }
+
+            // Figure out which resources the public key has access to, based on group or
+            // explicit definition
+            $resources = isset($acl['resources']) ? $acl['resources'] : [];
+            $group = isset($acl['group']) ? $acl['group'] : false;
+
+            // If we the rule contains a group, get resource from it
+            if ($group) {
+                $resources = $this->getGroup($group);
+
+                // If the group has not been defined, throw an exception to help debug the problem
+                if ($resources === false) {
+                    throw new InvalidArgumentException('Group "' . $group . '" is not defined', 500);
+                }
+            }
+
+            if (in_array($resource, $resources)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/library/Imbo/Auth/AccessControl/Adapter/ArrayAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/ArrayAdapter.php
@@ -91,51 +91,6 @@ class ArrayAdapter extends AbstractAdapter implements AdapterInterface {
     /**
      * {@inheritdoc}
      */
-    public function hasAccess($publicKey, $resource, $user = null) {
-        foreach ($this->accessList as $access) {
-            if ($access['publicKey'] !== $publicKey) {
-                continue;
-            }
-
-            foreach ($access['acl'] as $acl) {
-                // If the group specified has not been defined, throw an exception to help the user
-                if (!isset($acl['users'])) {
-                    throw new InvalidArgumentException('Missing property "users" in access rule');
-                }
-
-                // If a user is specified, ensure the public key has access to the user
-                $userAccess = !$user || $acl['users'] === '*' || in_array($user, $acl['users']);
-                if (!$userAccess) {
-                    continue;
-                }
-
-                // Figure out which resources the public key has access to, based on group or
-                // explicit definition
-                $resources = isset($acl['resources']) ? $acl['resources'] : [];
-                $group = isset($acl['group']) ? $acl['group'] : false;
-
-                // If the group specified has not been defined, throw an exception to help the user
-                if ($group && !isset($this->groups[$group])) {
-                    throw new InvalidArgumentException('Group "' . $group . '" is not defined');
-                }
-
-                // If a group is specified, fetch resources belonging to that group
-                if ($group) {
-                    $resources = $this->groups[$group];
-                }
-
-                if (in_array($resource, $resources)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getGroups(GroupQuery $query = null, GroupsModel $model) {
         if ($query === null) {
             $query = new GroupQuery();
@@ -196,7 +151,7 @@ class ArrayAdapter extends AbstractAdapter implements AdapterInterface {
     /**
      * {@inheritdoc}
      */
-    function getAccessRule($publicKey, $accessRuleId) {
+    public function getAccessRule($publicKey, $accessRuleId) {
         foreach ($this->getAccessListForPublicKey($publicKey) as $rule) {
             if ($rule['id'] == $accessRuleId) {
                 return $rule;

--- a/library/Imbo/Auth/AccessControl/Adapter/MongoDB.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/MongoDB.php
@@ -142,47 +142,6 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
     /**
      * {@inheritdoc}
      */
-    public function hasAccess($publicKey, $resource, $user = null) {
-        $accessList = $this->getAccessListForPublicKey($publicKey) ?: [];
-
-        foreach ($accessList as $acl) {
-            // If the group specified has not been defined, throw an exception to help the user
-            if (!isset($acl['users'])) {
-                throw new InvalidArgumentException('Missing property "users" in access rule', 500);
-            }
-
-            // If a user is specified, ensure the public key has access to the user
-            $userAccess = !$user || $acl['users'] === '*' || in_array($user, $acl['users']);
-            if (!$userAccess) {
-                continue;
-            }
-
-            // Figure out which resources the public key has access to, based on group or
-            // explicit definition
-            $resources = isset($acl['resources']) ? $acl['resources'] : [];
-            $group = isset($acl['group']) ? $acl['group'] : false;
-
-            // If we the rule contains a group, get resource from it
-            if ($group) {
-                $resources = $this->getGroup($group);
-
-                // If the group has not been defined, throw an exception to help debug the problem
-                if ($resources === false) {
-                    throw new InvalidArgumentException('Group "' . $group . '" is not defined', 500);
-                }
-            }
-
-            if (in_array($resource, $resources)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getGroups(GroupQuery $query = null, GroupsModel $model) {
         if ($query === null) {
             $query = new GroupQuery();

--- a/library/Imbo/EventListener/AccessControl.php
+++ b/library/Imbo/EventListener/AccessControl.php
@@ -95,11 +95,11 @@ class AccessControl implements ListenerInterface {
 
         $request = $event->getRequest();
         $response = $event->getResponse();
-        $accessControl = $event->getAccessControl();
+        $aclAdapter = $event->getAccessControl();
         $query = $request->query;
         $resource = $event->getName();
 
-        $hasAccess = $accessControl->hasAccess(
+        $hasAccess = $aclAdapter->hasAccess(
             $request->getPublicKey(),
             $resource,
             $request->getUser()
@@ -128,14 +128,14 @@ class AccessControl implements ListenerInterface {
         }
 
         $response = $event->getResponse();
-        $accessControl = $event->getAccessControl();
+        $aclAdapter = $event->getAccessControl();
 
         // Create the model and set some pagination values
         $model = new GroupsModel();
         $model->setLimit($query->limit())
               ->setPage($query->page());
 
-        $groups = $accessControl->getGroups($query, $model);
+        $groups = $aclAdapter->getGroups($query, $model);
         $modelGroups = [];
 
         foreach ($groups as $groupName => $resources) {


### PR DESCRIPTION
The MongoDB and array adapters had almost identical `hasAccess()`-implementations. This PR moves the common logic into the abstract adapter.