### PR TITLE
Add configuration options for HTTP cache headers

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -98,6 +98,21 @@ $config = [
     'contentNegotiateImages' => true,
 
     /**
+     * HTTP cache header settings that are applied to resources that do not explicitly set
+     * other values. For instance, the `image` resource sets a very long `max-age`, as it
+     * shouldn't change over time. The `metadata` resource however could potentially change
+     * much more often. To ensure that clients get fresh responses, the default is to ask
+     * the client to always revalidate (ask if there has been any changes since last fetch)
+     *
+     * @var array
+     */
+    'httpCacheHeaders' => [
+        'maxAge' => 0,
+        'mustRevalidate' => true,
+        'public' => true,
+    ],
+
+    /**
      * Options related to authentication. See documentation for individual settings.
      *
      * @var array

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -612,6 +612,30 @@ Custom generators
 
 To create your own custom image identifier generators, simply create a class that implements ``Imbo\Image\Identifier\Generator\GeneratorInterface`` and ensure that the identifiers generated are in the character range ``[A-Za-z0-9_-]`` and are between one and 255 characters long.
 
+.. _configuration-http-cache-headers:
+
+HTTP cache headers - ``httpCacheHeaders``
+-----------------------------------------
+
+Imbo ships with reasonable defaults for which HTTP cache header settings it sends to clients. For some resources, however, it can be difficult to figure out a good middle ground between clients asking too often and too rarely. For instance, the ``images`` resource will change every time a new image has been added - but whether that happens once a second or once a year is hard to know.
+
+To ensure that clients get fresh responses, Imbo sends ``max-age=0, must-revalidate`` on these kind of resources. You can however override these defaults in the configuration. For instance, if you wanted to set the ``max-age`` to 30 seconds, leave it up to the client if it should re-validate and tell intermediary proxies that this response is private, you could set the configuration to the following:
+
+.. code-block:: php
+
+    <?php
+    return [
+        // ...
+
+        'httpCacheHeaders' => [
+            'maxAge' => 30,
+            'mustRevalidate' => false,
+            'public' => false,
+        ],
+
+        // ...
+    ];
+
 .. _configuration-content-negotiation:
 
 Content negotiation for images - ``contentNegotiateImages``

--- a/library/Imbo/Application.php
+++ b/library/Imbo/Application.php
@@ -141,6 +141,7 @@ class Application {
             'Imbo\EventListener\ImageTransformer',
             'Imbo\EventListener\ResponseSender',
             'Imbo\EventListener\ResponseETag',
+            'Imbo\EventListener\HttpCache',
         ];
 
         foreach ($eventListeners as $listener => $params) {

--- a/library/Imbo/EventListener/HttpCache.php
+++ b/library/Imbo/EventListener/HttpCache.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\EventListener;
+
+use Imbo\EventManager\EventInterface;
+
+/**
+ * Http cache listener
+ *
+ * This event listener will listen to all outgoing responses and check if any HTTP cache headers
+ * have explicitly been set. If not, it will apply the configured defaults.
+ *
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @package Event\Listeners
+ */
+class HttpCache implements ListenerInterface {
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents() {
+        return [
+            'response.send' => ['setHeaders' => 1],
+        ];
+    }
+
+    /**
+     * Right before the response is sent to the client, check if any HTTP cache control headers
+     * have explicity been set for this response. If not, apply the configured defaults.
+     *
+     * @param EventInterface $event The event instance
+     */
+    public function setHeaders(EventInterface $event) {
+        $method = $event->getRequest()->getMethod();
+
+        // Obviously we shouldn't bother doing any HTTP caching logic for non-GET/HEAD requests
+        if ($method !== 'GET' && $method !== 'HEAD') {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $headers = $event->getResponse()->headers;
+
+        // Imbo defaults to 'public' as cache-control value - if it has changed from this value,
+        // assume the resource requested has explicitly defined its own caching rules and fall back
+        if ($headers->get('Cache-Control') !== 'public') {
+            return;
+        }
+
+        // Get configured HTTP cache defaults from configuration, then apply them
+        $config = $event->getConfig()['httpCacheHeaders'];
+
+        if (isset($config['maxAge'])) {
+            $response->setMaxAge((int) $config['maxAge']);
+        }
+
+        if (isset($config['sharedMaxAge'])) {
+            $response->setSharedMaxAge($config['sharedMaxAge']);
+        }
+
+        if (isset($config['public']) && $config['public']) {
+            $response->setPublic();
+        } else if (isset($config['public'])) {
+            $response->setPrivate();
+        }
+
+        if (isset($config['mustRevalidate']) && $config['mustRevalidate']) {
+            $headers->addCacheControlDirective('must-revalidate');
+        }
+    }
+}

--- a/tests/behat/features/client-caching.feature
+++ b/tests/behat/features/client-caching.feature
@@ -44,6 +44,16 @@ Feature: Imbo enables client caching using related response headers
         And I include an access token in the query
         When I request "/users/user/images"
         Then the response is cacheable
+        And the response has a max age of 0 seconds
+        And the response has a must-revalidate directive
+
+    Scenario: Request user images with custom caching configuration
+        Given Imbo uses the "custom-http-cache.php" configuration
+        And I use "publickey" and "privatekey" for public and private keys
+        And I include an access token in the query
+        When I request "/users/user/images"
+        Then the response has a max age of 15 seconds
+        And the response does not have a must-revalidate directive
 
     Scenario: Request user image
         Given I use "publickey" and "privatekey" for public and private keys
@@ -51,6 +61,7 @@ Feature: Imbo enables client caching using related response headers
         And the "Accept" request header is "image/*"
         When I request the previously added image
         Then the response is cacheable
+        And the response has a max age of 31536000 seconds
 
     Scenario: Request user image metadata
         Given I use "publickey" and "privatekey" for public and private keys

--- a/tests/behat/imbo-configs/custom-http-cache.php
+++ b/tests/behat/imbo-configs/custom-http-cache.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+/**
+ * Custom HTTP cache header configuration
+ */
+return [
+    'httpCacheHeaders' => [
+        'maxAge' => 15,
+        'mustRevalidate' => false,
+        'public' => false,
+    ],
+];


### PR DESCRIPTION
As outlined in #395 - this PR adds configuration options for HTTP cache headers, and also changes the defaults for resources such as metadata and images.

Closes #395.