### PR TITLE
WIP: Make TransformationPresets pluggable 

### DIFF
--- a/library/Imbo/Application.php
+++ b/library/Imbo/Application.php
@@ -13,6 +13,8 @@ namespace Imbo;
 use Imbo\Http\Request\Request,
     Imbo\Http\Response\Response,
     Imbo\EventListener\ListenerInterface,
+    Imbo\EventListener\TransformationPresets\PresetsInterface,
+    Imbo\EventListener\TransformationPresets\PresetsArrayAdapter,
     Imbo\EventManager\Event,
     Imbo\EventManager\EventManager,
     Imbo\Model\Error,
@@ -85,6 +87,19 @@ class Application {
             $accessControl = new SimpleAclArrayAdapter($config['auth']);
         }
 
+        // Transformation presets
+        $transformationPresets = $config['transformationPresets'];
+
+        if (is_array($transformationPresets) || !$transformationPresets) {
+            $transformationPresets = new PresetsArrayAdapter($config['transformationPresets']);
+        }
+
+        if (!$transformationPresets instanceof PresetsInterface) {
+            throw new InvalidArgumentException('Invalid transformation presets adapter (has to implement PresetsInterface)', 500);
+        }
+
+        var_dump($transformationPresets);
+
         // Create a router based on the routes in the configuration and internal routes
         $router = new Router($config['routes']);
 
@@ -99,6 +114,7 @@ class Application {
             'config' => $config,
             'manager' => $eventManager,
             'accessControl' => $accessControl,
+            'transformationPresets' => $transformationPresets,
         ]);
         $eventManager->setEventTemplate($event);
 

--- a/library/Imbo/Application.php
+++ b/library/Imbo/Application.php
@@ -98,8 +98,6 @@ class Application {
             throw new InvalidArgumentException('Invalid transformation presets adapter (has to implement PresetsInterface)', 500);
         }
 
-        var_dump($transformationPresets);
-
         // Create a router based on the routes in the configuration and internal routes
         $router = new Router($config['routes']);
 

--- a/library/Imbo/Application.php
+++ b/library/Imbo/Application.php
@@ -88,10 +88,10 @@ class Application {
         }
 
         // Transformation presets
-        $transformationPresets = $config['transformationPresets'];
+        $transformationPresets = isset($config['transformationPresets']) ? $config['transformationPresets'] : [];
 
