### PR TITLE
Add blur transformation

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -246,6 +246,7 @@ $config = [
 
         // Image transformations
         'autoRotate' => 'Imbo\Image\Transformation\AutoRotate',
+        'blur' => 'Imbo\Image\Transformation\Blur',
         'border' => 'Imbo\Image\Transformation\Border',
         'canvas' => 'Imbo\Image\Transformation\Canvas',
         'compress' => 'Imbo\Image\Transformation\Compress',

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -37,3 +37,4 @@ Behat
 Lighttpd
 ETag
 Uuid
+gaussian

--- a/docs/usage/image-transformations.rst
+++ b/docs/usage/image-transformations.rst
@@ -30,7 +30,7 @@ This transformation can be used to blur the image.
 **Parameters:**
 
 ``mode``
-    The blur type (optional). Possible values are:
+    The blur type (optional). Defaults to ``regular``. Possible values are:
 
     ``regular``
         When adding regular blur, the ``radius`` and ``sigma`` parameters are required.

--- a/docs/usage/image-transformations.rst
+++ b/docs/usage/image-transformations.rst
@@ -20,6 +20,44 @@ This transformation will auto rotate the image based on EXIF data stored in the 
 
 * ``t[]=autoRotate``
 
+.. _blur-transformation:
+
+Blur the image - ``t[]=blur``
+-----------------------------------
+
+This transformation can be used to blur the image.
+
+**Parameters:**
+
+``mode``
+    The blur type (optional). Possible values are:
+
+    ``regular``
+        When adding regular blur, the ``radius`` and ``sigma`` parameters are required.
+
+    ``adaptive``
+        When adding adaptive blur, the ``radius`` and ``sigma`` parameters are required. Adaptive blur decrease the blur in the part of the picture near to the edge of the image canvas.
+
+    ``motion``
+        When adding motion blur, the ``radius``, ``sigma`` and ``angle`` parameters are required.
+
+    ``radial``
+        When adding radial blur, the ``angle`` parameter is required.
+
+``radius``
+    The radius of the Gaussian operator in pixels.
+
+``sigma``
+    The standard deviation of the Gaussian, in pixels.
+
+``angle``
+    The number of degrees to rotate the image.
+
+**Examples:**
+
+* ``t[]=blur,radius=1,sigma=2``
+* ``t[]=blur,type=adaptive,radius=2,sigma=4``
+
 .. _border-transformation:
 
 Add an image border - ``t[]=border``

--- a/docs/usage/image-transformations.rst
+++ b/docs/usage/image-transformations.rst
@@ -30,10 +30,10 @@ This transformation can be used to blur the image.
 **Parameters:**
 
 ``mode``
-    The blur type (optional). Defaults to ``regular``. Possible values are:
+    The blur type (optional). Defaults to ``gaussian``. Possible values are:
 
-    ``regular``
-        When adding regular blur, the ``radius`` and ``sigma`` parameters are required.
+    ``gaussian``
+        When adding gaussian blur, the ``radius`` and ``sigma`` parameters are required.
 
     ``adaptive``
         When adding adaptive blur, the ``radius`` and ``sigma`` parameters are required. Adaptive blur decrease the blur in the part of the picture near to the edge of the image canvas.
@@ -45,7 +45,7 @@ This transformation can be used to blur the image.
         When adding radial blur, the ``angle`` parameter is required.
 
 ``radius``
-    The radius of the Gaussian operator in pixels.
+    The radius of the Gaussian, in pixels, not counting the center pixel.
 
 ``sigma``
     The standard deviation of the Gaussian, in pixels.

--- a/library/Imbo/Image/Transformation/Blur.php
+++ b/library/Imbo/Image/Transformation/Blur.php
@@ -47,8 +47,29 @@ class Blur extends Transformation implements ListenerInterface {
         }
 
         switch ($type) {
+            case 'adaptive':
+                return $this->adaptiveBlur($event);
+            case 'motion':
+                return $this->motionBlur($event);
+            case 'radial':
+                return $this->radialBlur($event);
             default:
                 return $this->blur($event);
+        }
+    }
+
+    /**
+     * Check that all params are present
+     *
+     * @param array $params Transformation parameter list
+     * @param array $required Array with required parameters
+     * @throws TransformationException
+     */
+    private function checkRequiredParams(array $params, array $required) {
+        foreach ($required as $param) {
+            if (!isset($params[$param])) {
+                throw new TransformationException('Missing required parameter: ' . $param, 400);
+            }
         }
     }
 
