### PR TITLE
New mongodb adapters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y --reinstall install imagemagick
   - printf "\n" | pecl install --force mongo
+  - printf "\n" | pecl install --force mongodb
   - printf "\n" | pecl install --force memcached-2.2.0
   - printf "\n" | pecl install apcu-4.0.10
   - printf "\n" | pecl install imagick-3.4.0RC2

--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -5,6 +5,7 @@ Imbo-2.x.x
 ----------
 __N/A__
 
+* #436: Added new MongoDB adapters that use the mongodb extension (Christer Edvartsen)
 * #434: Custom models for group(s) and access rule(s) (Christer Edvartsen)
 
 Imbo-2.0.0

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,14 @@
     "mongodb/mongodb": "~1.0.0"
   },
   "require-dev": {
+    "symfony/filesystem": "~2.8.3",
     "mikey179/vfsStream": "~1.5.0",
     "phpunit/phpunit": "~4.8",
     "behat/behat": "~2.0",
     "guzzle/guzzle": "~3.9.3",
     "doctrine/dbal": "~2.5.1",
+    "doctrine/common": "~2.5.3",
+    "doctrine/cache": "~1.5.4",
     "aws/aws-sdk-php": "~2.8"
   },
   "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "symfony/http-foundation": "~2.7.3",
     "symfony/event-dispatcher": "~2.7.3",
     "symfony/console": "~2.7.3",
-    "ramsey/uuid": "~3.0.0"
+    "ramsey/uuid": "~3.0.0",
+    "mongodb/mongodb": "~1.0.0"
   },
   "require-dev": {
     "mikey179/vfsStream": "~1.5.0",
@@ -34,6 +35,7 @@
   },
   "suggest": {
     "ext-mongo": "Enables usage of MongoDB and GridFS as database and store. Recommended version: >=1.4.0",
+    "ext-mongodb": "Enables usage of the new MongoDB extension. Recommended version: >=1.1.3",
     "ext-memcached": "Enables usage of the Memcached cache adapter for custom event listeners. Recommended version: >=2.0.0",
     "doctrine/dbal": "Enables usage of using RDMS for storing data (and optionally images). Recommended version: >=2.3",
     "aws/aws-sdk-php": "Enables usage of the AWS S3 storage adapter. Recommended version >=2.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,81 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "127a7007449934d40c5bc137c1686318",
-    "content-hash": "2a13f8fe970e7fbccdaffeb5e642818e",
+    "hash": "e0a30653abd55a916ebf410881ba31a3",
+    "content-hash": "0398b6d33a530bcf9b3c9908f0620ca7",
     "packages": [
         {
-            "name": "ramsey/uuid",
-            "version": "3.0.0",
+            "name": "mongodb/mongodb",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ramsey/uuid.git",
-                "reference": "0c0ac34e867219bb9936cc5b823f8a5af840d7eb"
+                "url": "https://github.com/mongodb/mongo-php-library.git",
+                "reference": "6093d68c06bebcc5361b9e49178725efd9182ed4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/0c0ac34e867219bb9936cc5b823f8a5af840d7eb",
-                "reference": "0c0ac34e867219bb9936cc5b823f8a5af840d7eb",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/6093d68c06bebcc5361b9e49178725efd9182ed4",
+                "reference": "6093d68c06bebcc5361b9e49178725efd9182ed4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mongodb": "^1.1.0",
+                "php": ">=5.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MongoDB\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Mikola",
+                    "email": "jmikola@gmail.com"
+                },
+                {
+                    "name": "Hannes Magnusson",
+                    "email": "bjori@mongodb.com"
+                },
+                {
+                    "name": "Derick Rethans",
+                    "email": "github@derickrethans.nl"
+                }
+            ],
+            "description": "MongoDB driver library",
+            "homepage": "https://jira.mongodb.org/browse/PHPLIB",
+            "keywords": [
+                "database",
+                "driver",
+                "mongodb",
+                "persistence"
+            ],
+            "time": "2016-03-04 20:27:01"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "3c84b9e2965a5fa666dec8617a3a66a8179c6ca8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/3c84b9e2965a5fa666dec8617a3a66a8179c6ca8",
+                "reference": "3c84b9e2965a5fa666dec8617a3a66a8179c6ca8",
                 "shasum": ""
             },
             "require": {
@@ -37,17 +97,13 @@
                 "squizlabs/php_codesniffer": "^2.3"
             },
             "suggest": {
-                "ircmaxell/random-lib": "Provides RandomLib to use with the RandomLibAdapter",
-                "moontoast/math": "Support for converting UUID to 128-bit integer (in string form).",
+                "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
+                "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
                 "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
-                "ramsey/uuid-doctrine": "Allow the use of a UUID as Doctrine field type."
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Ramsey\\Uuid\\": "src/"
@@ -79,20 +135,20 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2015-09-28 16:27:51"
+            "time": "2015-10-21 16:27:25"
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.5",
+            "version": "v2.7.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "06cb17c013a82f94a3d840682b49425cd00a2161"
+                "reference": "ee91ec301cd88ee38ab14505025fe94bbc19a9c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/06cb17c013a82f94a3d840682b49425cd00a2161",
-                "reference": "06cb17c013a82f94a3d840682b49425cd00a2161",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ee91ec301cd88ee38ab14505025fe94bbc19a9c1",
+                "reference": "ee91ec301cd88ee38ab14505025fe94bbc19a9c1",
                 "shasum": ""
             },
             "require": {
@@ -101,7 +157,6 @@
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/event-dispatcher": "~2.1",
-                "symfony/phpunit-bridge": "~2.7",
                 "symfony/process": "~2.1"
             },
             "suggest": {
@@ -118,7 +173,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -136,20 +194,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-25 08:32:23"
+            "time": "2016-02-28 16:19:47"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.5",
+            "version": "v2.7.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9"
+                "reference": "b68c0348ba5b3927a6c8e413cc7d594f3ccff3ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
-                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b68c0348ba5b3927a6c8e413cc7d594f3ccff3ce",
+                "reference": "b68c0348ba5b3927a6c8e413cc7d594f3ccff3ce",
                 "shasum": ""
             },
             "require": {
@@ -160,7 +218,6 @@
                 "symfony/config": "~2.0,>=2.0.5",
                 "symfony/dependency-injection": "~2.6",
                 "symfony/expression-language": "~2.6",
-                "symfony/phpunit-bridge": "~2.7",
                 "symfony/stopwatch": "~2.3"
             },
             "suggest": {
@@ -176,7 +233,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -194,28 +254,27 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-22 13:49:29"
+            "time": "2016-01-27 05:09:39"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.7.5",
+            "version": "v2.7.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "e1509119f164a0d0a940d7d924d693a7a28a5470"
+                "reference": "6aeb70d26da8f30753111b3f9cf47eb0421c0735"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e1509119f164a0d0a940d7d924d693a7a28a5470",
-                "reference": "e1509119f164a0d0a940d7d924d693a7a28a5470",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6aeb70d26da8f30753111b3f9cf47eb0421c0735",
+                "reference": "6aeb70d26da8f30753111b3f9cf47eb0421c0735",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
             "require-dev": {
-                "symfony/expression-language": "~2.4",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/expression-language": "~2.4"
             },
             "type": "library",
             "extra": {
@@ -229,6 +288,9 @@
                 },
                 "classmap": [
                     "Resources/stubs"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -247,22 +309,22 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-22 13:49:29"
+            "time": "2016-02-28 16:19:47"
         }
     ],
     "packages-dev": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "2.8.21",
