### PR TITLE
Fix MongoDB test dependencies in ImageVariations

### DIFF
--- a/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Database/MongoDBTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Database/MongoDBTest.php
@@ -23,6 +23,12 @@ use Imbo\EventListener\ImageVariations\Database\MongoDB,
 class MongoDBTest extends \PHPUnit_Framework_TestCase {
     private $databaseName = 'imboUnitTestDatabase';
 
+    protected function setUp() {
+        if (!class_exists('MongoClient')) {
+            $this->markTestSkipped('pecl/mongo >= 1.3.0 is required to run this test');
+        }
+    }
+
     /**
      * @covers Imbo\EventListener\ImageVariations\Database\MongoDB::__construct
      * @covers Imbo\EventListener\ImageVariations\Database\MongoDB::storeImageVariationMetadata

--- a/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Storage/GridFSTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Storage/GridFSTest.php
@@ -22,6 +22,12 @@ use Imbo\EventListener\ImageVariations\Storage\GridFS,
 class GridFSTest extends \PHPUnit_Framework_TestCase {
     private $databaseName = 'imboGridFSUnitTest';
 
+    protected function setUp() {
+        if (!class_exists('MongoClient')) {
+            $this->markTestSkipped('pecl/mongo >= 1.3.0 is required to run this test');
+        }
+    }
+
     /**
      * @covers Imbo\EventListener\ImageVariations\Storage\GridFS::__construct
      * @covers Imbo\EventListener\ImageVariations\Storage\GridFS::getGrid


### PR DESCRIPTION
The Image Variations unit tests assumes that the MongoDB driver is available. This patch marks the test as skipped if the driver is missing.