### PR TITLE
Added a getData method to the model interface

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,6 +1,12 @@
 Changelog for Imbo
 ==================
 
+Imbo-2.1.2
+----------
+__N/A__
+
+* #444: Added a getData() method to the Imbo\Model\ModelInterface (Christer Edvartsen)
+
 Imbo-2.1.1
 ----------
 __2016-03-11__

--- a/library/Imbo/Model/AccessRule.php
+++ b/library/Imbo/Model/AccessRule.php
@@ -128,4 +128,16 @@ class AccessRule implements ModelInterface {
     public function getUsers() {
         return $this->users;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'id' => $this->getId(),
+            'group' => $this->getGroup(),
+            'resources' => $this->getResources(),
+            'users' => $this->getUsers(),
+        ];
+    }
 }

--- a/library/Imbo/Model/AccessRules.php
+++ b/library/Imbo/Model/AccessRules.php
@@ -44,4 +44,11 @@ class AccessRules implements ModelInterface {
     public function getRules() {
         return $this->rules;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return $this->getRules();
+    }
 }

--- a/library/Imbo/Model/ArrayModel.php
+++ b/library/Imbo/Model/ArrayModel.php
@@ -44,9 +44,7 @@ class ArrayModel implements ModelInterface {
     }
 
     /**
-     * Get the data
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getData() {
         return $this->data;

--- a/library/Imbo/Model/Error.php
+++ b/library/Imbo/Model/Error.php
@@ -163,6 +163,19 @@ class Error implements ModelInterface {
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'httpCode' => $this->getHttpCode(),
+            'errorMessage' => $this->getErrorMessage(),
+            'date' => $this->getDate(),
+            'imboErrorCode' => $this->getImboErrorCode(),
+            'imageIdentifier' => $this->getImageIdentifier(),
+        ];
+    }
+
+    /**
      * Create an error based on an exception instance
      *
      * @param Exception $exception An Imbo\Exception instance

--- a/library/Imbo/Model/Group.php
+++ b/library/Imbo/Model/Group.php
@@ -72,4 +72,14 @@ class Group implements ModelInterface {
     public function getResources() {
         return $this->resources;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'name' => $this->getName(),
+            'resources' => $this->getResources(),
+        ];
+    }
 }

--- a/library/Imbo/Model/Groups.php
+++ b/library/Imbo/Model/Groups.php
@@ -137,4 +137,17 @@ class Groups implements ModelInterface {
     public function getPage() {
         return $this->page;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'groups' => $this->getGroups(),
+            'count' => $this->getCount(),
+            'hits' => $this->getHits(),
+            'limit' => $this->getLimit(),
+            'page' => $this->getPage(),
+        ];
+    }
 }

--- a/library/Imbo/Model/Image.php
+++ b/library/Imbo/Model/Image.php
@@ -436,6 +436,27 @@ class Image implements ModelInterface {
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'filesize' => $this->getFilesize(),
+            'mimeType' => $this->getMimeType(),
+            'extension' => $this->getExtension(),
+            'metadata' => $this->getMetadata(),
+            'width' => $this->getWidth(),
+            'height' => $this->getHeight(),
+            'addedDate' => $this->getAddedDate(),
+            'updatedDate' => $this->getUpdatedDate(),
+            'user' => $this->getUser(),
+            'imageIdentifier' => $this->getImageIdentifier(),
+            'checksum' => $this->getChecksum(),
+            'originalChecksum' => $this->getOriginalChecksum(),
+            'hasBeenTransformed' => $this->hasBeenTransformed(),
+        ];
+    }
+
+    /**
      * Check if a mime type is supported by Imbo
      *
      * @param string $mime The mime type to check. For instance "image/png"

--- a/library/Imbo/Model/Images.php
+++ b/library/Imbo/Model/Images.php
@@ -165,4 +165,18 @@ class Images implements ModelInterface {
     public function getPage() {
         return $this->page;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'images' => $this->getImages(),
+            'fields' => $this->getFields(),
+            'count' => $this->getCount(),
+            'hits' => $this->getHits(),
+            'limit' => $this->getLimit(),
+            'page' => $this->getPage(),
+        ];
+    }
 }

--- a/library/Imbo/Model/ListModel.php
+++ b/library/Imbo/Model/ListModel.php
@@ -100,4 +100,15 @@ class ListModel implements ModelInterface {
 
         return $this;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'list' => $this->getList(),
+            'container' => $this->getContainer(),
+            'entry' => $this->getEntry(),
+        ];
+    }
 }

--- a/library/Imbo/Model/ModelInterface.php
+++ b/library/Imbo/Model/ModelInterface.php
@@ -16,4 +16,11 @@ namespace Imbo\Model;
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Models
  */
