### PR TITLE
Increase visibility storage adapters

### DIFF
--- a/src/Imbo/Storage/Filesystem.php
+++ b/src/Imbo/Storage/Filesystem.php
@@ -50,7 +50,7 @@ class Filesystem implements StorageInterface {
      * {@inheritdoc}
      */
     public function store($user, $imageIdentifier, $imageData) {
-        if (!is_writable($this->params['dataDir'])) {
+        if (!is_writable($this->getParams()['dataDir'])) {
             throw new StorageException('Could not store image', 500);
         }
 
@@ -126,7 +126,7 @@ class Filesystem implements StorageInterface {
      * {@inheritdoc}
      */
     public function getStatus() {
-        return is_writable($this->params['dataDir']);
+        return is_writable($this->getParams()['dataDir']);
     }
 
     /**
@@ -139,6 +139,15 @@ class Filesystem implements StorageInterface {
     }
 
     /**
+     * Get the set of params provided when creating the instance
+     *
+     * @return array<string>
+     */
+    protected function getParams() {
+        return $this->params;
+    }
+
+    /**
      * Get the path to an image
      *
      * @param string $user The user which the image belongs to
@@ -147,10 +156,10 @@ class Filesystem implements StorageInterface {
      *                                 filename itself)
      * @return string
      */
-    private function getImagePath($user, $imageIdentifier, $includeFilename = true) {
+    protected function getImagePath($user, $imageIdentifier, $includeFilename = true) {
         $userPath = str_pad($user, 3, '0', STR_PAD_LEFT);
         $parts = [
-            $this->params['dataDir'],
+            $this->getParams()['dataDir'],
             $userPath[0],
             $userPath[1],
             $userPath[2],

--- a/src/Imbo/Storage/GridFS.php
+++ b/src/Imbo/Storage/GridFS.php
@@ -178,7 +178,7 @@ class GridFS implements StorageInterface {
     protected function getGrid() {
         if ($this->grid === null) {
             try {
-                $database = $this->getMongoClient()->selectDB($this->params['databaseName']);
+                $database = $this->getMongoClient()->selectDB($this->getParams()['databaseName']);
                 $this->grid = $database->getGridFS();
             } catch (MongoException $e) {
                 throw new StorageException('Could not connect to database', 500, $e);
@@ -196,13 +196,22 @@ class GridFS implements StorageInterface {
     protected function getMongoClient() {
         if ($this->mongoClient === null) {
             try {
-                $this->mongoClient = new MongoClient($this->params['server'], $this->params['options']);
+                $this->mongoClient = new MongoClient($this->getParams()['server'], $this->getParams()['options']);
             } catch (MongoException $e) {
                 throw new StorageException('Could not connect to database', 500, $e);
             }
         }
 
         return $this->mongoClient;
+    }
+
+    /**
+     * Get the set of params provided when creating the instance
+     *
+     * @return array<string>
+     */
+    protected function getParams() {
+        return $this->params;
     }
 
     /**
@@ -213,7 +222,7 @@ class GridFS implements StorageInterface {
      * @return boolean|MongoGridFSFile Returns false if the file does not exist or an instance of
      *                                 MongoGridFSFile if the file exists
      */
-    private function getImageObject($user, $imageIdentifier) {
+    protected function getImageObject($user, $imageIdentifier) {
         $cursor = $this->getGrid()->find([
             'user' => $user,
             'imageIdentifier' => $imageIdentifier

--- a/src/Imbo/Storage/S3.php
+++ b/src/Imbo/Storage/S3.php
@@ -80,7 +80,7 @@ class S3 implements StorageInterface {
     public function store($user, $imageIdentifier, $imageData) {
         try {
             $this->getClient()->putObject([
-                'Bucket' => $this->params['bucket'],
+                'Bucket' => $this->getParams()['bucket'],
                 'Key' => $this->getImagePath($user, $imageIdentifier),
                 'Body' => $imageData,
             ]);
@@ -100,7 +100,7 @@ class S3 implements StorageInterface {
         }
 
         $this->getClient()->deleteObject([
-            'Bucket' => $this->params['bucket'],
+            'Bucket' => $this->getParams()['bucket'],
             'Key' => $this->getImagePath($user, $imageIdentifier),
         ]);
 
@@ -113,7 +113,7 @@ class S3 implements StorageInterface {
     public function getImage($user, $imageIdentifier) {
         try {
             $model = $this->getClient()->getObject([
-                'Bucket' => $this->params['bucket'],
+                'Bucket' => $this->getParams()['bucket'],
                 'Key' => $this->getImagePath($user, $imageIdentifier),
             ]);
         } catch (NoSuchKeyException $e) {
@@ -129,7 +129,7 @@ class S3 implements StorageInterface {
     public function getLastModified($user, $imageIdentifier) {
         try {
             $model = $this->getClient()->headObject([
-                'Bucket' => $this->params['bucket'],
+                'Bucket' => $this->getParams()['bucket'],
                 'Key' => $this->getImagePath($user, $imageIdentifier),
             ]);
         } catch (NoSuchKeyException $e) {
@@ -145,7 +145,7 @@ class S3 implements StorageInterface {
     public function getStatus() {
         try {
             $this->getClient()->headBucket([
-                'Bucket' => $this->params['bucket'],
+                'Bucket' => $this->getParams()['bucket'],
             ]);
         } catch (S3Exception $e) {
             return false;
@@ -160,7 +160,7 @@ class S3 implements StorageInterface {
     public function imageExists($user, $imageIdentifier) {
         try {
             $this->getClient()->headObject([
-                'Bucket' => $this->params['bucket'],
+                'Bucket' => $this->getParams()['bucket'],
                 'Key' => $this->getImagePath($user, $imageIdentifier),
             ]);
         } catch (NoSuchKeyException $e) {
@@ -177,7 +177,7 @@ class S3 implements StorageInterface {
      * @param string $imageIdentifier Image identifier
      * @return string
      */
-    private function getImagePath($user, $imageIdentifier) {
+    protected function getImagePath($user, $imageIdentifier) {
         $userPath = str_pad($user, 3, '0', STR_PAD_LEFT);
         return implode('/', [
             $userPath[0],
@@ -192,19 +192,28 @@ class S3 implements StorageInterface {
     }
 
     /**
+     * Get the set of params provided when creating the instance
+     *
+     * @return array<string>
+     */
+    protected function getParams() {
+        return $this->params;
+    }
+
+    /**
      * Get the S3Client instance
      *
      * @return S3Client
      */
-    private function getClient() {
+    protected function getClient() {
         if ($this->client === null) {
             $params = [
-                'key' => $this->params['key'],
-                'secret' => $this->params['secret'],
+                'key' => $this->getParams()['key'],
+                'secret' => $this->getParams()['secret'],
             ];
 
-            if ($this->params['region']) {
-                $params['region'] = $this->params['region'];
+            if ($this->getParams()['region']) {
+                $params['region'] = $this->getParams()['region'];
             }
 
             $this->client = S3Client::factory($params);


### PR DESCRIPTION
This patch makes the getImagePath, getImageObject and getClient methods available for sub classing and visible to implementing sub classes. It also introduces a getParam helper method to retrieve params included to the constructor of the implementing class in a sub class without directly accessing the params array.

This implements / fixes #493.