### PR TITLE
Respond with 404 when trying to add a short URL to an image that does not exist

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -5,9 +5,13 @@ Imbo-x.x.x
 ----------
 __N/A__
 
-* #463: Fixed issue with an error model being formatted as an image (Christer Edvartsen)
 * #444: Added a getData() method to the Imbo\Model\ModelInterface (Christer Edvartsen)
 * #431: Added an Amazon S3 storage adapter for the image variations (Ali Asaria)
+
+Bug fixes:
+
+* #463: Fixed issue with an error model being formatted as an image (Christer Edvartsen)
+* #462: Adding short URLs to an image that does not exist now results in 404 (Christer Edvartsen)
 
 Imbo-2.1.1
 ----------
@@ -26,28 +30,31 @@ Imbo-2.0.0
 ----------
 __2016-02-28__
 
-* #430: Prevent race conditions in image transformation cache (Espen Hovlandsdal)
 * #429: Added opacity to watermark image (Sindre Gulseth)
 * #427: When resizing with one param round up the other calculated value (Sindre Gulseth)
 * #423: Make storage drivers throw exceptions as expected in StorageOperations (Mats Lindh)
 * #410: Validate incoming image metadata (Kristoffer Brabrand)
-* #402: Fix Strip-transformation not doing anything on newer Imagick versions (Espen Hovlandsdal)
 * #402: Improve Contrast-transformation predictability (Espen Hovlandsdal)
 * #400: New image transformation: Blur (Kristoffer Brabrand)
 * #398: Add ability to configure HTTP cache headers (Espen Hovlandsdal)
 * #391: Make Crop-transformation validate coordinates (Espen Hovlandsdal)
-* #390: Fix image variation + crop transformation bug (Espen Hovlandsdal)
-* #386: Fix CORS wildcard-issue when client did not send `Origin`-header (Espen Hovlandsdal)
 * #381: New image transformation: DrawPois (points of interest) (Espen Hovlandsdal)
 * #376: Add config option to alter protocol used for authentication signatures (Espen Hovlandsdal)
-* #367: Fix bug where special characters could break metadata XML response (Kristoffer Brabrand)
-* #366: Fix border transformation + alpha channel bug (Espen Hovlandsdal)
 * #363: Add pluggable image identifier generation (Espen Hovlandsdal)
 * #357: Add public key generation CLI-command (Espen Hovlandsdal)
 * #351: New image transformation: SmartSize (Kristoffer Brabrand, Espen Hovlandsdal)
 * #348: Add global images endpoint (Kristoffer Brabrand)
 * #347: Use UUID instead of MD5 for image identifiers (Espen Hovlandsdal)
 * #328: New access control implementation (Espen Hovlandsdal, Kristoffer Brabrand)
+
+Bug fixes:
+
+* #430: Prevent race conditions in image transformation cache (Espen Hovlandsdal)
+* #402: Fix Strip-transformation not doing anything on newer Imagick versions (Espen Hovlandsdal)
+* #390: Fix image variation + crop transformation bug (Espen Hovlandsdal)
+* #386: Fix CORS wildcard-issue when client did not send `Origin`-header (Espen Hovlandsdal)
+* #367: Fix bug where special characters could break metadata XML response (Kristoffer Brabrand)
+* #366: Fix border transformation + alpha channel bug (Espen Hovlandsdal)
 
 Imbo-1.2.5
 ----------

--- a/library/Imbo/Resource/ShortUrls.php
+++ b/library/Imbo/Resource/ShortUrls.php
@@ -86,6 +86,10 @@ class ShortUrls implements ResourceInterface {
 
         $database = $event->getDatabase();
 
+        if (!$database->imageExists($image['user'], $image['imageIdentifier'])) {
+            throw new InvalidArgumentException('Image does not exist', 404);
+        }
+
         // See if a short URL ID already exists the for given parameters
         $exists = true;
         $shortUrlId = $database->getShortUrlId($image['user'], $image['imageIdentifier'], $extension, $query);

--- a/tests/behat/features/shorturls.feature
+++ b/tests/behat/features/shorturls.feature
@@ -3,6 +3,21 @@ Feature: Imbo can generate short URLs for images on demand
     As an HTTP Client
     I can request the short URLs resource
 
+    Scenario: Responds with 404 when the image does not exist
+        Given I use "publickey" and "privatekey" for public and private keys
+        And I sign the request
+        And the request body contains:
+            """
+            {"user": "user", "imageIdentifier": "id", "extension": "gif", "query": null}
+            """
+        When I request "/users/user/images/id/shorturls" using HTTP "POST"
+        Then I should get a response with "404 Image does not exist"
+        And the "Content-Type" response header is "application/json"
+        And the response body matches:
+           """
+           #^{"error":{"code":404,"message":"Image does not exist".*?,"imageIdentifier":"id"}$#
+           """
+
     Scenario: Generate a short URL
         Given "tests/phpunit/Fixtures/image.png" exists in Imbo
         And I use "publickey" and "privatekey" for public and private keys


### PR DESCRIPTION
Imbo currently allows users to create short URLs to images that does not exist in the database. This PR fixes this (#462).