-interface ModelInterface {}
+interface ModelInterface {
+    /**
+     * Return the "data" found in the model
+     *
+     * @return mixed
+     */
+    function getData();
+}

--- a/library/Imbo/Model/Stats.php
+++ b/library/Imbo/Model/Stats.php
@@ -151,4 +151,16 @@ class Stats implements ModelInterface, ArrayAccess {
     public function offsetUnset($offset) {
         unset($this->customStats[$offset]);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'numUsers' => $this->getNumUsers(),
+            'numBytes' => $this->getNumBytes(),
+            'numImages' => $this->getNumImages(),
+            'customStats' => $this->getCustomStats(),
+        ];
+    }
 }

--- a/library/Imbo/Model/Status.php
+++ b/library/Imbo/Model/Status.php
@@ -102,4 +102,15 @@ class Status implements ModelInterface {
     public function getStorageStatus() {
         return $this->storageStatus;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'date' => $this->getDate(),
+            'database' => $this->getDatabaseStatus(),
+            'storage' => $this->getStorageStatus(),
+        ];
+    }
 }

--- a/library/Imbo/Model/User.php
+++ b/library/Imbo/Model/User.php
@@ -102,4 +102,15 @@ class User implements ModelInterface {
     public function getLastModified() {
         return $this->lastModified;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData() {
+        return [
+            'id' => $this->getUserId(),
+            'numImages' => $this->getNumImages(),
+            'lastModified' => $this->getLastModified(),
+        ];
+    }
 }

--- a/tests/phpunit/ImboUnitTest/Model/AccessRuleTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/AccessRuleTest.php
@@ -76,4 +76,22 @@ class AccessRuleTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($this->model, $this->model->setUsers(['u1', 'u2']));
         $this->assertSame(['u1', 'u2'], $this->model->getUsers());
     }
+
+    /**
+     * @covers Imbo\Model\AccessRule::getData
+     */
+    public function testGetData() {
+        $this->model
+            ->setId(1)
+            ->setGroup('name')
+            ->setResources(['r1', 'r2'])
+            ->setUsers(['u1', 'u2']);
+
+        $this->assertSame([
+            'id' => 1,
+            'group' => 'name',
+            'resources' => ['r1', 'r2'],
+            'users' => ['u1', 'u2'],
+        ], $this->model->getData());
+    }
 }

--- a/tests/phpunit/ImboUnitTest/Model/AccessRulesTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/AccessRulesTest.php
@@ -40,6 +40,7 @@ class AccessRulesTest extends \PHPUnit_Framework_TestCase {
     /**
      * @covers Imbo\Model\AccessRules::getRules
      * @covers Imbo\Model\AccessRules::setRules
+     * @covers Imbo\Model\AccessRules::getData
      */
     public function testSetAndGetId() {
         $rules = [
@@ -47,7 +48,9 @@ class AccessRulesTest extends \PHPUnit_Framework_TestCase {
             ['id' => 2, 'resources' => ['image.get', 'image.head'], 'users' => ['user']],
         ];
         $this->assertSame([], $this->model->getRules());
+        $this->assertSame([], $this->model->getData());
         $this->assertSame($this->model, $this->model->setRules($rules));
         $this->assertSame($rules, $this->model->getRules());
+        $this->assertSame($rules, $this->model->getData());
     }
 }

--- a/tests/phpunit/ImboUnitTest/Model/ErrorTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/ErrorTest.php
@@ -142,4 +142,25 @@ class ErrorTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame(123, $model->getImboErrorCode());
         $this->assertSame('imageId', $model->getImageIdentifier());
     }