@@ -60,11 +81,7 @@ class Blur extends Transformation implements ListenerInterface {
     private function blur(EventInterface $event) {
         $params = $event->getArgument('params');
 
-        foreach (['radius', 'sigma'] as $param) {
-            if (!isset($params[$param])) {
-                throw new TransformationException('Missing required parameter: ' . $param, 400);
-            }
-        }
+        $this->checkRequiredParams($params, ['radius', 'sigma']);
 
         if (isset($params['radius'])) {
             $radius = (float) $params['radius'];

--- a/library/Imbo/Image/Transformation/Blur.php
+++ b/library/Imbo/Image/Transformation/Blur.php
@@ -48,13 +48,9 @@ class Blur extends Transformation implements ListenerInterface {
 
         switch ($type) {
             case 'adaptive':
-                return $this->adaptiveBlur($event);
-            case 'motion':
-                return $this->motionBlur($event);
-            case 'radial':
-                return $this->radialBlur($event);
+                return $this->blur($event, true);
             default:
-                return $this->blur($event);
+                return $this->blur($event, false);
         }
     }
 
@@ -74,11 +70,12 @@ class Blur extends Transformation implements ListenerInterface {
     }
 
     /**
-     * Perform regular blur on the image
+     * Perform adaptive or regular blur on the image
      *
      * @param EventInterface $event The event instance
+     * @param bool $adaptive Whether or not to perform adaptive blur
      */
-    private function blur(EventInterface $event) {
+    private function blur(EventInterface $event, $adaptive = false) {
         $params = $event->getArgument('params');
 
         $this->checkRequiredParams($params, ['radius', 'sigma']);
@@ -92,7 +89,12 @@ class Blur extends Transformation implements ListenerInterface {
         }
 
         try {
-            $this->imagick->blurImage($radius, $sigma);
+            if ($adaptive) {
+                $this->imagick->adaptiveBlurImage($radius, $sigma);
+            } else {
+                $this->imagick->blurImage($radius, $sigma);
+            }
+
             $event->getArgument('image')->hasBeenTransformed(true);
         } catch (ImagickException $e) {
             throw new TransformationException($e->getMessage(), 400, $e);

--- a/library/Imbo/Image/Transformation/Blur.php
+++ b/library/Imbo/Image/Transformation/Blur.php
@@ -88,13 +88,8 @@ class Blur extends Transformation implements ListenerInterface {
 
         $this->checkRequiredParams($params, ['radius', 'sigma']);
 
-        if (isset($params['radius'])) {
-            $radius = (float) $params['radius'];
-        }
-
-        if (isset($params['sigma'])) {
-            $sigma = (float) $params['sigma'];
-        }
+        $radius = (float) $params['radius'];
+        $sigma = (float) $params['sigma'];
 
         try {
             if ($adaptive) {
@@ -119,17 +114,9 @@ class Blur extends Transformation implements ListenerInterface {
 
         $this->checkRequiredParams($params, ['radius', 'sigma', 'angle']);
 
-        if (isset($params['radius'])) {
-            $radius = (float) $params['radius'];
-        }
-
-        if (isset($params['sigma'])) {
-            $sigma = (float) $params['sigma'];
-        }
-
-        if (isset($params['angle'])) {
-            $angle = (float) $params['angle'];
-        }
+        $radius = (float) $params['radius'];
+        $sigma = (float) $params['sigma'];
+        $angle = (float) $params['angle'];
 
         try {
             $this->imagick->motionBlurImage($radius, $sigma, $angle);
@@ -149,9 +136,7 @@ class Blur extends Transformation implements ListenerInterface {
 
         $this->checkRequiredParams($params, ['angle']);
 
-        if (isset($params['angle'])) {
-            $angle = (float) $params['angle'];
-        }
+        $angle = (float) $params['angle'];
 
         try {
             $this->imagick->radialBlurImage($angle);

--- a/library/Imbo/Image/Transformation/Blur.php
+++ b/library/Imbo/Image/Transformation/Blur.php
@@ -128,7 +128,7 @@ class Blur extends Transformation implements ListenerInterface {
         }
 
         try {
-            $this->imagick->motionBlurImage(0, $sigma, $angle);
+            $this->imagick->motionBlurImage($radius, $sigma, $angle);
             $event->getArgument('image')->hasBeenTransformed(true);
         } catch (ImagickException $e) {
             throw new TransformationException($e->getMessage(), 400, $e);

--- a/library/Imbo/Image/Transformation/Blur.php
+++ b/library/Imbo/Image/Transformation/Blur.php
@@ -39,22 +39,26 @@ class Blur extends Transformation implements ListenerInterface {
      */
     public function transform(EventInterface $event) {
         $params = $event->getArgument('params');
+        $type = isset($params['type']) ? $params['type'] : 'gaussian';
 
-        $type = isset($params['type']) ? $params['type'] : 'regular';
+        $blurTypes = ['gaussian', 'adaptive', 'motion', 'radial'];
 
-        if (!in_array($type, ['regular', 'adaptive', 'motion', 'radial'])) {
+        if (!in_array($type, $blurTypes)) {
             throw new TransformationException('Unknown blur type: ' . $type, 400);
         }
 
         switch ($type) {
             case 'motion':
                 return $this->motionBlur($event);
+
             case 'radial':
                 return $this->radialBlur($event);
+
             case 'adaptive':
                 return $this->blur($event, true);
+
             default:
-                return $this->blur($event, false);
+                return $this->blur($event);
         }
     }
 
@@ -74,10 +78,10 @@ class Blur extends Transformation implements ListenerInterface {
     }
 
     /**
-     * Add adaptive or regular blur to the image
+     * Add Gaussian or adaptive blur to the image
      *
      * @param EventInterface $event The event instance
-     * @param bool $adaptive Whether or not to perform adaptive blur
+     * @param bool $adaptive Perform adaptive blur or not
      */
     private function blur(EventInterface $event, $adaptive = false) {
         $params = $event->getArgument('params');
@@ -96,7 +100,7 @@ class Blur extends Transformation implements ListenerInterface {
             if ($adaptive) {
                 $this->imagick->adaptiveBlurImage($radius, $sigma);
             } else {
-                $this->imagick->blurImage($radius, $sigma);
+                $this->imagick->gaussianBlurImage($radius, $sigma);
             }
 
             $event->getArgument('image')->hasBeenTransformed(true);

--- a/library/Imbo/Image/Transformation/Blur.php
+++ b/library/Imbo/Image/Transformation/Blur.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Image\Transformation;
+
+use Imbo\Model\Image,
+    Imbo\Exception\TransformationException,
+    Imbo\EventListener\ListenerInterface,
+    Imbo\EventManager\EventInterface,
+    ImagickException;
+
+/**
+ * Blur transformation
+ *
+ * @author Kristoffer Brabrand <kristoffer@brabrand.no>
+ * @package Image\Transformations
+ */
+class Blur extends Transformation implements ListenerInterface {
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents() {
+        return [
+            'image.transformation.blur' => 'transform',
+        ];
+    }
+
+    /**
+     * Transform the image
+     *
+     * @param EventInterface $event The event instance
+     */
+    public function transform(EventInterface $event) {
+        $params = $event->getArgument('params');
+
+        $type = isset($params['type']) ? $params['type'] : 'regular';
+
+        if (!in_array($type, ['regular', 'adaptive', 'motion', 'radial'])) {
+            throw new TransformationException('Unknown blur type: ' . $type, 400);
+        }
+
+        switch ($type) {
+            default:
+                return $this->blur($event);
+        }
+    }
+
+    /**
+     * Perform regular blur on the image
+     *
+     * @param EventInterface $event The event instance
+     */
+    private function blur(EventInterface $event) {
+        $params = $event->getArgument('params');
+
+        foreach (['radius', 'sigma'] as $param) {
+            if (!isset($params[$param])) {
+                throw new TransformationException('Missing required parameter: ' . $param, 400);
+            }
+        }
+
+        if (isset($params['radius'])) {
+            $radius = (float) $params['radius'];
+        }
+
+        if (isset($params['sigma'])) {
+            $sigma = (float) $params['sigma'];
+        }
+
+        try {
+            $this->imagick->blurImage($radius, $sigma);
+            $event->getArgument('image')->hasBeenTransformed(true);
+        } catch (ImagickException $e) {
+            throw new TransformationException($e->getMessage(), 400, $e);
+        }
+    }
+}

--- a/library/Imbo/Image/Transformation/Blur.php
+++ b/library/Imbo/Image/Transformation/Blur.php
@@ -49,6 +49,8 @@ class Blur extends Transformation implements ListenerInterface {
         switch ($type) {
             case 'motion':
                 return $this->motionBlur($event);
+            case 'radial':
+                return $this->radialBlur($event);
             case 'adaptive':
                 return $this->blur($event, true);
             default:
@@ -127,6 +129,28 @@ class Blur extends Transformation implements ListenerInterface {
 
         try {
             $this->imagick->motionBlurImage(0, $sigma, $angle);
+            $event->getArgument('image')->hasBeenTransformed(true);
+        } catch (ImagickException $e) {
+            throw new TransformationException($e->getMessage(), 400, $e);
+        }
+    }
+
+    /**
+     * Add radial blur to the image
+     *
+     * @param EventInterface $event The event instance
+     */
+    private function radialBlur(EventInterface $event) {
+        $params = $event->getArgument('params');
+
+        $this->checkRequiredParams($params, ['angle']);
+
+        if (isset($params['angle'])) {
+            $angle = (float) $params['angle'];
+        }
+
+        try {
+            $this->imagick->radialBlurImage($angle);
             $event->getArgument('image')->hasBeenTransformed(true);
         } catch (ImagickException $e) {
             throw new TransformationException($e->getMessage(), 400, $e);

--- a/library/Imbo/Image/Transformation/Blur.php
+++ b/library/Imbo/Image/Transformation/Blur.php
@@ -47,6 +47,8 @@ class Blur extends Transformation implements ListenerInterface {
         }
 
         switch ($type) {
+            case 'motion':
+                return $this->motionBlur($event);
             case 'adaptive':
                 return $this->blur($event, true);
             default:
@@ -70,7 +72,7 @@ class Blur extends Transformation implements ListenerInterface {
     }
 
     /**
-     * Perform adaptive or regular blur on the image
+     * Add adaptive or regular blur to the image
      *
      * @param EventInterface $event The event instance
      * @param bool $adaptive Whether or not to perform adaptive blur
@@ -95,6 +97,36 @@ class Blur extends Transformation implements ListenerInterface {
                 $this->imagick->blurImage($radius, $sigma);
             }
 
+            $event->getArgument('image')->hasBeenTransformed(true);
+        } catch (ImagickException $e) {
+            throw new TransformationException($e->getMessage(), 400, $e);
+        }
+    }
+
+    /**
+     * Add motion blur to the image
+     *
+     * @param EventInterface $event The event instance
+     */
+    private function motionBlur(EventInterface $event) {
+        $params = $event->getArgument('params');
+
+        $this->checkRequiredParams($params, ['radius', 'sigma', 'angle']);
+
+        if (isset($params['radius'])) {
+            $radius = (float) $params['radius'];
+        }
+
+        if (isset($params['sigma'])) {
+            $sigma = (float) $params['sigma'];
+        }
+
+        if (isset($params['angle'])) {
+            $angle = (float) $params['angle'];
+        }
+
+        try {
+            $this->imagick->motionBlurImage(0, $sigma, $angle);
             $event->getArgument('image')->hasBeenTransformed(true);
         } catch (ImagickException $e) {
             throw new TransformationException($e->getMessage(), 400, $e);

--- a/tests/behat/features/image-transformations.feature
+++ b/tests/behat/features/image-transformations.feature
@@ -25,6 +25,10 @@ Feature: Imbo enables dynamic transformations of images
 
         Examples:
             | transformation                                                                                    | width | height |
+            | blur:radius=2,sigma=4                                                                             | 599   | 417    |
+            | blur:angle=5,type=radial                                                                          | 599   | 417    |
+            | blur:radius=20,sigma=10,angle=70,type=motion                                                      | 599   | 417    |
+            | blur:radius=2,sigma=4,type=adaptive                                                               | 599   | 417    |
             | border                                                                                            | 601   | 419    |
             | border:width=4,height=5                                                                           | 607   | 427    |
             | border:mode=inline,width=4,height=5                                                               | 599   | 417    |
@@ -98,6 +102,10 @@ Feature: Imbo enables dynamic transformations of images
 
         Examples:
             | transformation                                                                                    |
+            | blur:radius=2,sigma=4                                                                             |
+            | blur:angle=5,type=radial                                                                          |
+            | blur:radius=20,sigma=10,angle=70,type=motion                                                      |
+            | blur:radius=2,sigma=4,type=adaptive                                                               |
             | border                                                                                            |
             | border:width=4,height=5                                                                           |
             | border:mode=inline,width=4,height=5                                                               |
@@ -163,6 +171,14 @@ Feature: Imbo enables dynamic transformations of images
 
         Examples:
             | transformation                    | reason-phrase                                                               |
+            | blur                              | 400 Missing required parameter: radius                                      |
+            | blur:radius=2                     | 400 Missing required parameter: sigma                                       |
+            | blur:type=foobar                  | 400 Unknown blur type: foobar                                               |
+            | blur:type=radial                  | 400 Missing required parameter: angle                                       |
+            | blur:radius=2,type=motion         | 400 Missing required parameter: sigma                                       |
+            | blur:sigma=1,type=motion          | 400 Missing required parameter: radius                                      |
+            | blur:sigma=1,radius=2,type=motion | 400 Missing required parameter: angle                                       |
+            | blur:type=radial                  | 400 Missing required parameter: angle                                       |
             | compress                          | 400 Missing required parameter: level                                       |
             | compress:level=200                | 400 level must be between 0 and 100                                         |
             | compress:level=-10                | 400 level must be between 0 and 100                                         |


### PR DESCRIPTION
This PR implements blur as a transformation in Imbo as requested by @sgasser in #389. As per the discussion in the issue, channel support has not been implemented but apart from that all the different blur types and options supported by imagick has been included.

Closes #389.