### PR TITLE
Use finfo to determine mime type

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -14,6 +14,12 @@ Bug fixes:
 * #463: Fixed issue with an error model being formatted as an image (Christer Edvartsen)
 * #462: Adding short URLs to an image that does not exist now results in 404 (Christer Edvartsen)
 
+Imbo-2.1.2
+----------
+__N/A__
+
+* #467: Use finfo to determine mime type of uploaded images before loading them into ImageMagick (Christer Edvartsen)
+
 Imbo-2.1.1
 ----------
 __2016-03-11__

--- a/tests/behat/features/cors-event-listener.feature
+++ b/tests/behat/features/cors-event-listener.feature
@@ -75,7 +75,7 @@ Feature: Imbo provides an event listener for CORS
         And I sign the request
         And I attach "ChangeLog.markdown" to the request body
         When I request "/users/user/images" using HTTP "POST"
-        Then I should get a response with "415 Invalid image"
+        Then I should get a response with "415 Unsupported image type: text/plain"
         And the "Vary" response header contains "Origin"
         And the following response headers should be present:
         """

--- a/tests/phpunit/ImboUnitTest/Image/ImagePreparationTest.php
+++ b/tests/phpunit/ImboUnitTest/Image/ImagePreparationTest.php
@@ -89,7 +89,7 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
     /**
      * @covers Imbo\Image\ImagePreparation::prepareImage
      * @expectedException Imbo\Exception\ImageException
-     * @expectedExceptionMessage Invalid image
+     * @expectedExceptionMessage Unsupported image type: text/x-php
      * @expectedExceptionCode 415
      */
     public function testThrowsExceptionWhenImageTypeIsNotSupported() {
@@ -116,7 +116,7 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionMessage Invalid image
      * @expectedExceptionCode 415
      */
-    public function testThrowsExceptionWhenImageIsBrokenButSizeIsReadable() {
+    public function testThrowsExceptionWhenImageIsSlightlyBroken() {
         $filePath = FIXTURES_DIR . '/slightly-broken-image.png';
 
         $this->request->expects($this->once())->method('getContent')->will($this->returnValue(file_get_contents($filePath)));


### PR DESCRIPTION
 Use [finfo](http://php.net/finfo) to determine mime type of images before loading them into ImageMagick, ref. https://imagetragick.com/. Close #467.