+
+    /**
+     * @covers Imbo\Model\Error::getData
+     */
+    public function testGetData() {
+        $date = new DateTime();
+
+        $this->model->setHttpCode(404);
+        $this->model->setErrorMessage('message');
+        $this->model->setDate($date);
+        $this->model->setImboErrorCode(100);
+        $this->model->setImageIdentifier('identifier');
+
+        $this->assertSame([
+            'httpCode' => 404,
+            'errorMessage' => 'message',
+            'date' => $date,
+            'imboErrorCode' => 100,
+            'imageIdentifier' => 'identifier',
+        ], $this->model->getData());
+    }
 }

--- a/tests/phpunit/ImboUnitTest/Model/GroupTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/GroupTest.php
@@ -56,4 +56,18 @@ class GroupTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($this->model, $this->model->setResources(['image.get', 'image.head']));
         $this->assertSame(['image.get', 'image.head'], $this->model->getResources());
     }
+
+    /**
+     * @covers Imbo\Model\Group::getData
+     */
+    public function testGetData() {
+        $this->model
+            ->setName('name')
+            ->setResources(['image.get', 'image.head']);
+
+        $this->assertSame([
+            'name' => 'name',
+            'resources' => ['image.get', 'image.head'],
+        ], $this->model->getData());
+    }
 }

--- a/tests/phpunit/ImboUnitTest/Model/GroupsTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/GroupsTest.php
@@ -85,4 +85,23 @@ class GroupsTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($this->model, $this->model->setGroups(['group1' => [], 'group2' => []]));
         $this->assertSame(2, $this->model->getCount());
     }
+
+    /**
+     * @covers Imbo\Model\Groups::getData
+     */
+    public function testGetData() {
+        $this->model
+            ->setGroups(['group' => [], 'group2' => []])
+            ->setHits(10)
+            ->setPage(10)
+            ->setLimit(10);
+
+        $this->assertSame([
+            'groups' => ['group' => [], 'group2' => []],
+            'count' => 2,
+            'hits' => 10,
+            'limit' => 10,
+            'page' => 10,
+        ], $this->model->getData());
+    }
 }

--- a/tests/phpunit/ImboUnitTest/Model/ImageTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/ImageTest.php
@@ -11,7 +11,8 @@
 namespace ImboUnitTest\Model;
 
 use Imbo\Model\Image,
-    Imbo\Image\Transformation\Transformation;
+    Imbo\Image\Transformation\Transformation,
+    DateTime;
 
 /**
  * @covers Imbo\Model\Image
@@ -247,5 +248,56 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
     public function testSetsTheCorrectMimeTypeWhenAMappedOneIsUsed($set, $get) {
         $this->image->setMimeType($set);
         $this->assertSame($get, $this->image->getMimeType());
+    }
+
+    /**
+     * @covers Imbo\Model\Image::getData
+     */
+    public function testGetData() {
+        $metadata = [
+            'foo' => 'bar',
+            'bar' => 'foo',
+        ];
+        $mimeType = 'image/png';
+        $blob = 'some string';
+        $filesize = strlen($blob);
+        $checksum = md5($blob);
+        $extension = 'png';
+        $width = 123;
+        $height = 234;
+        $added = new DateTime();
+        $updated = new DateTime();
+        $user = 'christer';
+        $identifier = 'identifier';
+
+        $this->image
+            ->setMetadata($metadata)
+            ->setMimeType($mimeType)
+            ->setBlob($blob)
+            ->setExtension($extension)
+            ->setWidth($width)
+            ->setHeight($height)
+            ->setAddedDate($added)
+            ->setUpdatedDate($updated)
+            ->setUser($user)
+            ->setImageIdentifier($identifier)
+            ->hasBeenTransformed(true)
+            ->setOriginalChecksum($checksum);
+
+        $this->assertSame([
+            'filesize' => $filesize,
+            'mimeType' => $mimeType,
+            'extension' => $extension,
+            'metadata' => $metadata,
+            'width' => $width,
+            'height' => $height,
+            'addedDate' => $added,
+            'updatedDate' => $updated,
+            'user' => $user,
+            'imageIdentifier' => $identifier,
+            'checksum' => $checksum,
+            'originalChecksum' => $checksum,
+            'hasBeenTransformed' => true,
+        ], $this->image->getData());
     }
 }

