### PR TITLE
When resizing with one param round up the other calculated value

### DIFF
--- a/library/Imbo/Image/Transformation/Resize.php
+++ b/library/Imbo/Image/Transformation/Resize.php
@@ -57,9 +57,9 @@ class Resize extends Transformation implements ListenerInterface {
 
         // Calculate width or height if not both have been specified
         if (!$height) {
-            $height = ($originalHeight / $originalWidth) * $width;
+            $height = ceil(($originalHeight / $originalWidth) * $width);
         } else if (!$width) {
-            $width = ($originalWidth / $originalHeight) * $height;
+            $width = ceil(($originalWidth / $originalHeight) * $height);
         }
 
         try {

--- a/tests/behat/features/image-transformations.feature
+++ b/tests/behat/features/image-transformations.feature
@@ -59,8 +59,8 @@ Feature: Imbo enables dynamic transformations of images
             | modulate:b=1,s=2                                                                                  | 599   | 417    |
             | modulate:b=1,s=2,h=3                                                                              | 599   | 417    |
             | progressive                                                                                       | 599   | 417    |
-            | resize:width=100                                                                                  | 100   | 69     |
-            | resize:height=200                                                                                 | 287   | 200    |
+            | resize:width=100                                                                                  | 100   | 70     |
+            | resize:height=200                                                                                 | 288   | 200    |
             | resize:width=100,height=100                                                                       | 100   | 100    |
             | rotate:angle=90                                                                                   | 417   | 599    |
             | sepia                                                                                             | 599   | 417    |

--- a/tests/phpunit/ImboIntegrationTest/Image/Transformation/ResizeTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Image/Transformation/ResizeTest.php
@@ -37,12 +37,12 @@ class ResizeTest extends TransformationTests {
                 'params'         => ['width' => 100],
                 'transformation' => true,
                 'resizedWidth'   => 100,
-                'resizedHeight'  => 69,
+                'resizedHeight'  => 70,
             ],
             'only height' => [
                 'params'         => ['height' => 100],
                 'transformation' => true,
-                'resizedWidth'   => 143,
+                'resizedWidth'   => 144,
                 'resizedHeight'  => 100,
             ],
             'width and height' => [


### PR DESCRIPTION
When imagick recieves a float as a resize width/height it casts
the value to an int. This could result in resized images beeing
1px too low/small.

After imbo 2.0 introduced new strict croping, when imageVariations
saves an variation which is 1px wider/higher than the actual
cropped image, imbo will throw a 400 error saying y+cropheight >
imageHeight.

Updated tests