### PR TITLE
Fixes bug that formats an error model as an image

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -5,6 +5,7 @@ Imbo-x.x.x
 ----------
 __N/A__
 
+* #463: Fixed issue with an error model being formatted as an image (Christer Edvartsen)
 * #444: Added a getData() method to the Imbo\Model\ModelInterface (Christer Edvartsen)
 * #431: Added an Amazon S3 storage adapter for the image variations (Ali Asaria)
 

--- a/library/Imbo/Http/Response/ResponseFormatter.php
+++ b/library/Imbo/Http/Response/ResponseFormatter.php
@@ -164,10 +164,10 @@ class ResponseFormatter implements ListenerInterface {
             // instead we want to use the original format of the image
             $mime = $model->getMimeType();
             $formatter = $this->supportedTypes[$mime];
-        } else if ($extension && !($model instanceof Model\Error && $routeName === 'image')) {
+        } else if ($extension && !($model instanceof Model\Error && ($routeName === 'image' || $routeName === 'globalshorturl'))) {
             // The user agent wants a specific type. Skip content negotiation completely, but not
-            // if the request is against the image resource, and ended up as an error, because then
-            // Imbo would try to render the error as an image.
+            // if the request is against the image resource (or the global short url resource), and
+            // ended up as an error, because then Imbo would try to render the error as an image.
             $mime = $this->defaultMimeType;
 
             if (isset($this->extensionsToMimeType[$extension])) {

--- a/tests/phpunit/ImboUnitTest/Http/Response/ResponseFormatterTest.php
+++ b/tests/phpunit/ImboUnitTest/Http/Response/ResponseFormatterTest.php
@@ -292,12 +292,20 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($expectedFormatter, $this->responseFormatter->getFormatter());
     }
 
+    public function getImageResources() {
+        return [
+            'image' => ['image'],
+            'global short url' => ['globalshorturl'],
+        ];
+    }
+
     /**
      * @covers Imbo\Http\Response\ResponseFormatter::negotiate
+     * @dataProvider getImageResources
      */
-    public function testForcesContentNegotiationOnErrorModelsWhenResourceIsAnImage() {
+    public function testForcesContentNegotiationOnErrorModelsWhenResourceIsAnImage($routeName) {
         $route = new Route();
-        $route->setName('image');
+        $route->setName($routeName);
 
         $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
         $requestHeaders->expects($this->once())->method('get')->with('Accept', '*/*')->will($this->returnValue('*/*'));


### PR DESCRIPTION
The global short URL resource will in some cases try to format an error model as an image, as explained in #463. This PR fixes this issue.