### PR TITLE
Include $request and $response to config callbacks

### DIFF
--- a/library/Imbo/Application.php
+++ b/library/Imbo/Application.php
@@ -50,7 +50,7 @@ class Application {
         $database = $config['database'];
 
         if (is_callable($database) && !($database instanceof DatabaseInterface)) {
-            $database = $database();
+            $database = $database($request, $response);
         }
 
         if (!$database instanceof DatabaseInterface) {
@@ -60,7 +60,7 @@ class Application {
         $storage = $config['storage'];
 
         if (is_callable($storage) && !($storage instanceof StorageInterface)) {
-            $storage = $storage();
+            $storage = $storage($request, $response);
         }
 
         if (!$storage instanceof StorageInterface) {
@@ -71,7 +71,7 @@ class Application {
         $accessControl = $config['accessControl'];
 
         if (is_callable($accessControl) && !($accessControl instanceof AccessControlInterface)) {
-            $accessControl = $accessControl();
+            $accessControl = $accessControl($request, $response);
         }
 
         if (!$accessControl instanceof AccessControlInterface) {
@@ -190,7 +190,7 @@ class Application {
 
             if (is_callable($definition) && !($definition instanceof ListenerInterface)) {
                 // Callable piece of code which is not an implementation of the listener interface
-                $definition = $definition();
+                $definition = $definition($request, $response);
             }
 
             if ($definition instanceof ListenerInterface) {
@@ -205,7 +205,7 @@ class Application {
                 $users = isset($definition['users']) ? $definition['users'] : [];
 
                 if (is_callable($listener) && !($listener instanceof ListenerInterface)) {
-                    $listener = $listener();
+                    $listener = $listener($request, $response);
                 }
 
                 if (!is_string($listener) && !($listener instanceof ListenerInterface)) {
@@ -246,7 +246,7 @@ class Application {
         // Custom resources
         foreach ($config['resources'] as $name => $resource) {
             if (is_callable($resource)) {
-                $resource = $resource();
+                $resource = $resource($request, $response);
             }
 
             $eventManager->addEventHandler($name, $resource)
@@ -266,7 +266,7 @@ class Application {
                 $resource = $config['resources'][$routeName];
 
                 if (is_callable($resource)) {
-                    $resource = $resource();
+                    $resource = $resource($request, $response);
                 }
 
                 if (is_string($resource)) {

--- a/tests/phpunit/ImboUnitTest/ApplicationTest.php
+++ b/tests/phpunit/ImboUnitTest/ApplicationTest.php
@@ -115,34 +115,34 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
         $default = require __DIR__ . '/../../../config/config.default.php';
         $test = array(
             'database' => function ($request, $response) {
-                $this->assertInstanceOf('Imbo\\Http\\Request\\Request', $request);
-                $this->assertInstanceOf('Imbo\\Http\\Response\\Response', $response);
+                $this->assertInstanceOf('Imbo\Http\Request\Request', $request);
+                $this->assertInstanceOf('Imbo\Http\Response\Response', $response);
 
                 return $this->getMock('Imbo\Database\DatabaseInterface');
             },
             'storage' => function ($request, $response) {
-                $this->assertInstanceOf('Imbo\\Http\\Request\\Request', $request);
-                $this->assertInstanceOf('Imbo\\Http\\Response\\Response', $response);
+                $this->assertInstanceOf('Imbo\Http\Request\Request', $request);
+                $this->assertInstanceOf('Imbo\Http\Response\Response', $response);
 
                 return $this->getMock('Imbo\Storage\StorageInterface');
             },
             'accessControl' => function ($request, $response) {
-                $this->assertInstanceOf('Imbo\\Http\\Request\\Request', $request);
-                $this->assertInstanceOf('Imbo\\Http\\Response\\Response', $response);
+                $this->assertInstanceOf('Imbo\Http\Request\Request', $request);
+                $this->assertInstanceOf('Imbo\Http\Response\Response', $response);
 
                 return $this->getMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface');
             },
             'eventListeners' => [
                 'test' => function ($request, $response) {
-                    $this->assertInstanceOf('Imbo\\Http\\Request\\Request', $request);
-                    $this->assertInstanceOf('Imbo\\Http\\Response\\Response', $response);
+                    $this->assertInstanceOf('Imbo\Http\Request\Request', $request);
+                    $this->assertInstanceOf('Imbo\Http\Response\Response', $response);
 
                     return new TestListener();
                 },
                 'testSubelement' => [
                     'listener' => function ($request, $response) {
-                        $this->assertInstanceOf('Imbo\\Http\\Request\\Request', $request);
-                        $this->assertInstanceOf('Imbo\\Http\\Response\\Response', $response);
+                        $this->assertInstanceOf('Imbo\Http\Request\Request', $request);
+                        $this->assertInstanceOf('Imbo\Http\Response\Response', $response);
 
                         return new TestListener();
                     },
@@ -150,8 +150,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
             ],
             'resources' => [
                 'test' => function ($request, $response) {
-                    $this->assertInstanceOf('Imbo\\Http\\Request\\Request', $request);
-                    $this->assertInstanceOf('Imbo\\Http\\Response\\Response', $response);
+                    $this->assertInstanceOf('Imbo\Http\Request\Request', $request);
+                    $this->assertInstanceOf('Imbo\Http\Response\Response', $response);
 
                     return new TestResource();
                 },


### PR DESCRIPTION
By adding the $request and $response objects from the Application setup to the callbacks defined in the configuration, any implementing module can make adjustments based on information from the request - such as the active user, invoked route, transformations, image referenced, etc.

This is less invasive than having each and every module implement a setRequest/setResponse set of methods if not needed - the callbacks now include context about both the request and the response to an extension developer.

Since the listener and resource objects has static methods, the test contains two small classes to implement NOOP-versions of these classes.