### PR TITLE
Fix undefined user when retrieving metadata

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -9,11 +9,15 @@ __N/A__
 * #440: Added configuration option to redirect clients hitting the index page (Christer Edvartsen)
 * #408: Moved the metadata cache event listener to a separate project: https://github.com/imbo/imbo-metadata-cache (Christer Edvartsen)
 
+Bug fixes:
+
+* #491: Fix undefined user when retrieving metadata (Mats Lindh)
+
 Imbo-2.2.0
 ----------
 __2016-08-08__
 
-* #475: Validate signed URLs regardless of t[] vs t[0] (Mats Lindh)
+* #475: Validate signed URLs regardless of `t[]` vs `t[0]` (Mats Lindh)
 * #459: Support wildcards when subscribing to events (Christer Edvartsen)
 * #444: Added a getData() method to the Imbo\Model\ModelInterface (Christer Edvartsen)
 * #431: Added an Amazon S3 storage adapter for the image variations (Ali Asaria)

--- a/src/Database/Doctrine.php
+++ b/src/Database/Doctrine.php
@@ -357,7 +357,7 @@ class Doctrine implements DatabaseInterface {
             ];
 
             if ($returnMetadata) {
-                $image['metadata'] = $this->getMetadata($user, $row['imageIdentifier']);
+                $image['metadata'] = $this->getMetadata($row['user'], $row['imageIdentifier']);
             }
 
             $images[] = $image;

--- a/tests/phpunit/integration/Database/DatabaseTests.php
+++ b/tests/phpunit/integration/Database/DatabaseTests.php
@@ -409,7 +409,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $query = new Query();
         $query->returnMetadata(true);
 
-        $images = $this->adapter->getImages(['user'], $query, $this->getMock('Imbo\Model\Images'));
+        $images = $this->adapter->getImages(['user', 'foo'], $query, $this->getMock('Imbo\Model\Images'));
 
         foreach ($images as $image) {
             $this->assertArrayHasKey('metadata', $image);

--- a/tests/phpunit/integration/Database/DatabaseTests.php
+++ b/tests/phpunit/integration/Database/DatabaseTests.php
@@ -328,6 +328,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
             $info = getimagesize($path);
 
             $user = 'user';
+
             if ($alternateUser && $i % 2 === 0) {
                 $user = 'user2';
             }
@@ -403,25 +404,39 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $this->assertSame(1, $model->getHits());
     }
 
+    /**
+     * @see https://github.com/imbo/imbo/pull/491
+     */
     public function testGetImagesAndReturnMetadata() {
-        $this->insertImages();
+        $this->insertImages(true);
 
         $query = new Query();
         $query->returnMetadata(true);
 
-        $images = $this->adapter->getImages(['user', 'foo'], $query, $this->getMock('Imbo\Model\Images'));
+        $images = $this->adapter->getImages(['user', 'user2'], $query, $this->getMock('Imbo\Model\Images'));
+        $this->assertCount(6, $images, 'Incorrect length. Expected 6, got ' . count($images));
 
         foreach ($images as $image) {
             $this->assertArrayHasKey('metadata', $image);
         }
 
+        $this->assertSame('user',  $images[0]['user']);
         $this->assertSame(['key5' => 'value5'], $images[0]['metadata']);
-        $this->assertSame(['key4' => 'value4'], $images[1]['metadata']);
-        $this->assertSame(['key3' => 'value3'], $images[2]['metadata']);
-        $this->assertSame(['key2' => 'value2'], $images[3]['metadata']);
-        $this->assertSame(['key1' => 'value1'], $images[4]['metadata']);
-        $this->assertSame(['key0' => 'value0'], $images[5]['metadata']);
 
+        $this->assertSame('user2', $images[1]['user']);
+        $this->assertSame(['key4' => 'value4'], $images[1]['metadata']);
+
+        $this->assertSame('user',  $images[2]['user']);
+        $this->assertSame(['key3' => 'value3'], $images[2]['metadata']);
+
+        $this->assertSame('user2', $images[3]['user']);
+        $this->assertSame(['key2' => 'value2'], $images[3]['metadata']);
+
+        $this->assertSame('user',  $images[4]['user']);
+        $this->assertSame(['key1' => 'value1'], $images[4]['metadata']);
+
+        $this->assertSame('user2', $images[5]['user']);
+        $this->assertSame(['key0' => 'value0'], $images[5]['metadata']);
     }
 
     public function testGetImagesReturnsImagesOnlyForSpecifiedUsers() {


### PR DESCRIPTION
There was a small bug lingering in the code that retrieves metadata for images based on a query. The code used `$user`, but this value is the last user from iteration earlier in the loop, and not the user of the image that owns the image to retrieve metadata for. `$row['user']` references the user that actually owns the image instead.

This failure was exposed by adding a dummy user to the list of users to retrieve metadata for.