### PR TITLE
Metadata validation

### DIFF
--- a/library/Imbo/EventListener/ExifMetadata.php
+++ b/library/Imbo/EventListener/ExifMetadata.php
@@ -190,29 +190,42 @@ class ExifMetadata implements ListenerInterface {
     /**
      * Parse an array of properties into a storable format
      *
-     * @param array $properties An array of properties to parse
+     * @param array $rawProperties An array of properties to parse
      * @return array Parsed array of properties
      */
-    protected function parseProperties(array $properties) {
-        if (isset($properties['exif:GPSLatitude']) &&
-            isset($properties['exif:GPSLongitude'])) {
+    protected function parseProperties(array $rawProperties) {
+        if (isset($rawProperties['exif:GPSLatitude']) &&
+            isset($rawProperties['exif:GPSLongitude'])) {
 
             // We store coordinates in GeoJSON-format (lng/lat)
-            $properties['gps:location'] = [
+            $rawProperties['gps:location'] = [
                 $this->parseGpsCoordinate(
-                    $properties['exif:GPSLongitude'],
-                    $properties['exif:GPSLongitudeRef']
+                    $rawProperties['exif:GPSLongitude'],
+                    $rawProperties['exif:GPSLongitudeRef']
                 ),
                 $this->parseGpsCoordinate(
-                    $properties['exif:GPSLatitude'],
-                    $properties['exif:GPSLatitudeRef']
+                    $rawProperties['exif:GPSLatitude'],
+                    $rawProperties['exif:GPSLatitudeRef']
                 ),
             ];
         }
 
-        if (isset($properties['exif:GPSAltitude'])) {
-            $alt = explode('/', $properties['exif:GPSAltitude'], 2);
-            $properties['gps:altitude'] = $alt[0] / (int) $alt[1];
+        if (isset($rawProperties['exif:GPSAltitude'])) {
+            $alt = explode('/', $rawProperties['exif:GPSAltitude'], 2);
+            $rawProperties['gps:altitude'] = $alt[0] / (int) $alt[1];
+        }
+
+        $properties = [];
+        foreach ($rawProperties as $key => $val) {
+            // Get rid of dots in property names
+            $key = str_replace('.', ':', $key);
+
+            // Replace underscore with dash for png properties
+            if (substr($key, 0, 3) === 'png') {
+                $key = str_replace('_', '-', $key);
+            }
+
+            $properties[$key] = $val;
         }
 
         return $properties;

--- a/library/Imbo/Resource/Metadata.php
+++ b/library/Imbo/Resource/Metadata.php
@@ -125,7 +125,7 @@ class Metadata implements ResourceInterface {
                     continue;
                 }
 
-                throw new InvalidArgumentException('Invalid metadata. Dots are not allowed in metadata keys', 400);
+                throw new InvalidArgumentException('Invalid metadata. Dot characters (\'.\') are not allowed in metadata keys', 400);
             }
 
             if ($metadata === null) {

--- a/library/Imbo/Resource/Metadata.php
+++ b/library/Imbo/Resource/Metadata.php
@@ -120,6 +120,14 @@ class Metadata implements ResourceInterface {
         } else {
             $metadata = json_decode($metadata, true);
 
+            foreach (array_keys($metadata) as $key) {
+                if (strpos($key, '.') === false) {
+                    continue;
+                }
+
+                throw new InvalidArgumentException('Invalid metadata. Dots are not allowed in metadata keys', 400);
+            }
+
             if ($metadata === null) {
                 throw new InvalidArgumentException('Invalid JSON data', 400);
             }

--- a/tests/behat/features/exif-metadata-event-listener.feature
+++ b/tests/behat/features/exif-metadata-event-listener.feature
@@ -5,10 +5,10 @@ Feature: Imbo provides an event listener for turning EXIF data into metadata
 
     Background:
         Given Imbo uses the "add-exif-data-as-metadata.php" configuration
-        And "tests/phpunit/Fixtures/exif-logo.jpg" exists in Imbo
 
     Scenario: Fetch the added metadata
-        Given I use "publickey" and "privatekey" for public and private keys
+        Given "tests/phpunit/Fixtures/exif-logo.jpg" exists in Imbo
+        And I use "publickey" and "privatekey" for public and private keys
         And I include an access token in the query
         When I request the metadata of the previously added image
         Then I should get a response with "200 OK"
@@ -40,4 +40,16 @@ Feature: Imbo provides an event listener for turning EXIF data into metadata
         And the response body contains:
         """
         "gps:altitude":50.8
+        """
+
+    Scenario: Metadata is normalized
+        Given "tests/phpunit/Fixtures/logo-horizontal.png" exists in Imbo
+        And I use "publickey" and "privatekey" for public and private keys
+        And I include an access token in the query
+        When I request the metadata of the previously added image
+        Then I should get a response with "200 OK"
+        And the "Content-Type" response header is "application/json"
+        And the response body contains:
+        """
+        "png:IHDR:bit-depth-orig":"8"
         """

--- a/tests/behat/features/metadata.feature
+++ b/tests/behat/features/metadata.feature
@@ -155,7 +155,7 @@ Feature: Imbo provides a metadata endpoint
           """
         And I sign the request
         When I request the metadata of the test image using HTTP "PUT"
-        Then I should get a response with "400 Invalid metadata. Dots are not allowed in metadata keys"
+        Then I should get a response with "400 Invalid metadata. Dot characters ('.') are not allowed in metadata keys"
 
     Scenario Outline: Set and get metadata with nested info
         Given I use "publickey" and "privatekey" for public and private keys

--- a/tests/behat/features/metadata.feature
+++ b/tests/behat/features/metadata.feature
@@ -141,11 +141,21 @@ Feature: Imbo provides a metadata endpoint
         Given I use "publickey" and "privatekey" for public and private keys
         And the request body contains:
           """
-          {"json got broken in half sort of
+          {foo bar}
           """
         And I sign the request
         When I request the metadata of the test image using HTTP "PUT"
         Then I should get a response with "400 Invalid JSON data"
+
+    Scenario: Set data for invalid metadata key
+        Given I use "publickey" and "privatekey" for public and private keys
+        And the request body contains:
+          """
+          {"foo.bar": "bar"}
+          """
+        And I sign the request
+        When I request the metadata of the test image using HTTP "PUT"
+        Then I should get a response with "400 Invalid metadata. Dots are not allowed in metadata keys"
 
     Scenario Outline: Set and get metadata with nested info
         Given I use "publickey" and "privatekey" for public and private keys

--- a/tests/behat/imbo-configs/add-exif-data-as-metadata.php
+++ b/tests/behat/imbo-configs/add-exif-data-as-metadata.php
@@ -13,6 +13,11 @@
  */
 return [
     'eventListeners' => [
-        'exifMetadataListener' => 'Imbo\EventListener\ExifMetadata',
+        'exifMetadataListener' => [
+            'listener' => 'Imbo\EventListener\ExifMetadata',
+            'params' => [
+                'allowedTags' => ['exif:*', 'png:*']
+            ]
+        ]
     ],
 ];


### PR DESCRIPTION
This PR adds validation of manually entered metadata, and also adds replacing of "dangerous" dots being returned from the exif metadata listener. Simple normalization of png metadata properties has been added too, to sort out the mix of `_`, `.`, `-` and `,` that we've had so far when storing PNG metadata as metadata in Imbo.

Solves #406.