### PR TITLE
Allow public keys to access their own resources+groups

### DIFF
--- a/library/Imbo/Auth/AccessControl/Adapter/AbstractAdapter.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/AbstractAdapter.php
@@ -12,6 +12,7 @@ namespace Imbo\Auth\AccessControl\Adapter;
 
 use Imbo\Auth\AccessControl\Adapter\AdapterInterface,
     Imbo\Auth\AccessControl\GroupQuery,
+    Imbo\Exception\InvalidArgumentException,
     Imbo\Model\Groups as GroupsModel;
 
 /**

--- a/library/Imbo/Resource.php
+++ b/library/Imbo/Resource.php
@@ -91,10 +91,6 @@ class Resource {
             self::IMAGE_HEAD,
             self::IMAGE_OPTIONS,
 
-            self::GROUPS_GET,
-            self::GROUPS_HEAD,
-            self::GROUPS_OPTIONS,
-
             self::IMAGES_GET,
             self::IMAGES_HEAD,
             self::IMAGES_OPTIONS,
@@ -160,6 +156,16 @@ class Resource {
                 self::ACCESS_RULES_HEAD,
                 self::ACCESS_RULES_POST,
                 self::ACCESS_RULES_OPTIONS,
+
+                self::GROUPS_GET,
+                self::GROUPS_HEAD,
+                self::GROUPS_OPTIONS,
+
+                self::GROUP_GET,
+                self::GROUP_HEAD,
+                self::GROUP_PUT,
+                self::GROUP_DELETE,
+                self::GROUP_OPTIONS,
             ]
         );
     }

--- a/tests/behat/features/group.feature
+++ b/tests/behat/features/group.feature
@@ -9,7 +9,7 @@ Feature: Imbo provides a group endpoint
     Scenario Outline: Fetch resources of a group
         Given I use "valid-group-pubkey" and "foobar" for public and private keys
         And I include an access token in the query
-        When I request "/groups/groups-read.<extension>"
+        When I request "/groups/images-read.<extension>"
         Then I should get a response with "200 OK"
         And the "Content-Type" response header is "<content-type>"
         And the response body matches:
@@ -18,8 +18,8 @@ Feature: Imbo provides a group endpoint
         """
         Examples:
             | extension | content-type     | response |
-            | json      | application/json | #^{"resources":\["groups\.get","groups\.head"]}$# |
-            | xml       | application/xml  | #^<\?xml version="1\.0" encoding="UTF-8"\?>\s*<imbo>\s*<resources>\s*<resource>groups\.get</resource>\s*<resource>groups\.head</resource>\s*</resources>\s*</imbo>$#ms |
+            | json      | application/json | #^{"resources":\["images\.get","images\.head"]}$# |
+            | xml       | application/xml  | #^<\?xml version="1\.0" encoding="UTF-8"\?>\s*<imbo>\s*<resources>\s*<resource>images\.get</resource>\s*<resource>images\.head</resource>\s*</resources>\s*</imbo>$#ms |
 
     Scenario Outline: Create a resource group with invalid data
         Given Imbo uses the "access-control-mutable.php" configuration

--- a/tests/behat/features/group.feature
+++ b/tests/behat/features/group.feature
@@ -83,7 +83,6 @@ Feature: Imbo provides a group endpoint
 
     Scenario: Delete a resource group with an immutable access control adapter
         Given I use "valid-group-pubkey" and "foobar" for public and private keys
-        And I prime the database with "access-control-mutable.php"
         And I sign the request
         When I request "/groups/groups-read" using HTTP "DELETE"
         Then I should get a response with "405 Access control adapter is immutable"
@@ -92,7 +91,6 @@ Feature: Imbo provides a group endpoint
 
     Scenario: Update a resource group with an immutable access control adapter
         Given I use "valid-group-pubkey" and "foobar" for public and private keys
-        And I prime the database with "access-control-mutable.php"
         And the request body contains:
           """
           ["images.get"]

--- a/tests/behat/features/groups.feature
+++ b/tests/behat/features/groups.feature
@@ -18,22 +18,22 @@ Feature: Imbo provides a groups endpoint
         """
         Examples:
             | extension | content-type     | response |
-            | json      | application/json | #^{"search":{"hits":2,"page":1,"limit":20,"count":2},"groups":\[{"name":"images-read","resources":\["images\.get"]},{"name":"groups-read","resources":\["groups\.get","groups\.head"]}]}$# |
-            | xml       | application/xml  | #^<\?xml version="1.0" encoding="UTF-8"\?>\s*<imbo>\s*<search>\s*<hits>2</hits>\s*<page>1</page>\s*<limit>20</limit>\s*<count>2</count>\s*</search>\s*<groups>\s*<group>\s*<name>images-read</name>\s*<resources>\s*<resource>images\.get</resource>\s*</resources>\s*</group>\s*<group>\s*<name>groups-read</name>\s*<resources>\s*<resource>groups\.get</resource>\s*<resource>groups\.head</resource>\s*</resources>\s*</group>\s*</groups>\s*</imbo>$#ms |
+            | json      | application/json | #^{"search":{"hits":2,"page":1,"limit":20,"count":2},"groups":\[{"name":"images-read","resources":\["images\.get","images\.head"]},{"name":"groups-read","resources":\["group\.get","group\.head","groups\.get","groups\.head"]}]}$# |
+            | xml       | application/xml  | #^<\?xml version="1.0" encoding="UTF-8"\?>\s*<imbo>\s*<search>\s*<hits>2</hits>\s*<page>1</page>\s*<limit>20</limit>\s*<count>2</count>\s*</search>\s*<groups>\s*<group>\s*<name>images-read</name>\s*<resources>\s*<resource>images\.get</resource>\s*<resource>images\.head</resource>\s*</resources>\s*</group>\s*<group>\s*<name>groups-read</name>\s*<resources>\s*<resource>group\.get</resource>\s*<resource>group\.head</resource>\s*<resource>groups\.get</resource>\s*<resource>groups\.head</resource>\s*</resources>\s*</group>\s*</groups>\s*</imbo>$#ms |
 
     Scenario Outline: Fetch a list of groups with limit + paging
         Given I use "valid-group-pubkey" and "foobar" for public and private keys
         And I include an access token in the query
         When I request "/groups.json?limit=1&page=<page>"
         Then I should get a response with "200 OK"
-        And the response body matches:
+        And the response body is:
         """
         <response>
         """
         Examples:
             | page | response |
-            | 1    | #^{"search":{"hits":2,"page":1,"limit":1,"count":1},"groups":\[{"name":"images-read","resources":\["images\.get"]}]}$# |
-            | 2    | #^{"search":{"hits":2,"page":2,"limit":1,"count":1},"groups":\[{"name":"groups-read","resources":\["groups\.get","groups\.head"]}]}$# |
+            | 1    | {"search":{"hits":2,"page":1,"limit":1,"count":1},"groups":[{"name":"images-read","resources":["images.get","images.head"]}]} |
+            | 2    | {"search":{"hits":2,"page":2,"limit":1,"count":1},"groups":[{"name":"groups-read","resources":["group.get","group.head","groups.get","groups.head"]}]} |
 
     Scenario: Fetch list of groups from MongoDB access control adapter
         Given Imbo uses the "access-control-mutable.php" configuration
@@ -42,9 +42,9 @@ Feature: Imbo provides a groups endpoint
         And I include an access token in the query
         When I request "/groups.json?limit=2"
         Then I should get a response with "200 OK"
-        And the response body matches:
+        And the response body is:
         """
-        #^{"search":{"hits":3,"page":1,"limit":2,"count":2},"groups":\[{"name":"existing-group","resources":\["group.get","group.head"]},{"name":"user-stats","resources":\["user.get","user.head"]}]}$#
+        {"search":{"hits":3,"page":1,"limit":2,"count":2},"groups":[{"name":"existing-group","resources":["group.get","group.head"]},{"name":"user-stats","resources":["user.get","user.head"]}]}
         """
 
     Scenario: Fetch list of groups without specifying a public key

--- a/tests/behat/imbo-configs/access-control.php
+++ b/tests/behat/imbo-configs/access-control.php
@@ -92,8 +92,10 @@ return [
                 ]]
             ]
         ], [
-            'images-read' => [Resource::IMAGES_GET],
+            'images-read' => [Resource::IMAGES_GET, Resource::IMAGES_HEAD],
             'groups-read' => [
+                Resource::GROUP_GET,
+                Resource::GROUP_HEAD,
                 Resource::GROUPS_GET,
                 Resource::GROUPS_HEAD
             ],

--- a/tests/behat/imbo-configs/access-control.php
+++ b/tests/behat/imbo-configs/access-control.php
@@ -77,6 +77,9 @@ return [
                 ], [
                     'group' => 'groups-read',
                     'users' => '*'
+                ], [
+                    'resources' => [Resource::GROUP_DELETE, Resource::GROUP_PUT],
+                    'users' => '*'
                 ]]
             ],
 


### PR DESCRIPTION
As outlined in #387 - public keys should be able to see which resources they have access to. I extended this to also include fetching resources for groups that a public key has been assigned.

Along the way I found two minor bugs that I fixed: A missing use statement and some mislabeled resources.