+            "version": "2.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "92642ca4906e6681a1301971cf41500d7c68581c"
+                "reference": "c1605360b6624958a5397601ad5543cd45fcf8f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/92642ca4906e6681a1301971cf41500d7c68581c",
-                "reference": "92642ca4906e6681a1301971cf41500d7c68581c",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c1605360b6624958a5397601ad5543cd45fcf8f7",
+                "reference": "c1605360b6624958a5397601ad5543cd45fcf8f7",
                 "shasum": ""
             },
             "require": {
@@ -312,7 +374,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2015-09-17 00:17:24"
+            "time": "2016-01-30 00:53:32"
         },
         {
             "name": "behat/behat",
@@ -507,38 +569,38 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.4.2",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "8c434000f420ade76a07c64cbe08ca47e5c101ca"
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/8c434000f420ade76a07c64cbe08ca47e5c101ca",
-                "reference": "8c434000f420ade76a07c64cbe08ca47e5c101ca",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "~5.5|~7.0"
             },
             "conflict": {
                 "doctrine/common": ">2.2,<2.4"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=3.7",
+                "phpunit/phpunit": "~4.8|~5.0",
                 "predis/predis": "~1.0",
                 "satooshi/php-coveralls": "~0.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Cache\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -573,7 +635,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-08-31 12:36:41"
+            "time": "2015-12-31 16:37:02"
         },
         {
             "name": "doctrine/collections",
@@ -643,16 +705,16 @@
         },
         {
             "name": "doctrine/common",
-            "version": "v2.5.1",
+            "version": "v2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "0009b8f0d4a917aabc971fb089eba80e872f83f9"
+                "reference": "a579557bc689580c19fee4e27487a67fe60defc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/0009b8f0d4a917aabc971fb089eba80e872f83f9",
-                "reference": "0009b8f0d4a917aabc971fb089eba80e872f83f9",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/a579557bc689580c19fee4e27487a67fe60defc0",
+                "reference": "a579557bc689580c19fee4e27487a67fe60defc0",
                 "shasum": ""
             },
             "require": {
@@ -661,20 +723,20 @@
                 "doctrine/collections": "1.*",
                 "doctrine/inflector": "1.*",
                 "doctrine/lexer": "1.*",
-                "php": ">=5.3.2"
+                "php": "~5.5|~7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~3.7"
+                "phpunit/phpunit": "~4.8|~5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6.x-dev"
+                    "dev-master": "2.7.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -712,24 +774,24 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-08-31 13:00:22"
+            "time": "2015-12-25 13:18:31"
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.5.2",
+            "version": "v2.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "01dbcbc5cd0a913d751418e635434a18a2f2a75c"
+                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/01dbcbc5cd0a913d751418e635434a18a2f2a75c",
-                "reference": "01dbcbc5cd0a913d751418e635434a18a2f2a75c",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
                 "shasum": ""
             },
             "require": {
-                "doctrine/common": ">=2.4,<2.6-dev",
+                "doctrine/common": ">=2.4,<2.7-dev",
                 "php": ">=5.3.2"
             },
             "require-dev": {
@@ -783,20 +845,20 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2015-09-16 16:29:33"
+            "time": "2016-01-05 22:11:12"
         },
         {
             "name": "doctrine/inflector",
-            "version": "v1.0.1",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "0bcb2e79d8571787f18b7eb036ed3d004908e604"
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/0bcb2e79d8571787f18b7eb036ed3d004908e604",
-                "reference": "0bcb2e79d8571787f18b7eb036ed3d004908e604",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
                 "shasum": ""
             },
             "require": {
@@ -808,7 +870,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -850,7 +912,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2014-12-20 21:24:13"
+            "time": "2015-11-06 14:35:42"
         },
         {
             "name": "doctrine/instantiator",
@@ -1152,22 +1214,24 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7"
+                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4745ded9307786b730d7a60df5cb5a6c43cf95f7",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3c91bdf81797d725b14cb62906f9a4ce44235972",
+                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1"
+                "sebastian/comparator": "~1.1",
+                "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "~2.0"
@@ -1175,7 +1239,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.5.x-dev"
                 }
             },
             "autoload": {
@@ -1208,20 +1272,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2015-08-13 10:07:40"
+            "time": "2016-02-15 07:46:21"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.3",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f"
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef1ca6835468857944d5c3b48fa503d5554cff2f",
-                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
                 "shasum": ""
             },
             "require": {
@@ -1270,7 +1334,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-09-14 06:51:16"
+            "time": "2015-10-06 15:47:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1452,16 +1516,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.9",
+            "version": "4.8.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "73fad41adb5b7bc3a494bb930d90648df1d5e74b"
+                "reference": "6e351261f9cd33daf205a131a1ba61c6d33bd483"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/73fad41adb5b7bc3a494bb930d90648df1d5e74b",
-                "reference": "73fad41adb5b7bc3a494bb930d90648df1d5e74b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6e351261f9cd33daf205a131a1ba61c6d33bd483",
+                "reference": "6e351261f9cd33daf205a131a1ba61c6d33bd483",
                 "shasum": ""
             },
             "require": {
@@ -1520,20 +1584,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-09-20 12:56:44"
+            "time": "2016-02-11 14:56:33"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.7",
+            "version": "2.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "5e2645ad49d196e020b85598d7c97e482725786a"
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5e2645ad49d196e020b85598d7c97e482725786a",
-                "reference": "5e2645ad49d196e020b85598d7c97e482725786a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
                 "shasum": ""
             },
             "require": {
@@ -1576,7 +1640,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-08-19 09:14:08"
+            "time": "2015-10-02 06:51:40"
         },
         {
             "name": "sebastian/comparator",
@@ -1644,28 +1708,28 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.3.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -1688,24 +1752,24 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2015-02-22 15:13:53"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.2",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
                 "shasum": ""
             },
             "require": {
@@ -1742,7 +1806,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-08-03 06:14:51"
+            "time": "2016-02-26 18:40:46"
         },
         {
             "name": "sebastian/exporter",
@@ -1812,16 +1876,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01"
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
                 "shasum": ""
             },
             "require": {
@@ -1859,20 +1923,20 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2014-10-06 09:23:50"
+            "time": "2015-10-12 03:26:01"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
                 "shasum": ""
             },
             "require": {
@@ -1912,7 +1976,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-06-21 08:04:50"
+            "time": "2015-11-11 19:50:13"
         },
         {
             "name": "sebastian/version",
@@ -1951,35 +2015,38 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9698fdf0a750d6887d5e7729d5cf099765b20e61"
+                "reference": "0f8f94e6a32b5c480024eed5fa5cbd2790d0ad19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9698fdf0a750d6887d5e7729d5cf099765b20e61",
-                "reference": "9698fdf0a750d6887d5e7729d5cf099765b20e61",
+                "url": "https://api.github.com/repos/symfony/config/zipball/0f8f94e6a32b5c480024eed5fa5cbd2790d0ad19",
+                "reference": "0f8f94e6a32b5c480024eed5fa5cbd2790d0ad19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
-                "symfony/filesystem": "~2.3"
+                "symfony/filesystem": "~2.3|~3.0.0"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Config\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1997,20 +2064,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-21 15:02:29"
+            "time": "2016-02-22 16:12:45"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "422c3819b110f610d79c6f1dc38af23787dc790e"
+                "reference": "62251761a7615435b22ccf562384c588b431be44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/422c3819b110f610d79c6f1dc38af23787dc790e",
-                "reference": "422c3819b110f610d79c6f1dc38af23787dc790e",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/62251761a7615435b22ccf562384c588b431be44",
+                "reference": "62251761a7615435b22ccf562384c588b431be44",
                 "shasum": ""
             },
             "require": {
@@ -2020,10 +2087,9 @@
                 "symfony/expression-language": "<2.6"
             },
             "require-dev": {
-                "symfony/config": "~2.2",
-                "symfony/expression-language": "~2.6",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/yaml": "~2.1"
+                "symfony/config": "~2.2|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/yaml": "~2.1|~3.0.0"
             },
             "suggest": {
                 "symfony/config": "",
@@ -2033,13 +2099,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\DependencyInjection\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2057,38 +2126,38 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-15 08:30:42"
+            "time": "2016-02-28 16:34:46"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.5",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "a17f8a17c20e8614c15b8e116e2f4bcde102cfab"
+                "reference": "23ae8f9648d0a7fe94a47c8e20e5bf37c489a451"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a17f8a17c20e8614c15b8e116e2f4bcde102cfab",
-                "reference": "a17f8a17c20e8614c15b8e116e2f4bcde102cfab",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
+                "reference": "23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2106,38 +2175,38 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-09 17:42:36"
+            "time": "2016-02-23 15:16:06"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8262ab605973afbb3ef74b945daabf086f58366f"
+                "reference": "877bb4b16ea573cc8c024e9590888fcf7eb7e0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8262ab605973afbb3ef74b945daabf086f58366f",
-                "reference": "8262ab605973afbb3ef74b945daabf086f58366f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/877bb4b16ea573cc8c024e9590888fcf7eb7e0f7",
+                "reference": "877bb4b16ea573cc8c024e9590888fcf7eb7e0f7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2155,34 +2224,93 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-19 19:59:23"
+            "time": "2016-02-22 16:12:45"
         },
         {
-            "name": "symfony/translation",
-            "version": "v2.7.5",
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "485877661835e188cd78345c6d4eef1290d17571"
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "1289d16209491b584839022f29257ad859b8532d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/485877661835e188cd78345c6d4eef1290d17571",
-                "reference": "485877661835e188cd78345c6d4eef1290d17571",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d",
+                "reference": "1289d16209491b584839022f29257ad859b8532d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-01-20 09:13:37"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v2.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "b7b4ebadd2b5e614ff7d2d6fc63e0ed0578909c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b7b4ebadd2b5e614ff7d2d6fc63e0ed0578909c7",
+                "reference": "b7b4ebadd2b5e614ff7d2d6fc63e0ed0578909c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/config": "<2.7"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.7",
-                "symfony/intl": "~2.4",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/yaml": "~2.2"
+                "symfony/config": "~2.8",
+                "symfony/intl": "~2.4|~3.0.0",
+                "symfony/yaml": "~2.2|~3.0.0"
             },
             "suggest": {
                 "psr/log": "To use logging capability in translator",
@@ -2192,13 +2320,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Translation\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2216,38 +2347,38 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-06 08:36:38"
+            "time": "2016-02-02 09:49:18"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.5",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770"
+                "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
-                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
+                "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2265,7 +2396,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-14 14:14:09"
+            "time": "2016-02-23 07:41:20"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -2228,7 +2228,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.1.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e0a30653abd55a916ebf410881ba31a3",
-    "content-hash": "0398b6d33a530bcf9b3c9908f0620ca7",
+    "hash": "a742001ab4a1a81d0941aa26f10219c2",
+    "content-hash": "4f3fcf0be9b466df12bd735e1fc672fd",
     "packages": [
         {
             "name": "mongodb/mongodb",
@@ -569,33 +569,33 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.6.0",
+            "version": "v1.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
+                "reference": "47cdc76ceb95cc591d9c79a36dc3794975b5d136"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/47cdc76ceb95cc591d9c79a36dc3794975b5d136",
+                "reference": "47cdc76ceb95cc591d9c79a36dc3794975b5d136",
                 "shasum": ""
             },
             "require": {
-                "php": "~5.5|~7.0"
+                "php": ">=5.3.2"
             },
             "conflict": {
                 "doctrine/common": ">2.2,<2.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8|~5.0",
+                "phpunit/phpunit": ">=3.7",
                 "predis/predis": "~1.0",
                 "satooshi/php-coveralls": "~0.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.5.x-dev"
                 }
             },
             "autoload": {
@@ -635,7 +635,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31 16:37:02"
+            "time": "2015-12-19 05:03:47"
         },
         {
             "name": "doctrine/collections",
@@ -705,16 +705,16 @@
         },
         {
             "name": "doctrine/common",
-            "version": "v2.6.1",
+            "version": "v2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "a579557bc689580c19fee4e27487a67fe60defc0"
+                "reference": "10f1f19651343f87573129ca970aef1a47a6f29e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/a579557bc689580c19fee4e27487a67fe60defc0",
-                "reference": "a579557bc689580c19fee4e27487a67fe60defc0",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/10f1f19651343f87573129ca970aef1a47a6f29e",
+                "reference": "10f1f19651343f87573129ca970aef1a47a6f29e",
                 "shasum": ""
             },
             "require": {
@@ -723,20 +723,20 @@
                 "doctrine/collections": "1.*",
                 "doctrine/inflector": "1.*",
                 "doctrine/lexer": "1.*",
-                "php": "~5.5|~7.0"
+                "php": ">=5.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8|~5.0"
+                "phpunit/phpunit": "~3.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7.x-dev"
+                    "dev-master": "2.5.x-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                "psr-0": {
+                    "Doctrine\\Common\\": "lib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -774,7 +774,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-12-25 13:18:31"
+            "time": "2015-12-25 13:10:16"
         },
         {
             "name": "doctrine/dbal",
@@ -2130,25 +2130,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.0.3",
+            "version": "v2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "23ae8f9648d0a7fe94a47c8e20e5bf37c489a451"
+                "reference": "65cb36b6539b1d446527d60457248f30d045464d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
-                "reference": "23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/65cb36b6539b1d446527d60457248f30d045464d",
+                "reference": "65cb36b6539b1d446527d60457248f30d045464d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -2175,7 +2175,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-23 15:16:06"
+            "time": "2016-02-22 15:02:30"
         },
         {
             "name": "symfony/finder",

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -319,6 +319,11 @@ Examples
         // ...
     ];
 
+Mongo
++++++
+
+This adapter uses PHP's `mongodb extension <http://pecl.php.net/package/mongodb>`_. It can be configured in the same was as the :ref:`mongodb-database-adapter` adapter.
+
 Custom database adapter
 +++++++++++++++++++++++
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -38,3 +38,4 @@ Lighttpd
 ETag
 Uuid
 gaussian
+Mongo

--- a/library/Imbo/Auth/AccessControl/Adapter/Mongo.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/Mongo.php
@@ -13,10 +13,10 @@ namespace Imbo\Auth\AccessControl\Adapter;
 use Imbo\Exception\DatabaseException,
     Imbo\Auth\AccessControl\GroupQuery,
     Imbo\Model\Groups as GroupsModel,
-    MongoClient,
-    MongoCollection,
-    MongoException,
-    MongoId;
+    MongoDB\Client as MongoClient,
+    MongoDB\Collection as MongoCollection,
+    MongoDB\Driver\Exception\Exception as MongoException,
+    MongoDB\BSON\ObjectID as MongoId;
 
 /**
  * MongoDB access control adapter
@@ -33,7 +33,7 @@ use Imbo\Exception\DatabaseException,
  * @author Kristoffer Brabrand <kristoffer@brabrand.no>
  * @package Core\Auth\AccessControl\Adapter
  */
-class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
+class Mongo extends AbstractAdapter implements MutableAdapterInterface {
     /**
      * Mongo client instance
      *
@@ -118,20 +118,22 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
         }
 
         $cursor = $this->getGroupsCollection()
-            ->find()
-            ->skip(($query->page() - 1) * $query->limit())
-            ->limit($query->limit());
+            ->find([], [
+                'skip' => ($query->page() - 1) * $query->limit(),
+                'limit' => $query->limit(),
+            ]);
 
         $groups = [];
+
         foreach ($cursor as $group) {
-            $groups[$group['name']] = $group['resources'];
+            $groups[$group['name']] = $group['resources']->getArrayCopy();
         }
 
         // Cache the retrieved groups
         $this->groups = array_merge($this->groups, $groups);
 
         // Update model with total hits
-        $model->setHits($cursor->count());
+        $model->setHits($this->getGroupsCollection()->count());
 
         return $groups;
     }
@@ -158,8 +160,9 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
         ]);
 
         if (isset($group['resources'])) {
-            $this->groups[$groupName] = $group['resources'];
-            return $group['resources'];
+            $this->groups[$groupName] = $group['resources']->getArrayCopy();
+
+            return $this->groups[$groupName];
         }
 
         return false;
@@ -183,14 +186,13 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
      */
     public function addKeyPair($publicKey, $privateKey) {
         try {
-            $result = $this->getAclCollection()->insert([
+            $result = $this->getAclCollection()->insertOne([
                 'publicKey' => $publicKey,
                 'privateKey' => $privateKey,
                 'acl' => []
             ]);
 
-            return (bool) $result['ok'];
-
+            return (bool) $result->getInsertedCount();
         } catch (MongoException $e) {
             throw new DatabaseException('Could not insert key into database', 500, $e);
         }
@@ -201,14 +203,13 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
      */
     public function deletePublicKey($publicKey) {
         try {
-            $result = $this->getAclCollection()->remove([
+            $result = $this->getAclCollection()->deleteOne([
                 'publicKey' => $publicKey
             ]);
 
             unset($this->publicKeys[$publicKey]);
 
-            return (bool) $result['ok'];
-
+            return (bool) $result->getDeletedCount();
         } catch (MongoException $e) {
             throw new DatabaseException('Could not delete key from database', 500, $e);
         }
@@ -219,15 +220,14 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
      */
     public function updatePrivateKey($publicKey, $privateKey) {
         try {
-            $result = $this->getAclCollection()->update(
+            $result = $this->getAclCollection()->updateOne(
                 ['publicKey' => $publicKey],
                 ['$set' => ['privateKey' => $privateKey]]
             );
 
             unset($this->publicKeys[$publicKey]);
 
-            return (bool) $result['updatedExisting'];
-
+            return (bool) $result->getMatchedCount();
         } catch (MongoException $e) {
             throw new DatabaseException('Could not update key in database', 500, $e);
         }
@@ -253,7 +253,7 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
      */
     public function addAccessRule($publicKey, array $accessRule) {
         try {
-            $result = $this->getAclCollection()->update(
+            $result = $this->getAclCollection()->updateOne(
                 ['publicKey' => $publicKey],
                 ['$push' => ['acl' => array_merge(
                     ['id' => $id = new MongoId()],
@@ -272,7 +272,7 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
      */
     public function deleteAccessRule($publicKey, $accessId) {
         try {
-            $result = $this->getAclCollection()->update(
+            $result = $this->getAclCollection()->updateOne(
                 ['publicKey' => $publicKey],
                 [
                     '$pull' => [
@@ -283,7 +283,7 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
                 ]
             );
 
-            return (bool) $result['ok'];
+            return (bool) $result->getMatchedCount();
         } catch (MongoException $e) {
             throw new DatabaseException('Could not delete rule from database', 500, $e);
         }
@@ -294,7 +294,7 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
      */
     public function addResourceGroup($groupName, array $resources = []) {
         try {
-            $this->getGroupsCollection()->insert([
+            $this->getGroupsCollection()->insertOne([
                 'name' => $groupName,
                 'resources' => $resources,
             ]);
@@ -310,7 +310,7 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
      */
     public function updateResourceGroup($groupName, array $resources) {
         try {
-            $this->getGroupsCollection()->update([
+            $this->getGroupsCollection()->updateOne([
                 'name' => $groupName
             ], [
                 '$set' => ['resources' => $resources],
@@ -328,16 +328,16 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
      */
     public function deleteResourceGroup($groupName) {
         try {
-            $result = $this->getGroupsCollection()->remove([
+            $result = $this->getGroupsCollection()->deleteOne([
                 'name' => $groupName,
             ]);
 
-            if ($result['ok']) {
+            if ($result->getDeletedCount()) {
                 // Remove from local cache
                 unset($this->groups[$groupName]);
 
                 // Also remove ACL rules that depended on this group
-                $this->getAclCollection()->update(
+                $this->getAclCollection()->updateMany(
                     ['acl.group' => $groupName],
                     [
                         '$pull' => [
@@ -345,12 +345,11 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
                                 'group' => $groupName
                             ]
                         ]
-                    ],
-                    ['multiple' => true]
+                    ]
                 );
             }
 
-            return (boolean) $result['n'];
+            return (bool) $result->getDeletedCount();
         } catch (MongoException $e) {
             throw new DatabaseException('Could not delete resource group from database', 500, $e);
         }
@@ -393,14 +392,29 @@ class MongoDB extends AbstractAdapter implements MutableAdapterInterface {
 
         // Not in cache, fetch from database
         $pubkeyInfo = $this->getAclCollection()->findOne([
-            'publicKey' => $publicKey
+            'publicKey' => $publicKey,
         ]);
 
-        if ($pubkeyInfo) {
-            $this->publicKeys[$publicKey] = $pubkeyInfo;
+        if (!$pubkeyInfo) {
+            return [];
         }
 
-        return $pubkeyInfo;
+        $data = $pubkeyInfo->getArrayCopy();
+        $acl = [];
+
+        foreach ($data['acl'] as $rule) {
+            $rule = $rule->getArrayCopy();
+            $rule['resources'] = $rule['resources']->getArrayCopy();
+            $rule['users'] = $rule['users']->getArrayCopy();
+
+            $acl[] = $rule;
+        }
+
+        $data['acl'] = $acl;
+
+        $this->publicKeys[$publicKey] = $data;
+
+        return $data;
     }
 
     /**

--- a/library/Imbo/Auth/AccessControl/Adapter/MutableAdapterInterface.php
+++ b/library/Imbo/Auth/AccessControl/Adapter/MutableAdapterInterface.php
@@ -66,7 +66,7 @@ interface MutableAdapterInterface extends AdapterInterface {
      *
      * @param string $groupName Group name
      * @param array  $resources Array of resources (eg. 'image.get', 'user.head' etc)
-     * @param boolean
+     * @return boolean
      */
     function addResourceGroup($groupName, array $resources = []);
 

--- a/library/Imbo/Database/Mongo.php
+++ b/library/Imbo/Database/Mongo.php
@@ -1,0 +1,673 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Database;
+
+use Imbo\Model\Image,
+    Imbo\Model\Images,
+    Imbo\Resource\Images\Query,
+    Imbo\Exception\DatabaseException,
+    MongoDB\Client as MongoClient,
+    MongoDB\Driver\Manager,
+    MongoDB\Driver\Command,
+    MongoDB\Collection as MongoCollection,
+    MongoDB\Driver\Exception\Exception as MongoException,
+    DateTime,
+    DateTimeZone;
+
+/**
+ * MongoDB database driver
+ *
+ * A MongoDB database driver for Imbo
+ *
+ * Valid parameters for this driver:
+ *
+ * - (string) databaseName Name of the database. Defaults to 'imbo'
+ * - (string) server The server string to use when connecting to MongoDB. Defaults to
+ *                   'mongodb://localhost:27017'
+ * - (array) options Options to use when creating the MongoDB\Client instance. Defaults to
+ *                   ['connect' => true, 'connectTimeoutMS' => 1000].
+ *
+ * @author Christer Edvartsen <cogo@starzinger.net>
+ * @package Database
+ */
+class Mongo implements DatabaseInterface {
+    /**
+     * Mongo client instance
+     *
+     * @var MongoClient
+     */
+    private $mongoClient;
+
+    /**
+     * The collection instances used by the driver
+     *
+     * @var array
+     */
+    private $collections = [
+        'image' => null,
+        'shortUrl' => null,
+    ];
+
+    /**
+     * Parameters for the driver
+     *
+     * @var array
+     */
+    private $params = [
+        // Database name
+        'databaseName' => 'imbo',
+
+        // Server string and ctor options
+        'server'  => 'mongodb://localhost:27017',
+        'options' => ['connect' => true, 'connectTimeoutMS' => 1000],
+    ];
+
+    /**
+     * Class constructor
+     *
+     * @param array $params Parameters for the driver
+     * @param MongoClient $client MongoClient instance
+     * @param MongoCollection $imageCollection MongoCollection instance for the images
+     * @param MongoCollection $shortUrlCollection MongoCollection instance for the short URLs
+     */
+    public function __construct(array $params = null, MongoClient $client = null, MongoCollection $imageCollection = null, MongoCollection $shortUrlCollection = null) {
+        if ($params !== null) {
+            $this->params = array_replace_recursive($this->params, $params);
+        }
+
+        if ($client !== null) {
+            $this->mongoClient = $client;
+        }
+
+        if ($imageCollection !== null) {
+            $this->collections['image'] = $imageCollection;
+        }
+
+        if ($shortUrlCollection !== null) {
+            $this->collections['shortUrl'] = $shortUrlCollection;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function insertImage($user, $imageIdentifier, Image $image) {
+        $now = time();
+
+        if ($added = $image->getAddedDate()) {
+            $added = $added->getTimestamp();
+        }
+
+        if ($updated = $image->getUpdatedDate()) {
+            $updated = $updated->getTimestamp();
+        }
+
+        if ($this->imageExists($user, $imageIdentifier)) {
+            try {
+                $this->getImageCollection()->updateOne(
+                    ['user' => $user, 'imageIdentifier' => $imageIdentifier],
+                    ['$set' => ['updated' => $now]]
+                );
+
+                return true;
+            } catch (MongoException $e) {
+                throw new DatabaseException('Unable to save image data', 500, $e);
+            }
+        }
+
+        $data = [
+            'size'             => $image->getFilesize(),
+            'user'             => $user,
+            'imageIdentifier'  => $imageIdentifier,
+            'extension'        => $image->getExtension(),
+            'mime'             => $image->getMimeType(),
+            'metadata'         => [],
+            'added'            => $added ?: $now,
+            'updated'          => $updated ?: $now,
+            'width'            => $image->getWidth(),
+            'height'           => $image->getHeight(),
+            'checksum'         => $image->getChecksum(),
+            'originalChecksum' => $image->getOriginalChecksum(),
+        ];
+
+        try {
+            $this->getImageCollection()->insertOne($data);
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to save image data', 500, $e);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteImage($user, $imageIdentifier) {
+        try {
+            $data = $this->getImageCollection()->findOne([
+                'user' => $user,
+                'imageIdentifier' => $imageIdentifier,
+            ]);
+
+            if ($data === null) {
+                throw new DatabaseException('Image not found', 404);
+            }
+
+            $this->getImageCollection()->deleteOne([
+                'user' => $user,
+                'imageIdentifier' => $imageIdentifier,
+            ]);
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to delete image data', 500, $e);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateMetadata($user, $imageIdentifier, array $metadata) {
+        try {
+            // Fetch existing metadata and merge with the incoming data
+            $existing = $this->getMetadata($user, $imageIdentifier);
+            $updatedMetadata = array_merge($existing, $metadata);
+
+            $this->getImageCollection()->updateOne(
+                ['user' => $user, 'imageIdentifier' => $imageIdentifier],
+                ['$set' => ['updated' => time(), 'metadata' => $updatedMetadata]]
+            );
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to update meta data', 500, $e);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata($user, $imageIdentifier) {
+        try {
+            $data = $this->getImageCollection()->findOne([
+                'user' => $user,
+                'imageIdentifier' => $imageIdentifier,
+            ]);
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to fetch meta data', 500, $e);
+        }
+
+        if ($data === null) {
+            throw new DatabaseException('Image not found', 404);
+        }
+
+        return $data['metadata']->getArrayCopy();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteMetadata($user, $imageIdentifier) {
+        try {
+            $data = $this->getImageCollection()->findOne([
+                'user' => $user,
+                'imageIdentifier' => $imageIdentifier,
+            ]);
+
+            if ($data === null) {
+                throw new DatabaseException('Image not found', 404);
+            }
+
+            $this->getImageCollection()->updateOne(
+                ['user' => $user, 'imageIdentifier' => $imageIdentifier],
+                ['$set' => ['metadata' => []]]
+            );
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to delete meta data', 500, $e);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImages(array $users, Query $query, Images $model) {
+        // Initialize return value
+        $images = [];
+
+        // Query data
+        $queryData = ['user' => ['$in' => $users]];
+
+        $from = $query->from();
+        $to = $query->to();
+
+        if ($from || $to) {
+            $tmp = [];
+
+            if ($from !== null) {
+                $tmp['$gte'] = $from;
+            }
+
+            if ($to !== null) {
+                $tmp['$lte'] = $to;
+            }
+
+            $queryData['added'] = $tmp;
+        }
+
+        $imageIdentifiers = $query->imageIdentifiers();
+
+        if (!empty($imageIdentifiers)) {
+            $queryData['imageIdentifier']['$in'] = $imageIdentifiers;
+        }
+
+        $checksums = $query->checksums();
+
+        if (!empty($checksums)) {
+            $queryData['checksum']['$in'] = $checksums;
+        }
+
+        $originalChecksums = $query->originalChecksums();
+
+        if (!empty($originalChecksums)) {
+            $queryData['originalChecksum']['$in'] = $originalChecksums;
+        }
+
+        // Sorting
+        $sort = ['added' => -1];
+
+        if ($querySort = $query->sort()) {
+            $sort = [];
+
+            foreach ($querySort as $s) {
+                $sort[$s['field']] = ($s['sort'] === 'asc' ? 1 : -1);
+            }
+        }
+
+        // Fields to fetch
+        $fields = array_fill_keys([
+            'extension', 'added', 'checksum', 'originalChecksum', 'updated',
+            'user', 'imageIdentifier', 'mime', 'size', 'width', 'height'
+        ], true);
+
+        if ($query->returnMetadata()) {
+            $fields['metadata'] = true;
+        }
+
+        try {
+            $options = [
+                'projection' => $fields,
+                'limit' => $query->limit(),
+                'sort' => $sort,
+            ];
+
+            // Skip some images if a page has been set
+            if (($page = $query->page()) > 1) {
+                $skip = $query->limit() * ($page - 1);
+                $options['skip'] = $skip;
+            }
+
+            $cursor = $this->getImageCollection()->find($queryData, $options);
+
+            foreach ($cursor as $image) {
+                unset($image['_id']);
+                $image['added'] = new DateTime('@' . $image['added'], new DateTimeZone('UTC'));
+                $image['updated'] = new DateTime('@' . $image['updated'], new DateTimeZone('UTC'));
+
+                if (isset($image['metadata'])) {
+                    $metadata = $image['metadata']->getArrayCopy();
+                    $image->offsetSet('metadata', $metadata);
+                }
+
+                $images[] = $image->getArrayCopy();
+            }
+
+            // Update model
+            $model->setHits($this->getImageCollection()->count($queryData));
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to search for images', 500, $e);
+        }
+
+        return $images;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImageProperties($user, $imageIdentifier) {
+        try {
+            $data = $this->getImageCollection()->findOne(
+                ['user' => $user, 'imageIdentifier' => $imageIdentifier],
+                array_fill_keys(['size', 'width', 'height', 'mime', 'extension', 'added', 'updated'], true)
+            );
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to fetch image data', 500, $e);
+        }
+        if ($data === null) {
+            throw new DatabaseException('Image not found', 404);
+        }
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load($user, $imageIdentifier, Image $image) {
+        $data = $this->getImageProperties($user, $imageIdentifier);
+
+        $image->setWidth($data['width'])
+              ->setHeight($data['height'])
+              ->setFilesize($data['size'])
+              ->setMimeType($data['mime'])
+              ->setExtension($data['extension'])
+              ->setAddedDate(new DateTime('@' . $data['added'], new DateTimeZone('UTC')))
+              ->setUpdatedDate(new DateTime('@' . $data['updated'], new DateTimeZone('UTC')));
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastModified(array $users, $imageIdentifier = null) {
+        try {
+            // Query on the user
+            $query = ['user' => ['$in' => $users]];
+
+            if ($imageIdentifier) {
+                // We want information about a single image. Add the identifier to the query
+                $query['imageIdentifier'] = $imageIdentifier;
+            }
+
+            // Find a document
+            $data = $this->getImageCollection()->findOne($query, [
+                'sort' => [
+                    'updated' => -1,
+                ],
+                'projection' => [
+                    'updated' => true
+                ],
+            ]);
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to fetch image data', 500, $e);
+        }
+
+        if ($data === null && $imageIdentifier) {
+            throw new DatabaseException('Image not found', 404);
+        } else if ($data === null) {
+            $data = ['updated' => time()];
+        }
+
+        return new DateTime('@' . $data['updated'], new DateTimeZone('UTC'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNumImages($user = null) {
+        try {
+            $query = [];
+
+            if ($user) {
+                $query['user'] = $user;
+            }
+
+            $result = (int) $this->getImageCollection()->count($query);
+
+            return $result;
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to fetch information from the database', 500, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNumBytes($user = null) {
+        try {
+            $pipeline = [
+                [
+                    '$group' => [
+                        '_id' => null,
+                        'numBytes' => [
+                            '$sum' => '$size',
+                        ],
+                    ],
+                ],
+            ];
+
+            if ($user) {
+                array_unshift($pipeline, [
+                    '$match' => [
+                        'user' => $user,
+                    ],
+                ]);
+            }
+
+            $result = $this->getImageCollection()->aggregate($pipeline, ['useCursor' => false]);
+
+            if (!count($result)) {
+                return 0;
+            }
+
+            return (int) $result[0]->numBytes;
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to fetch information from the database', 500, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNumUsers() {
+        try {
+            $result = (int) count($this->getImageCollection()->distinct('user'));
+
+            return $result;
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to fetch information from the database', 500, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatus() {
+        try {
+            // Create a manager and try to get servers
+            $manager = new Manager($this->params['server']);
+            $manager->executeCommand($this->params['databaseName'], new Command(['ping' => 1]));
+
+            return true;
+        } catch (MongoException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImageMimeType($user, $imageIdentifier) {
+        try {
+            $data = $this->getImageCollection()->findOne([
+                'user' => $user,
+                'imageIdentifier' => $imageIdentifier,
+            ]);
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to fetch image meta data', 500, $e);
+        }
+
+        if ($data === null) {
+            throw new DatabaseException('Image not found', 404);
+        }
+
+        return $data['mime'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function imageExists($user, $imageIdentifier) {
+        $data = $this->getImageCollection()->findOne([
+            'user' => $user,
+            'imageIdentifier' => $imageIdentifier,
+        ]);
+
+        return $data !== null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function insertShortUrl($shortUrlId, $user, $imageIdentifier, $extension = null, array $query = []) {
+        try {
+            $data = [
+                'shortUrlId' => $shortUrlId,
+                'user' => $user,
+                'imageIdentifier' => $imageIdentifier,
+                'extension' => $extension,
+                'query' => serialize($query),
+            ];
+
+            $this->getShortUrlCollection()->insertOne($data);
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to create short URL', 500, $e);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getShortUrlId($user, $imageIdentifier, $extension = null, array $query = []) {
+        try {
+            $result = $this->getShortUrlCollection()->findOne([
+                'user' => $user,
+                'imageIdentifier' => $imageIdentifier,
+                'extension' => $extension,
+                'query' => serialize($query),
+            ], [
+                'shortUrlId' => true,
+            ]);
+
+            if (!$result) {
+                return null;
+            }
+
+            return $result['shortUrlId'];
+        } catch (MongoException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getShortUrlParams($shortUrlId) {
+        try {
+            $result = $this->getShortUrlCollection()->findOne([
+                'shortUrlId' => $shortUrlId,
+            ], [
+                '_id' => false
+            ]);
+
+            if (!$result) {
+                return null;
+            }
+
+            $result['query'] = unserialize($result['query']);
+
+            return $result;
+        } catch (MongoException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteShortUrls($user, $imageIdentifier, $shortUrlId = null) {
+        $query = [
+            'user' => $user,
+            'imageIdentifier' => $imageIdentifier,
+        ];
+
+        if ($shortUrlId) {
+            $query['shortUrlId'] = $shortUrlId;
+        }
+
+        try {
+            $this->getShortUrlCollection()->deleteMany($query);
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to delete short URLs', 500, $e);
+        }
+
+        return true;
+    }
+
+    /**
+     * Fetch the image collection
+     *
+     * @return MongoCollection
+     */
+    private function getImageCollection() {
+        return $this->getCollection('image');
+    }
+
+    /**
+     * Fetch the shortUrl collection
+     *
+     * @return MongoCollection
+     */
+    private function getShortUrlCollection() {
+        return $this->getCollection('shortUrl');
+    }
+
+    /**
+     * Get the mongo collection instance
+     *
+     * @param string $type "image" or "shortUrl"
+     * @return MongoCollection
+     */
+    private function getCollection($type) {
+        if ($this->collections[$type] === null) {
+            try {
+                $this->collections[$type] = $this->getMongoClient()->selectCollection(
+                    $this->params['databaseName'],
+                    $type
+                );
+            } catch (MongoException $e) {
+                throw new DatabaseException('Could not select collection', 500, $e);
+            }
+        }
+
+        return $this->collections[$type];
+    }
+
+    /**
+     * Get the mongo client instance
+     *
+     * @return MongoClient
+     */
+    private function getMongoClient() {
+        if ($this->mongoClient === null) {
+            try {
+                $this->mongoClient = new MongoClient($this->params['server'], $this->params['options']);
+            } catch (MongoException $e) {
+                throw new DatabaseException('Could not connect to database', 500, $e);
+            }
+        }
+
+        return $this->mongoClient;
+    }
+}

--- a/library/Imbo/EventListener/ImageVariations/Database/Mongo.php
+++ b/library/Imbo/EventListener/ImageVariations/Database/Mongo.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\EventListener\ImageVariations\Database;
+
+use Imbo\Exception\DatabaseException,
+    MongoDB\Client as MongoClient,
+    MonboDB\Collection as MongoCollection,
+    MongoDB\Driver\Exception\Exception as MongoException;
+
+/**
+ * MongoDB database driver for the image variations
+ *
+ * Valid parameters for this driver:
+ *
+ * - (string) databaseName Name of the database. Defaults to 'imbo'
+ * - (string) server The server string to use when connecting to MongoDB. Defaults to
+ *                   'mongodb://localhost:27017'
+ * - (array) options Options to use when creating the MongoClient instance. Defaults to
+ *                   ['connect' => true, 'connectTimeoutMS' => 1000].
+ *
+ * @author Christer Edvartsen <cogo@starzinger.net>
+ * @package Database
+ */
+class Mongo implements DatabaseInterface {
+    /**
+     * Mongo client instance
+     *
+     * @var MongoClient
+     */
+    private $mongoClient;
+
+    /**
+     * The imagevariation collection
+     *
+     * @var MongoCollection
+     */
+    private $collection;
+
+    /**
+     * Parameters for the driver
+     *
+     * @var array
+     */
+    private $params = [
+        // Database name
+        'databaseName' => 'imbo',
+
+        // Server string and ctor options
+        'server'  => 'mongodb://localhost:27017',
+        'options' => ['connect' => true, 'connectTimeoutMS' => 1000],
+    ];
+
+    /**
+     * Class constructor
+     *
+     * @param array $params Parameters for the driver
+     * @param MongoClient $client MongoClient instance
+     * @param MongoCollection $collection MongoCollection instance for the image variation collection
+     */
+    public function __construct(array $params = null, MongoClient $client = null, MongoCollection $collection = null) {
+        if ($params !== null) {
+            $this->params = array_replace_recursive($this->params, $params);
+        }
+
+        if ($client !== null) {
+            $this->mongoClient = $client;
+        }
+
+        if ($collection !== null) {
+            $this->collection = $collection;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storeImageVariationMetadata($user, $imageIdentifier, $width, $height) {
+        try {
+            $this->getCollection()->insertOne([
+                'added' => time(),
+                'user' => $user,
+                'imageIdentifier'  => $imageIdentifier,
+                'width' => $width,
+                'height' => $height,
+            ]);
+        } catch (MongoException $e) {
+            throw new DatabaseException('Unable to save image variation data', 500, $e);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBestMatch($user, $imageIdentifier, $width) {
+        $query = [
+            'user' => $user,
+            'imageIdentifier' => $imageIdentifier,
+            'width' => [
+                '$gte' => $width,
+            ],
+        ];
+
+        $result = $this->getCollection()
+            ->findOne($query, [
+                'projection' => [
+                    '_id' => false,
+                    'width' => true,
+                    'height' => true,
+                ],
+                'sort' => [
+                    'width' => 1,
+                ],
+            ]);
+
+        return $result ? $result->getArrayCopy() : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteImageVariations($user, $imageIdentifier, $width = null) {
+        $query = [
+            'user' => $user,
+            'imageIdentifier' => $imageIdentifier,
+        ];
+
+        if ($width !== null) {
+            $query['width'] = $width;
+        }
+
+        $this->getCollection()->deleteMany($query);
+
+        return true;
+    }
+
+    /**
+     * Get the mongo collection
+     *
+     * @return MongoCollection
+     */
+    private function getCollection() {
+        if ($this->collection === null) {
+            try {
+                $this->collection = $this->getMongoClient()->selectCollection(
+                    $this->params['databaseName'],
+                    'imagevariation'
+                );
+            } catch (MongoException $e) {
+                throw new DatabaseException('Could not select collection', 500, $e);
+            }
+        }
+
+        return $this->collection;
+    }
+
+    /**
+     * Get the mongo client instance
+     *
+     * @return MongoClient
+     */
+    private function getMongoClient() {
+        if ($this->mongoClient === null) {
+            try {
+                $this->mongoClient = new MongoClient($this->params['server'], $this->params['options']);
+            } catch (MongoException $e) {
+                throw new DatabaseException('Could not connect to database', 500, $e);
+            }
+        }
+
+        return $this->mongoClient;
+    }
+}

--- a/tests/phpunit/ImboIntegrationTest/Auth/AccessControl/Adapter/AdapterTests.php
+++ b/tests/phpunit/ImboIntegrationTest/Auth/AccessControl/Adapter/AdapterTests.php
@@ -95,21 +95,44 @@ abstract class AdapterTests extends \PHPUnit_Framework_TestCase {
     }
 
     public function testCanRemoveGroup() {
-        $this->adapter->addResourceGroup('g1', ['images.get', 'images.head']);
+        // Try to delete group that does not exist
+        $this->assertFalse($this->adapter->deleteResourceGroup('g1'));
+
+        $this->assertTrue($this->adapter->addResourceGroup('g1', ['images.get', 'images.head']));
         $this->assertSame(['images.get', 'images.head'], $this->adapter->getGroup('g1'));
         $this->assertTrue($this->adapter->deleteResourceGroup('g1'));
         $this->assertSame(false, $this->adapter->getGroup('g1'));
     }
 
     public function testCanManipulateKeys() {
-        $this->assertNull($this->adapter->getPrivateKey('publicKey'));
+        // Ensure the public key does not exist
         $this->assertFalse($this->adapter->publicKeyExists('publicKey'));
+
+        // Get private key of a public key that does not exist
+        $this->assertNull($this->adapter->getPrivateKey('publicKey'));
+
+        // Try to update the private key of a public key that does not exist
+        $this->assertFalse($this->adapter->updatePrivateKey('publicKey', 'privateKey'));
+
+        // Add a key pair
         $this->assertTrue($this->adapter->addKeyPair('publicKey', 'privateKey'));
+
+        // Ensure it exists
         $this->assertTrue($this->adapter->publicKeyExists('publicKey'));
+
+        // Fetch the private key
         $this->assertSame('privateKey', $this->adapter->getPrivateKey('publicKey'));
+
+        // Change the public key
         $this->assertTrue($this->adapter->updatePrivateKey('publicKey', 'newPrivateKey'));
+
+        // Make sure the change occured
         $this->assertSame('newPrivateKey', $this->adapter->getPrivateKey('publicKey'));
+
+        // Delete the key
         $this->assertTrue($this->adapter->deletePublicKey('publicKey'));
+
+        // Ensure the key no longer exists
         $this->assertFalse($this->adapter->publicKeyExists('publicKey'));
         $this->assertNull($this->adapter->getPrivateKey('publicKey'));
     }

--- a/tests/phpunit/ImboIntegrationTest/Auth/AccessControl/Adapter/MongoTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Auth/AccessControl/Adapter/MongoTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboIntegrationTest\Auth\AccessControl\Adapter;
+
+use Imbo\Auth\AccessControl\Adapter\Mongo,
+    MongoDB\Client as MongoClient;
+
+/**
+ * @covers Imbo\Auth\AccessControl\Adapter\Mongo
+ * @group integration
+ * @group mongo
+ */
+class MongoTest extends AdapterTests {
+    /**
+     * Name of the test database
+     *
+     * @var string
+     */
+    protected $databaseName = 'imboIntegrationTestAuth';
+
+    /**
+     * @see ImboIntegrationTest\Database\DatabaseTests::getAdapter()
+     */
+    protected function getAdapter() {
+        return new Mongo([
+            'databaseName' => $this->databaseName,
+        ]);
+    }
+
+    /**
+     * Make sure we have the mongo extension available and drop the test database just in case
+     */
+    public function setUp() {
+        if (!class_exists('MongoDB\Client')) {
+            $this->markTestSkipped('pecl/mongodb >= 1.1.3 is required to run this test');
+        }
+
+        $client = new MongoClient();
+        $client->dropDatabase($this->databaseName);
+
+        parent::setUp();
+    }
+
+    /**
+     * Drop the test database after each test
+     */
+    public function tearDown() {
+        if (class_exists('MongoDB\Client')) {
+            $client = new MongoClient();
+            $client->dropDatabase($this->databaseName);
+        }
+
+        parent::tearDown();
+    }
+}

--- a/tests/phpunit/ImboIntegrationTest/Database/DatabaseTests.php
+++ b/tests/phpunit/ImboIntegrationTest/Database/DatabaseTests.php
@@ -680,4 +680,8 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
             $this->assertSame($values[$i], $image[$field]);
         }
     }
+
+    public function testCanGetStatus() {
+        $this->assertTrue($this->adapter->getStatus());
+    }
 }

--- a/tests/phpunit/ImboIntegrationTest/Database/MongoTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Database/MongoTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboIntegrationTest\Database;
+
+use Imbo\Database\Mongo,
+    MongoDB\Client as MongoClient;
+
+/**
+ * @covers Imbo\Database\Mongo
+ * @group integration
+ * @group database
+ * @group mongo
+ */
+class MongoTest extends DatabaseTests {
+    protected $databaseName = 'imboIntegrationTestDatabase';
+
+    /**
+     * @see ImboIntegrationTest\Database\DatabaseTests::getAdapter()
+     */
+    protected function getAdapter() {
+        return new Mongo([
+            'databaseName' => $this->databaseName,
+        ]);
+    }
+
+    /**
+     * Make sure we have the mongo extension available and drop the test database just in case
+     */
+    public function setUp() {
+        if (!class_exists('MongoDB\Client')) {
+            $this->markTestSkipped('pecl/mongodb >= 1.1.3 is required to run this test');
+        }
+
+        $client = new MongoClient();
+        $client->dropDatabase($this->databaseName);
+
+        parent::setUp();
+    }
+
+    /**
+     * Drop the test database after each test
+     */
+    public function tearDown() {
+        if (class_exists('MongoDB\Client')) {
+            $client = new MongoClient();
+            $client->dropDatabase($this->databaseName);
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * @covers Imbo\Database\Mongo::getStatus
+     */
+    public function testReturnsFalseWhenFetchingStatusAndTheHostnameIsNotCorrect() {
+        $db = new Mongo([
+            'server' => 'mongodb://localhost:11111',
+        ]);
+        $this->assertFalse($db->getStatus());
+    }
+}

--- a/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Database/MongoTest.php
+++ b/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Database/MongoTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboIntegrationTest\EventListener\ImageVariations\Database;
+
+use Imbo\EventListener\ImageVariations\Database\Mongo,
+    MongoDB\Client as MongoClient;
+
+/**
+ * @covers Imbo\EventListener\ImageVariations\Database\Mongo
+ * @group integration
+ * @group database
+ * @group mongo
+ */
+class MongoTest extends DatabaseTests {
+    private $databaseName = 'imboIntegrationTestDatabase';
+
+    /**
+     * @see ImboIntegrationTest\EventListener\ImageVariations\Database\DatabaseTests::getAdapter()
+     */
+    protected function getAdapter() {
+        return new Mongo([
+            'databaseName' => $this->databaseName,
+        ]);
+    }
+
+    /**
+     * Make sure we have the mongo extension available and drop the test database just in case
+     */
+    public function setUp() {
+        if (!class_exists('MongoDB\Client')) {
+            $this->markTestSkipped('pecl/mongodb >= 1.1.3 is required to run this test');
+        }
+
+        $client = new MongoClient();
+        $client->dropDatabase($this->databaseName);
+
+        parent::setUp();
+    }
+
+    /**
+     * Drop the test database after each test
+     */
+    public function tearDown() {
+        if (class_exists('MongoDB\Client')) {
+            $client = new MongoClient();
+            $client->dropDatabase($this->databaseName);
+        }
+
+        parent::tearDown();
+    }
+}

--- a/tests/phpunit/ImboUnitTest/Image/Transformation/LevelTest.php
+++ b/tests/phpunit/ImboUnitTest/Image/Transformation/LevelTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboUnitTest\Image\Transformation;
+
+use Imbo\Image\Transformation\Level;
+
+/**
+ * @covers Imbo\Image\Transformation\Level
+ * @group unit
+ * @group transformations
+ */
+class LevelTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @var Level
+     */
+    private $transformation;
+
+    /**
+     * Set up the transformation instance
+     */
+    public function setUp() {
+        $this->transformation = new Level();
+    }
+
+    /**
+     * Tear down the transformation instance
+     */
+    public function tearDown() {
+        $this->transformation = null;
+    }
+
+    /**
+     * @covers Imbo\Image\Transformation\Level::getSubscribedEvents
+     */
+    public function testReturnsEventsForSubscribers() {
+        $this->assertSame(['image.transformation.level' => 'transform'], Level::getSubscribedEvents());
+    }
+}

--- a/tests/travis-php.ini
+++ b/tests/travis-php.ini
@@ -1,5 +1,6 @@
 extension=apcu.so
 extension=mongo.so
+extension=mongodb.so
 extension=memcached.so
 extension=imagick.so
 


### PR DESCRIPTION
Implemented database adapters for the new [mongodb PHP extension](http://pecl.php.net/package/mongodb) that uses the [MongoDB driver library](https://github.com/mongodb/mongo-php-library) along with test cases. The name of the new adapters (`Mongo`) might be confusing as this is the name of the old extension.

The following adapters uses the old (`mongo`) PHP extension:

- `Imbo\EventListener\ImageVariations\Database\MongoDB`
- `Imbo\Auth\AccessControl\Adapter\MongoDB`
- `Imbo\Database\MongoDB`

and the following adapters uses the new (`mongodb`) PHP extension:

- `Imbo\EventListener\ImageVariations\Database\Mongo`
- `Imbo\Auth\AccessControl\Adapter\Mongo`
- `Imbo\Database\Mongo`

Support for GridFS is not yet supported in the new PHP-based client that these adapters use. In the future these new adapters will be renamed to `MongoDB` and the old adapters will be removed.

This pull request fixes #403.