### PR TITLE
MD5 image identifier generator

### DIFF
--- a/library/Imbo/Image/Identifier/Generator/Md5.php
+++ b/library/Imbo/Image/Identifier/Generator/Md5.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Image\Identifier\Generator;
+
+use Imbo\Model\Image;
+
+/**
+ * Md5 image identifier generator. Please do not use this except in the
+ * early transition phase from Imbo 1.x to Imbo 2.x.
+ *
+ * @author Espen Hovlandsdal <espen@hovlandsdal.com>
+ * @package Core\Image\Identifier\Generator
+ */
+class Md5 implements GeneratorInterface {
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(Image $image) {
+        return md5($image->getBlob());
+    }
+}

--- a/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/Md5Test.php
+++ b/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/Md5Test.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboUnitTest\Image\Identifier\Generator;
+
+use Imbo\Image\Identifier\Generator\Md5 as Md5Generator,
+    ImagickException;
+
+/**
+ * @covers Imbo\Image\Identifier\Generator\Md5
+ * @group unit
+ */
+class Md5Test extends \PHPUnit_Framework_TestCase {
+    public function testGeneratesUniqueUuidV4() {
+        $image = $this->getMock('Imbo\Model\Image');
+        $image->expects($this->any())->method('getBlob')->will($this->returnValue('foobar'));
+
+        $generator = new Md5Generator();
+
+        // Make sure it generates the same MD5 every time
+        for ($i = 0; $i < 15; $i++) {
+            $imageIdentifier = $generator->generate($image);
+            $this->assertSame(md5('foobar'), $imageIdentifier);
+        }
+    }
+}

--- a/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/Md5Test.php
+++ b/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/Md5Test.php
@@ -18,7 +18,7 @@ use Imbo\Image\Identifier\Generator\Md5 as Md5Generator,
  * @group unit
  */
 class Md5Test extends \PHPUnit_Framework_TestCase {
-    public function testGeneratesUniqueUuidV4() {
+    public function testGeneratesCorrectMd5ForBlob() {
         $image = $this->getMock('Imbo\Model\Image');
         $image->expects($this->any())->method('getBlob')->will($this->returnValue('foobar'));
 


### PR DESCRIPTION
This PR  adds a simple generator that simply generates an MD5-hash of the image blob. This should not usually be used (and as such is not documented), but can be useful while upgrading from Imbo 1 to Imbo 2.