### PR TITLE
Prevent race conditions in image transformation cache

### DIFF
--- a/library/Imbo/EventListener/ImageTransformationCache.php
+++ b/library/Imbo/EventListener/ImageTransformationCache.php
@@ -38,11 +38,18 @@ use Imbo\EventManager\EventInterface,
  */
 class ImageTransformationCache implements ListenerInterface {
     /**
-     * Root path where the temp. images can be stored
+     * Root path where the cached images can be stored
      *
      * @var string
      */
     private $path;
+
+    /**
+     * Whether or not this request hit a cached version
+     *
+     * @var boolean
+     */
+    private $cacheHit = false;
 
     /**
      * Class constructor
@@ -120,6 +127,9 @@ class ImageTransformationCache implements ListenerInterface {
                 // Stop other listeners on this event
                 $event->stopPropagation();
 
+                // Mark this as a cache hit to prevent us from re-writing the result
+                $this->cacheHit = true;
+
                 return;
             } else {
                 // Invalid data in the cache, delete the file
@@ -141,8 +151,8 @@ class ImageTransformationCache implements ListenerInterface {
         $response = $event->getResponse();
         $model = $response->getModel();
 
-        if (!$model instanceof Image) {
-            // Only store images in the cache
+        if (!$model instanceof Image || $this->cacheHit) {
+            // Only store images in the cache, and don't try to rewrite on cache hit
             return;
         }
 

--- a/library/Imbo/EventListener/ImageTransformationCache.php
+++ b/library/Imbo/EventListener/ImageTransformationCache.php
@@ -173,7 +173,14 @@ class ImageTransformationCache implements ListenerInterface {
         //
         // "What?! Did you forget to is_dir()-guard it?" - Mats Lindh
         if (is_dir($dir) || @mkdir($dir, 0775, true) || is_dir($dir)) {
-            if (file_put_contents($path. '.tmp', $data)) {
+            $tmpPath = $path. '.tmp';
+
+            // If in the middle of a cache write operation, fall back
+            if (file_exists($tmpPath) || file_exists($path)) {
+                return;
+            }
+
+            if (file_put_contents($tmpPath, $data)) {
                 rename($path. '.tmp', $path);
             }
         }


### PR DESCRIPTION
As outlined in #426, the image transformation cache listener currently has some race conditions. I was surprised to find that the listener will always re-write the cache file, even when fetched from cache, and was a little unsure if this was the intended behaviour because of creation timestamps or similar, but couldn't find any tests or documentation referring to it, so I've changed it to only write on cache miss.

I also added a few more checks that should make the chance of race conditions less likely, but I think that if we want to be 100% sure it doesn't trigger any errors, we need to actually silence the `rename()` call :-/

Opinions?