### PR TITLE
[wip] Add support for wildcards in the event manager

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -5,6 +5,7 @@ Imbo-x.x.x
 ----------
 __N/A__
 
+* #459: Support wildcards when subscribing to events (Christer Edvartsen)
 * #444: Added a getData() method to the Imbo\Model\ModelInterface (Christer Edvartsen)
 * #431: Added an Amazon S3 storage adapter for the image variations (Ali Asaria)
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "php": ">=5.4.0",
     "ext-imagick": ">=3.0.1",
     "symfony/http-foundation": "~2.7.3",
-    "symfony/event-dispatcher": "~2.7.3",
     "symfony/console": "~2.7.3",
     "ramsey/uuid": "~3.0.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a8806eef6afed4735830bc45bafced08",
-    "content-hash": "a9b68d8da25532fee872bf093571d245",
+    "hash": "c1f1f93ab992f5b356c484377b10e223",
+    "content-hash": "9faeaf9aa39d628bac142b41bb1e8b00",
     "packages": [
         {
             "name": "ramsey/uuid",
@@ -79,16 +79,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.10",
+            "version": "v2.7.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ee91ec301cd88ee38ab14505025fe94bbc19a9c1"
+                "reference": "6100a40569b2be1b6aba1cc6a92fe6cb71024fc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ee91ec301cd88ee38ab14505025fe94bbc19a9c1",
-                "reference": "ee91ec301cd88ee38ab14505025fe94bbc19a9c1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6100a40569b2be1b6aba1cc6a92fe6cb71024fc8",
+                "reference": "6100a40569b2be1b6aba1cc6a92fe6cb71024fc8",
                 "shasum": ""
             },
             "require": {
@@ -134,84 +134,25 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-28 16:19:47"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v2.7.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "b68c0348ba5b3927a6c8e413cc7d594f3ccff3ce"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b68c0348ba5b3927a6c8e413cc7d594f3ccff3ce",
-                "reference": "b68c0348ba5b3927a6c8e413cc7d594f3ccff3ce",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/stopwatch": "~2.3"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-01-27 05:09:39"
+            "time": "2016-03-09 16:30:49"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.7.10",
+            "version": "v2.7.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "6aeb70d26da8f30753111b3f9cf47eb0421c0735"
+                "reference": "b69b6e103712870a3137e9132115d800b2713aac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6aeb70d26da8f30753111b3f9cf47eb0421c0735",
-                "reference": "6aeb70d26da8f30753111b3f9cf47eb0421c0735",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/b69b6e103712870a3137e9132115d800b2713aac",
+                "reference": "b69b6e103712870a3137e9132115d800b2713aac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.1"
             },
             "require-dev": {
                 "symfony/expression-language": "~2.4"
@@ -249,7 +190,66 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-28 16:19:47"
+            "time": "2016-03-25 17:55:03"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "1289d16209491b584839022f29257ad859b8532d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d",
+                "reference": "1289d16209491b584839022f29257ad859b8532d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-01-20 09:13:37"
         }
     ],
     "packages-dev": [
@@ -1105,16 +1105,16 @@
         },
         {
             "name": "mongodb/mongodb",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mongodb/mongo-php-library.git",
-                "reference": "6093d68c06bebcc5361b9e49178725efd9182ed4"
+                "reference": "faf8a1d86b5c10684ef91fa6c81475b0c7f95240"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/6093d68c06bebcc5361b9e49178725efd9182ed4",
-                "reference": "6093d68c06bebcc5361b9e49178725efd9182ed4",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/faf8a1d86b5c10684ef91fa6c81475b0c7f95240",
+                "reference": "faf8a1d86b5c10684ef91fa6c81475b0c7f95240",
                 "shasum": ""
             },
             "require": {
@@ -1122,11 +1122,6 @@
                 "php": ">=5.4"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "MongoDB\\": "src/"
@@ -1161,7 +1156,7 @@
                 "mongodb",
                 "persistence"
             ],
