### PR TITLE
Add getter for inherited tests to get image identifier

### DIFF
--- a/tests/phpunit/integration/Storage/StorageTests.php
+++ b/tests/phpunit/integration/Storage/StorageTests.php
@@ -63,6 +63,15 @@ abstract class StorageTests extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Get the imageIdentifier in inherited tests
+     *
+     * @return string
+     */
+    protected function getImageIdentifier() {
+        return $this->imageIdentifier;
+    }
+
+    /**
      * Set up
      */
     public function setUp() {


### PR DESCRIPTION
Simple patch to allow inherited tests to get the imageIdentifier from the abstract StorageTests class. Provides the same functionality as getUser() already does for the user associated with the test.