### PR TITLE
Fix bug in the metadata validator

### DIFF
--- a/library/Imbo/Resource/Metadata.php
+++ b/library/Imbo/Resource/Metadata.php
@@ -120,16 +120,16 @@ class Metadata implements ResourceInterface {
         } else {
             $metadata = json_decode($metadata, true);
 
+            if ($metadata === null) {
+                throw new InvalidArgumentException('Invalid JSON data', 400);
+            }
+
             foreach (array_keys($metadata) as $key) {
                 if (strpos($key, '.') === false) {
                     continue;
                 }
 
                 throw new InvalidArgumentException('Invalid metadata. Dot characters (\'.\') are not allowed in metadata keys', 400);
-            }
-
-            if ($metadata === null) {
-                throw new InvalidArgumentException('Invalid JSON data', 400);
             }
         }
     }


### PR DESCRIPTION
Reorder the ifs to fix bug caused by calling array_keys on null if `json_decode` returns null (invalid json).