-            "time": "2016-03-04 20:27:01"
+            "time": "2016-03-30 19:10:28"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -2015,16 +2010,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.3",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "0f8f94e6a32b5c480024eed5fa5cbd2790d0ad19"
+                "reference": "5273f4724dc5288fe7a33cb08077ab9852621f2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/0f8f94e6a32b5c480024eed5fa5cbd2790d0ad19",
-                "reference": "0f8f94e6a32b5c480024eed5fa5cbd2790d0ad19",
+                "url": "https://api.github.com/repos/symfony/config/zipball/5273f4724dc5288fe7a33cb08077ab9852621f2c",
+                "reference": "5273f4724dc5288fe7a33cb08077ab9852621f2c",
                 "shasum": ""
             },
             "require": {
@@ -2064,20 +2059,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-22 16:12:45"
+            "time": "2016-03-04 07:54:35"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.3",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "62251761a7615435b22ccf562384c588b431be44"
+                "reference": "f7b4a498e679fa440b16facb934680a1527ed48c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/62251761a7615435b22ccf562384c588b431be44",
-                "reference": "62251761a7615435b22ccf562384c588b431be44",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f7b4a498e679fa440b16facb934680a1527ed48c",
+                "reference": "f7b4a498e679fa440b16facb934680a1527ed48c",
                 "shasum": ""
             },
             "require": {
@@ -2126,20 +2121,80 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-28 16:34:46"
+            "time": "2016-03-21 07:27:21"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v2.8.3",
+            "name": "symfony/event-dispatcher",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "65cb36b6539b1d446527d60457248f30d045464d"
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "47d2d8cade9b1c3987573d2943bb9352536cdb87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/65cb36b6539b1d446527d60457248f30d045464d",
-                "reference": "65cb36b6539b1d446527d60457248f30d045464d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/47d2d8cade9b1c3987573d2943bb9352536cdb87",
+                "reference": "47d2d8cade9b1c3987573d2943bb9352536cdb87",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-07 14:04:32"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v2.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "f08ffdf229252cd2745558cb2112df43903bcae4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f08ffdf229252cd2745558cb2112df43903bcae4",
+                "reference": "f08ffdf229252cd2745558cb2112df43903bcae4",
                 "shasum": ""
             },
             "require": {
@@ -2175,20 +2230,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-22 15:02:30"
+            "time": "2016-03-27 10:20:16"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.3",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "877bb4b16ea573cc8c024e9590888fcf7eb7e0f7"
+                "reference": "ca24cf2cd4e3826f571e0067e535758e73807aa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/877bb4b16ea573cc8c024e9590888fcf7eb7e0f7",
-                "reference": "877bb4b16ea573cc8c024e9590888fcf7eb7e0f7",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ca24cf2cd4e3826f571e0067e535758e73807aa1",
+                "reference": "ca24cf2cd4e3826f571e0067e535758e73807aa1",
                 "shasum": ""
             },
             "require": {
@@ -2224,79 +2279,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-22 16:12:45"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "1289d16209491b584839022f29257ad859b8532d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d",
-                "reference": "1289d16209491b584839022f29257ad859b8532d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2016-01-20 09:13:37"
+            "time": "2016-03-10 10:53:53"
         },
         {
             "name": "symfony/translation",
-            "version": "v2.8.3",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "b7b4ebadd2b5e614ff7d2d6fc63e0ed0578909c7"
+                "reference": "d60b8e076d22953aabebeebda53bf334438e7aca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/b7b4ebadd2b5e614ff7d2d6fc63e0ed0578909c7",
-                "reference": "b7b4ebadd2b5e614ff7d2d6fc63e0ed0578909c7",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/d60b8e076d22953aabebeebda53bf334438e7aca",
+                "reference": "d60b8e076d22953aabebeebda53bf334438e7aca",
                 "shasum": ""
             },
             "require": {
@@ -2347,20 +2343,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-02 09:49:18"
+            "time": "2016-03-25 01:40:30"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.3",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995"
+                "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
-                "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/584e52cb8f788a887553ba82db6caacb1d6260bb",
+                "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb",
                 "shasum": ""
             },
             "require": {
@@ -2396,7 +2392,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-23 07:41:20"
+            "time": "2016-03-04 07:54:35"
         }
     ],
     "aliases": [],

