### PR TITLE
Configure redirects on the index page

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -6,6 +6,7 @@ Imbo-3.0.0
 __N/A__
 
 * #449: Removed support for XML (Christer Edvartsen)
+* #440: Added configuration option to redirect clients hitting the index page (Christer Edvartsen)
 * #408: Moved the metadata cache event listener to a separate project: https://github.com/imbo/imbo-metadata-cache (Christer Edvartsen)
 
 Imbo-x.x.x

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bde5250fa0d75e3a3434169a03ad1328",
+    "hash": "a9b8098519ba3e35aaf8b8b34edb3e66",
     "content-hash": "6dd1a68b2a797d4e97f6f9e1554cadf5",
     "packages": [
         {

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -370,6 +370,16 @@ $config = [
      * @var array
      */
     'trustedProxies' => [],
+
+    /**
+     * Index redirect
+     *
+     * Set this to a URL if you want the front page to do a redirect instead of showing generic
+     * information regarding the Imbo-project.
+     *
+     * @var string
+     */
+    'indexRedirect' => null,
 ];
 
 // See if a custom config path has been defined. If so, don't require the custom one as this is

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -1131,3 +1131,21 @@ In the ``get()`` method we are simply creating a list model for Imbo's response 
     }
 
 Feel free to experiment with this feature. If you end up creating a resource that you think should be a part of Imbo, send a `pull request on GitHub <https://github.com/imbo/imbo>`_.
+
+.. _configuration-indexredirect:
+
+Redirect the index route - ``indexRedirect``
+--------------------------------------------
+
+The index resource (:ref:`index-resource`) simply lists some URL's related to the Imbo project. If you would rather the index resource redirect the client to some specific URL, set the ``indexRedirect`` configuration option to that URL:
+
+.. code-block:: php
+
+    <?php
+    return [
+        // ...
+
+        'indexRedirect' => 'https://github.com/imbo',
+
+        // ...
+    ];

--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -17,7 +17,7 @@ In this section you will find information on the different resources Imbo's REST
 Index resource - ``/``
 ++++++++++++++++++++++
 
-The index resource shows the version of the Imbo installation along with some external URLs for Imbo-related information, and some internal URLs for the available endpoints.
+The index resource shows some URL's related to the Imbo project.
 
 .. code-block:: bash
 
@@ -28,33 +28,20 @@ results in:
 .. code-block:: javascript
 
     {
-      "version": "dev",
-      "urls": {
-        "site": "http://www.imbo-project.org",
-        "source": "https://github.com/imbo/imbo",
-        "issues": "https://github.com/imbo/imbo/issues",
-        "docs": "http://docs.imbo-project.org"
-      },
-      "endpoints": {
-        "status": "http://imbo/status",
-        "stats": "http://imbo/stats",
-        "user": "http://imbo/users/{user}",
-        "images": "http://imbo/users/{user}/images",
-        "image": "http://imbo/users/{user}/images/{imageIdentifier}",
-        "globalShortImageUrl": "http://imbo/s/{id}",
-        "metadata": "http://imbo/users/{user}/images/{imageIdentifier}/metadata",
-        "shortImageUrls": "http://imbo/users/{user}/images/{imageIdentifier}/shorturls",
-        "shortImageUrl": "http://imbo/users/{user}/images/{imageIdentifier}/shorturls/{id}"
-      }
+      "site": "http://imbo.io",
+      "source": "https://github.com/imbo/imbo",
+      "issues": "https://github.com/imbo/imbo/issues",
+      "docs": "http://docs.imbo.io"
     }
 
-This resource does not support any extensions in the URI, so you will need to use the ``Accept`` header to fetch different representations of the data.
-
 The index resource does not require any authentication per default.
+
+If you want the client to be redirected to some URL instead of displaying the above information, use the ``indexRedirect`` configuration option (:ref:`configuration-indexredirect`).
 
 **Typical response codes:**
 
 * 200 Hell Yeah
+* 307 Temporary Redirect
 
 .. note:: The index resource is not cache-able.
 

--- a/src/Imbo/Resource/Index.php
+++ b/src/Imbo/Resource/Index.php
@@ -46,31 +46,25 @@ class Index implements ResourceInterface {
     public function get(EventInterface $event) {
         $request = $event->getRequest();
         $response = $event->getResponse();
+
+        $redirectUrl = $event->getConfig()['indexRedirect'];
+
+        if ($redirectUrl) {
+            $response->setStatusCode(307);
+            $response->headers->set('Location', $redirectUrl);
+            return;
+        }
+
         $response->setStatusCode(200, 'Hell Yeah');
 
         $baseUrl = $request->getSchemeAndHttpHost() . $request->getBaseUrl();
 
         $model = new Model\ArrayModel();
         $model->setData([
-            'version' => Version::VERSION,
-            'urls' => [
-                'site' => 'http://www.imbo-project.org',
-                'source' => 'https://github.com/imbo/imbo',
-                'issues' => 'https://github.com/imbo/imbo/issues',
-                'docs' => 'http://docs.imbo-project.org',
-            ],
-            'endpoints' => [
-                'status' => $baseUrl . '/status',
-                'stats' => $baseUrl . '/stats',
-                'user' => $baseUrl . '/users/{user}',
-                'images' => $baseUrl . '/users/{user}/images',
-                'image' => $baseUrl . '/users/{user}/images/{imageIdentifier}',
-                'globalShortImageUrl' => $baseUrl . '/s/{id}',
-                'globalImages' => $baseUrl . '/images',
-                'metadata' => $baseUrl . '/users/{user}/images/{imageIdentifier}/metadata',
-                'shortImageUrls' => $baseUrl . '/users/{user}/images/{imageIdentifier}/shorturls',
-                'shortImageUrl' =>  $baseUrl . '/users/{user}/images/{imageIdentifier}/shorturls/{id}',
-            ],
+            'site' => 'http://imbo.io',
+            'source' => 'https://github.com/imbo/imbo',
+            'issues' => 'https://github.com/imbo/imbo/issues',
+            'docs' => 'http://docs.imbo.io',
         ]);
 
         $response->setModel($model);

--- a/tests/behat/features/access-control.feature
+++ b/tests/behat/features/access-control.feature
@@ -104,5 +104,5 @@ Feature: Imbo provides a way to access control resources on a per-public key bas
 
         Examples:
             | url          | status           | response |
-            | /            | 200 Hell Yeah    | #^{"version":".*?",.*}$# |
+            | /            | 200 Hell Yeah    | #^{.*}$# |
             | /status.json | 200 OK           | #^{"date":".*?","database":true,"storage":true}$# |

--- a/tests/behat/features/index.feature
+++ b/tests/behat/features/index.feature
@@ -14,7 +14,7 @@ Feature: Imbo provides an index endpoint
 
         Examples:
             | accept           | response |
-            | application/json | #^{"version":"[^"]+".*?}$#    |
+            | application/json | #^{.*}$#    |
 
     Scenario Outline: The index endpoint only supports HTTP GET and HEAD
         When I request "/" using HTTP "<method>"

--- a/tests/phpunit/ImboUnitTest/ApplicationTest.php
+++ b/tests/phpunit/ImboUnitTest/ApplicationTest.php
@@ -85,7 +85,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Application::run
      */
     public function testApplicationSetsTrustedProxies() {
-        $this->expectOutputRegex('|{"version":"' . preg_quote(Version::VERSION, '|') . '",.*}|');
+        $this->expectOutputRegex('|^{.*}$|');
 
         $this->assertEmpty(Request::getTrustedProxies());
         $this->application->run([
@@ -99,6 +99,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
             'routes' => [],
             'auth' => [],
             'trustedProxies' => ['10.0.0.77'],
+            'indexRedirect' => null,
         ]);
         $this->assertSame(['10.0.0.77'], Request::getTrustedProxies());
     }
@@ -107,7 +108,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Application::run
      */
     public function testCanRunWithDefaultConfiguration() {
-        $this->expectOutputRegex('|{"version":"' . preg_quote(Version::VERSION, '|') . '",.*}|');
+        $this->expectOutputRegex('|^{.*}$|');
         $this->application->run(require __DIR__ . '/../../../config/config.default.php');
     }
 }


### PR DESCRIPTION
This PR implementes support for a `indexRedirect` configuration option in case users don't want the index page to show anything. Also changed the output format of the index page somewhat. Now it does not show any version or endpoint information, simply generic project URL's.