### PR TITLE
Remove references to internal Doctrine class

### DIFF
--- a/src/Database/Doctrine.php
+++ b/src/Database/Doctrine.php
@@ -16,7 +16,6 @@ use Imbo\Model\Image,
     Imbo\Exception\DatabaseException,
     Imbo\Exception\InvalidArgumentException,
     Imbo\Exception,
-    Doctrine\DBAL\Configuration,
     Doctrine\DBAL\DriverManager,
     Doctrine\DBAL\Connection,
     PDO,
@@ -643,7 +642,7 @@ class Doctrine implements DatabaseInterface {
      */
     private function getConnection() {
         if ($this->connection === null) {
-            $this->connection = DriverManager::getConnection($this->params, new Configuration());
+            $this->connection = DriverManager::getConnection($this->params);
         }
 
         return $this->connection;


### PR DESCRIPTION
The Configuration class is defined as an internal class by Doctrine. Since we don't need to include an empty configuration instance anyways (Doctrine create it if the parameter is null), we can avoid referencing internal classes by just leaving it out.