--- a/docs/develop/event_listeners.rst
+++ b/docs/develop/event_listeners.rst
@@ -151,6 +151,60 @@ For testing and/or debugging purposes you can also write the event listener dire
 
 The ``$event`` object passed to the function is the same as in the previous two examples. This approach should mostly be used for testing purposes and quick hacks. More information regarding this approach is available in the :ref:`event listener configuration <configuration-event-listeners>` section.
 
+Subscribing to events using a wild card
++++++++++++++++++++++++++++++++++++++++
+When subscribing to one or more events Imbo let's you use wild cards. This means that you can have your event listener subscribe to all the different image events by specifying ``'image.*'`` as the event you are subscribing to. If you want a listener to subscribe to **all** events you can simply use ``'*'``. Use ``$event->getName()`` in your handler to figure out which event is actually being triggered.
+
+One other thing to keep in mind while using wild card events is priorities. Global wild card event listeners (that listens to ``'*'``) is triggered before all other listeners, and other wild card listeners are triggered before the ones who has absolute event names they are subscribing to.
+
+Example:
+
+.. code-block:: php
+
+    <?php
+    return [
+        // ...
+
+        'eventListeners' => [
+            'listener1' => [
+                'callback' => function ($e) { /* ... */ },
+                'events' => ['*'],
+                'priority' => 100,
+            ],
+            'listener2' => [
+                'callback' => function ($e) { /* ... */ },
+                'events' => ['*'],
+                'priority' => 200,
+            ],
+            'listener3' => [
+                'callback' => function ($e) { /* ... */ },
+                'events' => ['image.*'],
+                'priority' => 300,
+            ],
+            'listener4' => [
+                'callback' => function ($e) { /* ... */ },
+                'events' => ['image.*'],
+                'priority' => 400,
+            ],
+            'listener5' => [
+                'callback' => function ($e) { /* ... */ },
+                'events' => ['image.get'],
+                'priority' => PHP_INT_MAX,
+            ],
+        ],
+
+        // ...
+    ];
+
+Given the configuration above the execution order would be:
+
+* ``listener2``
+* ``listener1``
+* ``listener4``
+* ``listener3``
+* ``listener5``
+
+Even though ``listener5`` has the highest possible priority the wild card listeners are executed first, because they are in their own priority queues.
 
 .. _the-event-object:
 

--- a/library/Imbo/EventManager/Event.php
+++ b/library/Imbo/EventManager/Event.php
@@ -10,7 +10,7 @@
 
 namespace Imbo\EventManager;
 
-use Symfony\Component\EventDispatcher\GenericEvent;
+use InvalidArgumentException;
 
 /**
  * Event class
@@ -18,7 +18,120 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Event
  */
