### PR TITLE
Make storage drivers throw exceptions as expected in StorageOperations

### DIFF
--- a/library/Imbo/Storage/Doctrine.php
+++ b/library/Imbo/Storage/Doctrine.php
@@ -90,12 +90,18 @@ class Doctrine implements StorageInterface {
             ]);
         }
 
-        return (boolean) $this->getConnection()->insert($this->getTableName($user, $imageIdentifier), [
+        $inserted = $this->getConnection()->insert($this->getTableName($user, $imageIdentifier), [
             'user'            => $user,
             'imageIdentifier' => $imageIdentifier,
             'data'            => $imageData,
             'updated'         => $now,
         ]);
+
+        if (!$inserted) {
+            throw new StorageException('Unable to persist image data to database.', 500);
+        }
+
+        return true;
     }
 
     /**

--- a/library/Imbo/Storage/Filesystem.php
+++ b/library/Imbo/Storage/Filesystem.php
@@ -69,7 +69,14 @@ class Filesystem implements StorageInterface {
 
         $imagePath = $imageDir . '/' . $imageIdentifier;
 
-        return (bool) file_put_contents($imagePath, $imageData);
+        $bytesWritten = file_put_contents($imagePath, $imageData);
+
+        // if write failed or 0 bytes were written (0 byte input == fail), or we wrote less than expected
+        if (!$bytesWritten || ($bytesWritten < strlen($imageData))) {
+            throw new StorageException('Failed writing file (disk full? zero bytes input?) to disk: ' . $imagePath, 507);
+        }
+
+        return true;
     }
 
     /**

--- a/tests/phpunit/ImboIntegrationTest/Storage/FilesystemTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Storage/FilesystemTest.php
@@ -53,6 +53,14 @@ class FilesystemTest extends StorageTests {
     }
 
     /**
+     * @expectedException Imbo\Exception\StorageException
+     * @expectedExceptionCode 507
+     */
+    public function testStoringEmptyDataFails() {
+        $this->getDriverActive()->store($this->getUser(), "this_identifier_left_empty", "");
+    }
+
+    /**
      * Recursively delete the test directory
      *
      * @param string $path Path to a file or a directory

--- a/tests/phpunit/ImboIntegrationTest/Storage/StorageTests.php
+++ b/tests/phpunit/ImboIntegrationTest/Storage/StorageTests.php
@@ -45,6 +45,24 @@ abstract class StorageTests extends \PHPUnit_Framework_TestCase {
     abstract protected function getDriver();
 
     /**
+     * Get the currently instanced, active driver in inherited tests
+     *
+     * @return string
+     */
+    protected function getDriverActive() {
+        return $this->driver;
+    }
+
+    /**
+     * Get the user name in inherited tests
+     *
+     * @return string
+     */
+    protected function getUser() {
+        return $this->user;
+    }
+
+    /**
      * Set up
      */
     public function setUp() {

--- a/tests/phpunit/ImboUnitTest/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboUnitTest/Storage/DoctrineTest.php
@@ -31,6 +31,11 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
     private $connection;
 
     /**
+     * @var string
+     */
+    private $user = 'key';
+
+    /**
      * Set up the driver
      */
     public function setUp() {
@@ -48,6 +53,23 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
     public function tearDown() {
         $this->connection = null;
         $this->driver = null;
+    }
+
+    /**
+     * @covers Imbo\Storage\Doctrine::store
+     * @expectedException Imbo\Exception\StorageException
+     * @expectedExceptionCode 500
+     */
+    public function testStoreExceptionOnInsertFailure() {
+        $this->connection->expects($this->once())->method('insert')->will($this->returnValue(0));
+
+        $driverMock = $this->getMockBuilder('Imbo\Storage\Doctrine')
+            ->setConstructorArgs(array([], $this->connection))
+            ->setMethods(array('imageExists'))
+            ->getMock();
+
+        $driverMock->expects($this->once())->method('imageExists')->will($this->returnValue(false));
+        $driverMock->store($this->user, 'image_identifier_not_used', 'image_data_not_used');
     }
 
     /**


### PR DESCRIPTION
The StorageOperations manager expects an exception to be thrown if saving image data fails. The Doctrine and Filesystem drivers instead returned a boolean, which meant that we failed quietly on write failure. 

This introduces the 507 HTTP Error Code (`507 Insufficient Storage`) for writes that fail on the filesystem storage driver, while using the regular 500 error for Doctrine fails (which can be caused by other issues than insufficient storage).

9c691e0changes the StorageTest abstract class so implementing classes can retrieve the user configuration and the active driver (as a new call to `getDriver` would create a different driver object than the one being used for the running tests). This makes it easier to create local tests for each driver.