### PR TITLE
Fix JSON-encoding issues from metadata fetched from the new Mongo adapter

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,9 +1,9 @@
 Changelog for Imbo
 ==================
 
-Imbo-2.x.x
+Imbo-2.1.0
 ----------
-__N/A__
+__2016-03-10__
 
 * #436: Added new MongoDB adapters that use the mongodb extension (Christer Edvartsen)
 * #434: Custom models for group(s) and access rule(s) (Christer Edvartsen)

--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,6 +1,12 @@
 Changelog for Imbo
 ==================
 
+Imbo-2.1.1
+----------
+__2016-03-11__
+
+* #437: Fixed issue with metadata not being formatted correctly using the new Mongo adapters (Christer Edvartsen)
+
 Imbo-2.1.0
 ----------
 __2016-03-10__

--- a/library/Imbo/Helpers/BSONToArray.php
+++ b/library/Imbo/Helpers/BSONToArray.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Helpers;
+
+use MongoDB\Model\BSONDocument,
+    MongoDB\Model\BSONArray;
+
+/**
+ * Convert BSONDocument and BSONArray to their array counterparts, recursively
+ *
+ * @author Christer Edvartsen <cogo@starzinger.net>
+ * @package Core\Helpers
+ */
+class BSONToArray {
+    /**
+     * Convert to array, recursively
+     *
+     * @param array|BSONDocument|BSONArray $document
+     * @return mixed
+     */
+    public function toArray($document) {
+        if ($this->isBSONModel($document)) {
+            // If the document is a BSON model, get the array copy first
+            $document = $document->getArrayCopy();
+        } else if (!is_array($document)) {
+            // The variable to convert is not an array, simply return it as-is
+            return $document;
+        }
+
+        $result = [];
+
+        foreach ($document as $key => $value) {
+            if ($this->isBSONModel($value)) {
+                // The value is another model, convert it as well
+                $value = $this->toArray($value->getArrayCopy());
+            }
+
+            // Regular value, set it
+            $result[$key] = $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if the value is a valid BSON model
+     *
+     * @param mixed $value
+     * @return boolean
+     */
+    private function isBSONModel($value) {
+        return ($value instanceof BSONDocument || $value instanceof BSONArray);
+    }
+}

--- a/tests/phpunit/ImboUnitTest/Helpers/BSONToArrayTest.php
+++ b/tests/phpunit/ImboUnitTest/Helpers/BSONToArrayTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboUnitTest;
+
+use Imbo\Helpers\BSONToArray,
+    MongoDB\Model\BSONArray,
+    MongoDB\Model\BSONDocument;
+
+/**
+ * @covers Imbo\Helpers\BSONToArray
+ * @group unit
+ * @group helpers
+ */
+class BSONToArrayTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @var BSONToArray
+     */
+    private $helper;
+
+    /**
+     * Set up the helper
+     */
+    public function setUp() {
+        $this->helper = new BSONToArray();
+    }
+
+    /**
+     * Tear down the helper
+     */
+    public function tearDown() {
+        $this->helper = null;
+    }
+
+    /**
+     * Get different values to test
+     *
+     * @return array[]
+     */
+    public function getValues() {
+        return [
+            'string value' => [
+                'string',
+                'string',
+            ],
+            'integer value' => [
+                1,
+                1,
+            ],
+            'float value' => [
+                [1.1],
+                [1.1],
+            ],
+            'true boolean value' => [
+                true,
+                true,
+            ],
+            'false boolean value' => [
+                false,
+                false,
+            ],
+            'list value' => [
+                [1, 2],
+                [1, 2],
+            ],
+            'simple bson-array' => [
+                new BSONArray([1, 2, 3]),
+                [1, 2, 3],
+            ],
+            'simple bson-document' => [
+                new BSONDocument([
+                    'integer' => 1,
+                    'string' => 'string',
+                    'boolean' => true,
+                    'double' => 1.1
+                ]),
+                [
+                    'integer' => 1,
+                    'string' => 'string',
+                    'boolean' => true,
+                    'double' => 1.1
+                ],
+            ],
+            'nested bson-document' => [
+                new BSONDocument([
+                    'list' => new BSONArray([1, 2, 3]),
+                    'document' => new BSONDocument([
+                        'list' => new BSONArray([1, 2, 3]),
+                         'document' => new BSONDocument([
+                             'foo' => 'bar',
+                         ]),
+                    ]),
+                ]),
+                [
+                    'list' => [1, 2, 3],
+                    'document' => [
+                        'list' => [1, 2, 3],
+                        'document' => [
+                            'foo' => 'bar',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getValues
+     * @covers Imbo\Helpers\BSONToArray::toArray
+     * @covers Imbo\Helpers\BSONToArray::isBSONModel
+     */
+    public function testCanConvertValuesToArray($document, $expected) {
+        $this->assertSame($expected, $this->helper->toArray($document));
+    }
+}


### PR DESCRIPTION
This PR should fix the JSON-encoding issues that the latest Mongo adapters introduced (#437). The PR includes a helper class that recursively converts BSONDocument and BSONArray classes.