### PR TITLE
Add missing groupExists()-method to static ACL-adapter

### DIFF
--- a/tests/behat/imbo-configs/custom-access-control.php
+++ b/tests/behat/imbo-configs/custom-access-control.php
@@ -33,6 +33,10 @@ class StaticAccessControl extends AbstractAdapter implements AdapterInterface {
         return false;
     }
 
+    public function groupExists($groupName) {
+        return false;
+    }
+
     public function userExists($publicKey) {
         return $publicKey === 'public';
     }


### PR DESCRIPTION
This was causing the tests to fail for me in `develop`.