### PR TITLE
Remove deprecated `auth`

### DIFF
--- a/src/Imbo/Application.php
+++ b/src/Imbo/Application.php
@@ -78,13 +78,6 @@ class Application {
             throw new InvalidArgumentException('Invalid access control adapter', 500);
         }
 
-        // Check if we have an auth array present in the configuration
-        if (isset($config['auth']) && is_array($config['auth']) &&
-            $accessControl instanceof SimpleAclArrayAdapter &&
-            $accessControl->isEmpty()) {
-            $accessControl = new SimpleAclArrayAdapter($config['auth']);
-        }
-
         // Create a router based on the routes in the configuration and internal routes
         $router = new Router($config['routes']);
 


### PR DESCRIPTION
`auth` has been replaced by `accessControl` and support is no longer needed, nor
desired.

Fixes #456 