--- a/tests/phpunit/ImboUnitTest/Model/ImagesTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/ImagesTest.php
@@ -105,4 +105,32 @@ class ImagesTest extends \PHPUnit_Framework_TestCase {
         $this->model->setImages($images);
         $this->assertSame(3, $this->model->getCount());
     }
+
+    /**
+     * @covers Imbo\Model\Images::getData
+     */
+    public function testGetData() {
+        $images = [
+            $this->getMock('Imbo\Model\Image'),
+            $this->getMock('Imbo\Model\Image'),
+            $this->getMock('Imbo\Model\Image'),
+        ];
+        $fields = ['width', 'height'];
+
+        $this->model
+            ->setImages($images)
+            ->setFields($fields)
+            ->setHits(10)
+            ->setLimit(11)
+            ->setPage(12);
+
+        $this->assertSame([
+            'images' => $images,
+            'fields' => $fields,
+            'count' => 3,
+            'hits' => 10,
+            'limit' => 11,
+            'page' => 12,
+        ], $this->model->getData());
+    }
 }

--- a/tests/phpunit/ImboUnitTest/Model/ListModelTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/ListModelTest.php
@@ -69,4 +69,24 @@ class ListModelTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($this->model, $this->model->setEntry($entry));
         $this->assertSame($entry, $this->model->getEntry());
     }
+
+    /**
+     * @covers Imbo\Model\ListModel::getData
+     */
+    public function testGetData() {
+        $list = [1, 2, 3];
+        $container = 'container';
+        $entry = 'entry';
+
+        $this->model
+            ->setList($list)
+            ->setContainer($container)
+            ->setEntry($entry);
+
+        $this->assertSame([
+            'list' => $list,
+            'container' => $container,
+            'entry' => $entry,
+        ], $this->model->getData());
+    }
 }

--- a/tests/phpunit/ImboUnitTest/Model/StatsTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/StatsTest.php
@@ -129,4 +129,22 @@ class StatsTest extends \PHPUnit_Framework_TestCase {
     public function testThrowsExceptionWhenUsedAsArrayWithoutAKey() {
         $this->model[] = 'foobar';
     }
+
+    /**
+     * @covers Imbo\Model\Stats::getData
+     */
+    public function testGetData() {
+        $this->model
+            ->setNumUsers(100)
+            ->setNumBytes(1000)
+            ->setNumImages(10000);
+        $this->model['some'] = 'value';
+
+        $this->assertSame([
+            'numUsers' => 100,
+            'numBytes' => 1000,
+            'numImages' => 10000,
+            'customStats' => ['some' => 'value'],
+        ], $this->model->getData());
+    }
 }

--- a/tests/phpunit/ImboUnitTest/Model/StatusTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/StatusTest.php
@@ -68,4 +68,22 @@ class StatusTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($this->model, $this->model->setStorageStatus(true));
         $this->assertTrue($this->model->getStorageStatus());
     }
+
+    /**
+     * @covers Imbo\Model\Status::getData
+     */
+    public function testGetData() {
+        $date = new DateTime();
+
+        $this->model
+            ->setDate($date)
+            ->setDatabaseStatus(true)
+            ->setStorageStatus(true);
+
+        $this->assertSame([
+            'date' => $date,
+            'database' => true,
+            'storage' => true,
+        ], $this->model->getData());
+    }
 }

--- a/tests/phpunit/ImboUnitTest/Model/UserTest.php
+++ b/tests/phpunit/ImboUnitTest/Model/UserTest.php
@@ -68,4 +68,21 @@ class UserTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($this->model, $this->model->setLastModified($date));
         $this->assertSame($date, $this->model->getLastModified());
     }
+
+    /**
+     * @covers Imbo\Model\User::getData
+     */
+    public function testGetData() {
+        $date = new DateTime();
+        $this->model
+            ->setUserId('id')
+            ->setNumImages(100)
+            ->setLastModified($date);
+
+        $this->assertSame([
+            'id' => 'id',
+            'numImages' => 100,
+            'lastModified' => $date,
+        ], $this->model->getData());
+    }
 }


### PR DESCRIPTION
This PR adds a `getData()` method to the `Imbo\Model\ModelInterface` interface along with implementations for all models and unit tests. Closes #444.