### PR TITLE
Handle deterministic image identifier generators

### DIFF
--- a/library/Imbo/Image/Identifier/Generator/GeneratorInterface.php
+++ b/library/Imbo/Image/Identifier/Generator/GeneratorInterface.php
@@ -26,4 +26,12 @@ interface GeneratorInterface {
      * @return string A valid image identifier, between 1 and 255 characters
      */
     function generate(Image $image);
+
+    /**
+     * Return a boolean indicating whether or not the generator is deterministic. Meaning
+     * that it will always return the same identifier for the same image.
+     *
+     * @return boolean
+     */
+    function isDeterministic();
 }

--- a/library/Imbo/Image/Identifier/Generator/Md5.php
+++ b/library/Imbo/Image/Identifier/Generator/Md5.php
@@ -26,4 +26,11 @@ class Md5 implements GeneratorInterface {
     public function generate(Image $image) {
         return md5($image->getBlob());
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDeterministic() {
+        return true;
+    }
 }

--- a/library/Imbo/Image/Identifier/Generator/RandomString.php
+++ b/library/Imbo/Image/Identifier/Generator/RandomString.php
@@ -43,4 +43,11 @@ class RandomString implements GeneratorInterface {
 
         return $key;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDeterministic() {
+        return false;
+    }
 }

--- a/library/Imbo/Image/Identifier/Generator/Uuid.php
+++ b/library/Imbo/Image/Identifier/Generator/Uuid.php
@@ -26,4 +26,11 @@ class Uuid implements GeneratorInterface {
     public function generate(Image $image) {
         return (string) UuidFactory::uuid4();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDeterministic() {
+        return false;
+    }
 }

--- a/library/Imbo/Image/ImagePreparation.php
+++ b/library/Imbo/Image/ImagePreparation.php
@@ -113,6 +113,10 @@ class ImagePreparation implements ListenerInterface {
             $imageIdentifierGenerator = $imageIdentifierGenerator();
         }
 
+        if ($imageIdentifierGenerator->isDeterministic()) {
+            return $imageIdentifierGenerator->generate($image);
+        }
+
         // Continue generating image identifiers until we get one that does not already exist
         $maxAttempts = 100;
         $attempts = 0;

--- a/tests/behat/features/image-identifier-generator-md5.feature
+++ b/tests/behat/features/image-identifier-generator-md5.feature
@@ -1,0 +1,32 @@
+Feature: Imbo supports generation of md5 image identifiers
+    In order to insert images
+    As an HTTP Client
+    I want to make requests against the image endpoint
+
+    Background:
+        Given Imbo uses the "image-identifier-md5.php" configuration
+        And "tests/phpunit/Fixtures/image1.png" exists in Imbo
+
+    Scenario: Add a new image
+        Given I use "publickey" and "privatekey" for public and private keys
+        And I sign the request
+        And I attach "tests/phpunit/Fixtures/image.jpg" to the request body
+        When I request "/users/user/images" using HTTP "POST"
+        Then I should get a response with "201 Created"
+        And the "Content-Type" response header is "application/json"
+        And the response body matches:
+          """
+          /{"imageIdentifier":"f3210f1bb34bfbfa432cc3560be40761".*}/
+          """
+
+    Scenario: Add an image that already exists
+        Given I use "publickey" and "privatekey" for public and private keys
+        And I sign the request
+        And I attach "tests/phpunit/Fixtures/image1.png" to the request body
+        When I request "/users/user/images" using HTTP "POST"
+        Then I should get a response with "200 OK"
+        And the "Content-Type" response header is "application/json"
+        And the response body matches:
+          """
+          /{"imageIdentifier":"fc7d2d06993047a0b5056e8fac4462a2".*}/
+          """

--- a/tests/behat/imbo-configs/image-identifier-md5.php
+++ b/tests/behat/imbo-configs/image-identifier-md5.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+/**
+ * Enable the md5 image identifier generator
+ */
+return [
+    'imageIdentifierGenerator' => function() {
+        return new Imbo\Image\Identifier\Generator\Md5();
+    }
+];


### PR DESCRIPTION
This PR adds support for image identifier generators that always yields the same result for the same image, such as `Imbo\Image\Identifier\Generator\Md5`. With this fix the behavior should be the same as in 1.x.