-        if (is_array($transformationPresets) || !$transformationPresets) {
-            $transformationPresets = new PresetsArrayAdapter($config['transformationPresets']);
+        if (is_array($transformationPresets)) {
+            $transformationPresets = new PresetsArrayAdapter($transformationPresets);
         }
 
         if (!$transformationPresets instanceof PresetsInterface) {

--- a/library/Imbo/EventListener/TransformationPresets/Preset.php
+++ b/library/Imbo/EventListener/TransformationPresets/Preset.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\EventListener\TransformationPresets;
+
+/**
+ * Describes a pre defined set of transformations
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package EventListener\TransformationPresets
+ */
+class Preset {
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $transformations = array();
+
+    /**
+     * @var boolean
+     */
+    private $argumentsMutable = true;
+
+    /**
+     * @return string
+     */
+    public function getName() {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name) {
+        $this->name = $name;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTransformations() {
+        return $this->transformations;
+    }
+
+    /**
+     * @param array $transformations
+     */
+    public function setTransformations($transformations) {
+        $this->transformations = $transformations;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function areArgumentsMutable() {
+        return (boolean) $this->argumentsMutable;
+    }
+
+    /**
+     * @param boolean $argumentsMutable
+     */
+    public function setArgumentsMutable($argumentsMutable) {
+        $this->argumentsMutable = $argumentsMutable;
+    }
+}

--- a/library/Imbo/EventListener/TransformationPresets/PresetsArrayAdapter.php
+++ b/library/Imbo/EventListener/TransformationPresets/PresetsArrayAdapter.php
@@ -24,7 +24,7 @@ class PresetsArrayAdapter implements PresetsInterface {
             $preset = new Preset();
             $preset->setName($name);
             $preset->setTransformations($params);
-            $preset->isArgumentsMutable(true);
+            $preset->setArgumentsMutable(true);
             $this->presets[$name] = $preset;
         }
     }

--- a/library/Imbo/EventListener/TransformationPresets/PresetsArrayAdapter.php
+++ b/library/Imbo/EventListener/TransformationPresets/PresetsArrayAdapter.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\EventListener\TransformationPresets;
+
+/**
+ * Load a list of transformation presets from an array.
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package EventListener\TransformationPresets
+ */
+class PresetsArrayAdapter implements PresetsInterface {
+    private $presets = array();
+
+    public function __construct(array $presets) {
+        foreach ($presets as $name => $params) {
+            $preset = new Preset();
+            $preset->setName($name);
+            $preset->setTransformations($params);
+            $preset->isArgumentsMutable(true);
+            $this->presets[$name] = $preset;
+        }
+    }
+
+    public function hasTransformationPreset($key) {
+        return isset($this->presets[$key]);
+    }
+
+    public function getTransformationPreset($key) {
+        if ($this->hasTransformationPreset($key)) {
+            return $this->presets[$key];
+        }
+
+        return null;
+    }
+}

--- a/library/Imbo/EventListener/TransformationPresets/PresetsInterface.php
+++ b/library/Imbo/EventListener/TransformationPresets/PresetsInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\EventListener\TransformationPresets;
+
+/**
+ * Interface that describes what an implementation has to support for Imbo to be able to
+ * retrieve transformation preset configurations
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package EventListener\TransformationPresets
+ */
+interface PresetsInterface {
+    function hasTransformationPreset($key);
+    function getTransformationPreset($key);
+}

--- a/library/Imbo/EventManager/Event.php
+++ b/library/Imbo/EventManager/Event.php
@@ -163,6 +163,13 @@ class Event implements EventInterface {
     /**
      * {@inheritdoc}
      */
+    public function getTransformationPresets() {
+        return $this->getArgument('transformationPresets');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getAccessControl() {
         return $this->getArgument('accessControl');
     }

--- a/library/Imbo/EventManager/EventInterface.php
+++ b/library/Imbo/EventManager/EventInterface.php
@@ -24,6 +24,14 @@ use Imbo\Http\Request\Request,
  */
 interface EventInterface {
     /**
+     * Get parameter from key
+     *
+     * @param string $key Parameter to event to retrieve
+     * @return mixed
+     */
+    function getArgument($key);
+
+    /**
      * Get the request parameter
      *
      * @return Request

--- a/library/Imbo/EventManager/EventInterface.php
+++ b/library/Imbo/EventManager/EventInterface.php
@@ -74,6 +74,11 @@ interface EventInterface {
     function getManager();
 
     /**
+     * Get the defined transformation presets
+     */
+    function getTransformationPresets();
+
+    /**
      * Get the Imbo configuration
      *
      * @return array

--- a/tests/phpunit/ImboUnitTest/EventListener/ImageTransformerTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ImageTransformerTest.php
@@ -28,6 +28,7 @@ class ImageTransformerTest extends ListenerTests {
     private $event;
     private $image;
     private $eventManager;
+    private $transformationPresets;
 
     /**
      * Set up the listener
@@ -36,6 +37,7 @@ class ImageTransformerTest extends ListenerTests {
         $this->eventManager = $this->getMock('Imbo\EventManager\EventManager');
         $this->request = $this->getMock('Imbo\Http\Request\Request');
         $this->image = $this->getMock('Imbo\Model\Image');
+        $this->transformationPresets = $this->getMock('Imbo\EventListener\TransformationPresets\PresetsInterface');
         $this->response = $this->getMock('Imbo\Http\Response\Response');
         $this->response->expects($this->any())->method('getModel')->will($this->returnValue($this->image));
         $this->event = $this->getMock('Imbo\EventManager\Event');
@@ -56,6 +58,7 @@ class ImageTransformerTest extends ListenerTests {
         $this->event = null;
         $this->listener = null;
         $this->eventManager = null;
+        $this->transformationPresets = null;
     }
 
     /**
@@ -69,7 +72,7 @@ class ImageTransformerTest extends ListenerTests {
      * @covers Imbo\EventListener\ImageTransformer::transform
      */
     public function testTriggersImageTransformationEvents() {
-        $this->event->expects($this->once())->method('getConfig')->will($this->returnValue(['transformationPresets' => []]));
+        $this->event->expects($this->once())->method('getTransformationPresets')->will($this->returnValue($this->transformationPresets));
         $this->request->expects($this->once())->method('getTransformations')->will($this->returnValue([
             [
                 'name' => 'resize',
@@ -115,14 +118,23 @@ class ImageTransformerTest extends ListenerTests {
      * @covers Imbo\EventListener\ImageTransformer::transform
      */
     public function testSupportsPresets() {
-        $this->event->expects($this->once())->method('getConfig')->will($this->returnValue([
-            'transformationPresets' => [
-                'preset' => [
-                    'flipHorizontally',
-                    'flipVertically',
-                ],
+        $preset = $this->getMock('Imbo\EventListener\TransformationPresets\Preset');
+        $preset->expects($this->any())->method('areArgumentsMutable')->will($this->returnValue(true));
+        $preset->expects($this->any())->method('getTransformations')->will($this->returnValue([
+            'flipHorizontally',
+            'flipVertically',
+        ]));
+        $this->transformationPresets->expects($this->any())->method('hasTransformationPreset')->will($this->returnValueMap([
+            [
+                'preset', true
             ]
         ]));
+        $this->transformationPresets->expects($this->any())->method('getTransformationPreset')->will($this->returnValueMap([
+            [
+                'preset', $preset
+            ]
+        ]));
+        $this->event->expects($this->once())->method('getTransformationPresets')->will($this->returnValue($this->transformationPresets));
         $this->request->expects($this->once())->method('getTransformations')->will($this->returnValue([
             [
                 'name' => 'preset',
@@ -156,15 +168,25 @@ class ImageTransformerTest extends ListenerTests {
      * @covers Imbo\EventListener\ImageTransformer::transform
      */
     public function testPresetsCanHardcodeSomeParameters() {
-        $this->event->expects($this->once())->method('getConfig')->will($this->returnValue([
-            'transformationPresets' => [
-                'preset' => [
-                    'thumbnail' => [
-                        'height' => 75,
-                    ],
-                ],
+        $preset = $this->getMock('Imbo\EventListener\TransformationPresets\Preset');
+        $preset->expects($this->any())->method('areArgumentsMutable')->will($this->returnValue(true));
+        $preset->expects($this->any())->method('getTransformations')->will($this->returnValue([
+            'thumbnail' => [
+                'height' => 75,
+            ],
+        ]));
+        $this->transformationPresets->expects($this->any())->method('hasTransformationPreset')->will($this->returnValueMap([
+            [
+                'preset', true
             ]
         ]));
+        $this->transformationPresets->expects($this->any())->method('getTransformationPreset')->will($this->returnValueMap([
+            [
+                'preset', $preset
+            ]
+        ]));
+        $this->event->expects($this->once())->method('getTransformationPresets')->will($this->returnValue($this->transformationPresets));
+
         $this->request->expects($this->once())->method('getTransformations')->will($this->returnValue([
             [
                 'name' => 'preset',

--- a/tests/phpunit/ImboUnitTest/Http/Response/Formatter/XMLTest.php
+++ b/tests/phpunit/ImboUnitTest/Http/Response/Formatter/XMLTest.php
@@ -481,7 +481,7 @@ class XMLTest extends \PHPUnit_Framework_TestCase {
         $model->expects($this->once())->method('getCount')->will($this->returnValue($count));
         $model->expects($this->once())->method('getGroups')->will($this->returnValue($groups));
 
-        $this->assertRegExp('#<imbo>\s*<search>\s*<hits>2</hits>\s*<page>1</page>\s*<limit>5</limit>\s*<count>1</count>\s*</search>\s*<groups><group>\s*<name>group</name>\s*<resources>\s*<resource>user.get</resource><resource>user.head</resource>\s*</resources></group></groups>\s</imbo>$#', $this->formatter->format($model));
+        $this->assertRegExp('#<imbo>\s*<search>\s*<hits>2</hits>\s*<page>1</page>\s*<limit>5</limit>\s*<count>1</count>\s*</search>\s*<groups><group>\s*<name>group</name>\s*<resources>\s*<resource>user.get</resource><resource>user.head</resource>\s*</resources></group></groups>\s*</imbo>$#', $this->formatter->format($model));
     }
 
     /**


### PR DESCRIPTION
This is a currently work-in-progress patch to make the transformation presets functionality pluggable. The goal is to allow an imbo installation to retrieve a set of available presets based on custom requirements (such as per user presets, or retrieve presets from a database instead of the configuration file).

This feature depends on two other minor changes (which will be included in this PR when necessary): 
- Introduce getArgument() to the EventInterface, which allows an implementation to get Event arguments without the Event having to have a custom method for each argument. This allows easier extension of the Event interface for non-core functions in the future as well.
- Introduce `isMutable` for TransformationPresets. If a transformation preset isn't mutable, imbo will ignore any attempt to overwrite (or provide) settings for that transformation. Currently transformation presets will allow any value to be overriden (or new arguments provided). By implementing a `isMutable` flag we can allow for whitelisting certain standard transformations without worrying that future arguments can be introduced for the underlying transformations that would break the preset (for example by supplying gigantic dimensions).