-class Event extends GenericEvent implements EventInterface {
+class Event implements EventInterface {
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var boolean
+     */
+    private $propagationStopped = false;
+
+    /**
+     * @var array
+     */
+    private $arguments = [];
+
+    /**
+     * Class constructor
+     *
+     * @param array $arguments
+     */
+    public function __construct(array $arguments = []) {
+        $this->arguments = $arguments;
+    }
+
+    /**
+     * Get the event name
+     *
+     * @return string
+     */
+    public function getName() {
+        return $this->name;
+    }
+
+    /**
+     * Sets the event name
+     *
+     * @param string $name
+     * @return self
+     */
+    public function setName($name) {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Check if propagation has been stopped
+     *
+     * @return boolean
+     */
+    public function isPropagationStopped() {
+        return $this->propagationStopped;
+    }
+
+    /**
+     * Stops the propagation of the event
+     */
+    public function stopPropagation() {
+        $this->propagationStopped = true;
+
+        return $this;
+    }
+
+    /**
+     * Get argument
+     *
+     * @param string $key
+     * @throws InvalidArgumentException
+     * @return mixed
+     */
+    public function getArgument($key) {
+        if ($this->hasArgument($key)) {
+            return $this->arguments[$key];
+        }
+
+        throw new InvalidArgumentException(sprintf('Argument "%s" does not exist', $key), 500);
+    }
+
+    /**
+     * Add argument
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return self
+     */
+    public function setArgument($key, $value) {
+        $this->arguments[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set arguments
+     *
+     * @param array $arguments
+     * @return self
+     */
+    public function setArguments(array $arguments = []) {
+        $this->arguments = $arguments;
+
+        return $this;
+    }
+
+    /**
+     * See if the event has an argument
+     *
+     * @param string $key
+     * @return boolean
+     */
+    public function hasArgument($key) {
+        return isset($this->arguments[$key]);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/tests/phpunit/ImboUnitTest/EventManager/EventTest.php
+++ b/tests/phpunit/ImboUnitTest/EventManager/EventTest.php
@@ -78,4 +78,59 @@ class EventTest extends \PHPUnit_Framework_TestCase {
         $this->event->setArgument($argument, $value);
         $this->assertSame($value, $this->event->$method());
     }
+
+    /**
+     * @covers Imbo\EventManager\Event::setName
+     * @covers Imbo\EventManager\Event::getName
+     */
+    public function testCanSetAndGetName() {
+        $this->assertNull($this->event->getName());
+        $this->assertSame($this->event, $this->event->setName('name'));
+        $this->assertSame('name', $this->event->getName());
+    }
+
+    /**
+     * @covers Imbo\EventManager\Event::stopPropagation
+     * @covers Imbo\EventManager\Event::isPropagationStopped
+     */
+    public function testCanStopPropagation() {
+        $this->assertFalse($this->event->isPropagationStopped());
+        $this->assertSame($this->event, $this->event->stopPropagation());
+        $this->assertTrue($this->event->isPropagationStopped());
+    }
+
+    /**
+     * @covers Imbo\EventManager\Event::getArgument
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Argument "foobar" does not exist
+     * @expectedExceptionCode 500
+     */
+    public function testThrowsExceptionWhenGettingArgumentThatDoesNotExist() {
+        $this->event->getArgument('foobar');
+    }
+
+    /**
+     * @covers Imbo\EventManager\Event::__construct
+     * @covers Imbo\EventManager\Event::setArguments
+     */
+    public function testCanSetArgumentsThroughConstructor() {
+        $event = new Event(['foo' => 'bar']);
+        $this->assertSame('bar', $event->getArgument('foo'));
+    }
+
+    /**
+     * @covers Imbo\EventManager\Event::setArguments
+     * @covers Imbo\EventManager\Event::getArgument
+     * @covers Imbo\EventManager\Event::hasArgument
+     */
+    public function testSetArgumentsOverridesAllArguments() {
+        $this->assertFalse($this->event->hasArgument('foo'));
+
+        $this->assertSame($this->event, $this->event->setArguments(['foo' => 'bar']));
+        $this->assertSame('bar', $this->event->getArgument('foo'));
+
+        $this->assertSame($this->event, $this->event->setArguments(['bar' => 'foo']));
+        $this->assertFalse($this->event->hasArgument('foo'));
+        $this->assertSame('foo', $this->event->getArgument('bar'));
+    }
 }


### PR DESCRIPTION
This PR implements support for event subscribers with wildcards in the event names (#459). It also removes the dependency on `symfony/event-dispatcher` as described in #455.

Need to do some more work before merging:
- [x] Update docs (e1141cb7fc525f0572f17e6357fa84c6d84377f1)
- [x] Update ChangeLog (b20794c154e7bdd8a2c5edb49d8d99b48512964a)