### PR TITLE
Upgrade the aws-sdk-php-dependency to the most recent version

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -5,6 +5,7 @@ Imbo-3.0.0
 ----------
 __N/A__
 
+* #495: Upgrade aws-sdk-php-dependency to new major: `^3.19` (Mats Lindh)
 * #449: Removed support for XML (Christer Edvartsen)
 * #440: Added configuration option to redirect clients hitting the index page (Christer Edvartsen)
 * #408: Moved the metadata cache event listener to a separate project: https://github.com/imbo/imbo-metadata-cache (Christer Edvartsen)

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "mongodb/mongodb": "^1.0",
     "guzzlehttp/psr7": "^1.3",
     "doctrine/dbal": "^2.5",
-    "aws/aws-sdk-php": "^2.8"
+    "aws/aws-sdk-php": "^3.19"
   },
   "require-dev": {
     "mikey179/vfsStream": "^1.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,52 +4,64 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
-    "hash": "d05c52c9b6801324f97ed603de072315",
-    "content-hash": "3b9d5e20752d7455c4a4f4cb595ce14d",
-=======
-    "hash": "3f7a59ec27ea8e8279aa41890f70c81e",
-    "content-hash": "08b223b1b871d55aac5b0a1768e08981",
->>>>>>> Bump composer.lock to new versions
+    "hash": "0ad78b3eb4c332c15ab1a49c9d881d10",
+    "content-hash": "0584739505815dea8c57c9df23e939c6",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "2.8.31",
+            "version": "3.19.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "64fa4b07f056e338a5f0f29eece75babaa83af68"
+                "reference": "eb9488f671175e708cf68c74cc04bd9115c96761"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/64fa4b07f056e338a5f0f29eece75babaa83af68",
-                "reference": "64fa4b07f056e338a5f0f29eece75babaa83af68",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/eb9488f671175e708cf68c74cc04bd9115c96761",
+                "reference": "eb9488f671175e708cf68c74cc04bd9115c96761",
                 "shasum": ""
             },
             "require": {
-                "guzzle/guzzle": "~3.7",
-                "php": ">=5.3.3"
+                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "~1.3.1",
+                "mtdowling/jmespath.php": "~2.2",
+                "php": ">=5.5"
             },
             "require-dev": {
-                "doctrine/cache": "~1.0",
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-json": "*",
                 "ext-openssl": "*",
-                "monolog/monolog": "~1.4",
-                "phpunit/phpunit": "~4.0",
-                "phpunit/phpunit-mock-objects": "2.3.1",
-                "symfony/yaml": "~2.1"
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "ext-spl": "*",
+                "nette/neon": "^2.3",
+                "phpunit/phpunit": "~4.0|~5.0",
+                "psr/cache": "^1.0"
             },
             "suggest": {
-                "doctrine/cache": "Adds support for caching of credentials and responses",
-                "ext-apc": "Allows service description opcode caching, request and response caching, and credentials caching",
-                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
-                "monolog/monolog": "Adds support for logging HTTP requests and responses",
-                "symfony/yaml": "Eases the ability to write manifests for creating jobs in AWS Import/Export"
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
             },
             "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Aws": "src/"
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
                 }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -73,7 +85,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-07-25 18:03:20"
+            "time": "2016-09-22 19:32:03"
         },
         {
             "name": "doctrine/annotations",
@@ -144,7 +156,6 @@
             "time": "2015-08-31 12:32:49"
         },
         {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "doctrine/cache",
             "version": "v1.6.0",
             "source": {
@@ -156,19 +167,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
                 "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
-=======
-            "name": "psr/http-message",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -219,22 +217,13 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "Caching library offering an object-oriented API for many cache backends",
             "homepage": "http://www.doctrine-project.org",
-=======
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
->>>>>>> Bump composer.lock to new versions
             "keywords": [
                 "cache",
                 "caching"
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2015-12-31 16:37:02"
-=======
-            "time": "2016-08-06 14:39:51"
->>>>>>> Bump composer.lock to new versions
         },
         {
             "name": "doctrine/collections",
@@ -303,7 +292,6 @@
             "time": "2015-04-14 22:21:58"
         },
         {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "doctrine/common",
             "version": "v2.6.1",
             "source": {
@@ -315,19 +303,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/doctrine/common/zipball/a579557bc689580c19fee4e27487a67fe60defc0",
                 "reference": "a579557bc689580c19fee4e27487a67fe60defc0",
-=======
-            "name": "symfony/console",
-            "version": "v2.7.18",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "cc3d188345b84d27a931db0969b0ff36272f451c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cc3d188345b84d27a931db0969b0ff36272f451c",
-                "reference": "cc3d188345b84d27a931db0969b0ff36272f451c",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -378,7 +353,6 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "Common Library for Doctrine projects",
             "homepage": "http://www.doctrine-project.org",
             "keywords": [
@@ -402,24 +376,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/doctrine/dbal/zipball/9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
                 "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
-=======
-            "description": "Symfony Console Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-06 07:26:07"
-        },
-        {
-            "name": "symfony/http-foundation",
-            "version": "v2.7.18",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "4b590c1e6f8045befac815b41a924b9b815f97bd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/4b590c1e6f8045befac815b41a924b9b815f97bd",
-                "reference": "4b590c1e6f8045befac815b41a924b9b815f97bd",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -469,7 +425,6 @@
                     "email": "jonwage@gmail.com"
                 }
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "Database Abstraction Layer",
             "homepage": "http://www.doctrine-project.org",
             "keywords": [
@@ -479,11 +434,6 @@
                 "queryobject"
             ],
             "time": "2016-09-09 19:13:33"
-=======
-            "description": "Symfony HttpFoundation Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-06 09:29:51"
->>>>>>> Bump composer.lock to new versions
         },
         {
             "name": "doctrine/inflector",
@@ -553,7 +503,6 @@
             "time": "2015-11-06 14:35:42"
         },
         {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "doctrine/lexer",
             "version": "v1.0.1",
             "source": {
@@ -569,71 +518,17 @@
             },
             "require": {
                 "php": ">=5.3.2"
-=======
-            "name": "aws/aws-sdk-php",
-            "version": "3.19.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "34060bf0db260031697b17dbb37fa1bbec92f1c4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/34060bf0db260031697b17dbb37fa1bbec92f1c4",
-                "reference": "34060bf0db260031697b17dbb37fa1bbec92f1c4",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
-                "guzzlehttp/promises": "~1.0",
-                "guzzlehttp/psr7": "~1.3.1",
-                "mtdowling/jmespath.php": "~2.2",
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "andrewsville/php-token-reflection": "^1.4",
-                "aws/aws-php-sns-message-validator": "~1.0",
-                "behat/behat": "~3.0",
-                "doctrine/cache": "~1.4",
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "ext-simplexml": "*",
-                "ext-spl": "*",
-                "nette/neon": "^2.3",
-                "phpunit/phpunit": "~4.0|~5.0",
-                "psr/cache": "^1.0"
-            },
-            "suggest": {
-                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
-                "doctrine/cache": "To use the DoctrineCacheAdapter",
-                "ext-curl": "To send requests using cURL",
-                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
->>>>>>> Bump composer.lock to new versions
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
                     "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
                     "Doctrine\\Common\\Lexer\\": "lib/"
-=======
-                    "dev-master": "3.0-dev"
->>>>>>> Bump composer.lock to new versions
                 }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Aws\\": "src/"
-                },
-                "files": [
-                    "src/functions.php"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -659,77 +554,44 @@
                 "lexer",
                 "parser"
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2014-09-09 13:34:57"
-=======
-            "time": "2016-09-08 20:27:15"
->>>>>>> Bump composer.lock to new versions
         },
         {
-            "name": "guzzle/guzzle",
-            "version": "v3.9.3",
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle3.git",
-                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9"
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/0645b70d953bc1c067bbc8d5bc53194706b628d9",
-                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "php": ">=5.3.3",
-                "symfony/event-dispatcher": "~2.1"
-            },
-            "replace": {
-                "guzzle/batch": "self.version",
-                "guzzle/cache": "self.version",
-                "guzzle/common": "self.version",
-                "guzzle/http": "self.version",
-                "guzzle/inflection": "self.version",
-                "guzzle/iterator": "self.version",
-                "guzzle/log": "self.version",
-                "guzzle/parser": "self.version",
-                "guzzle/plugin": "self.version",
-                "guzzle/plugin-async": "self.version",
-                "guzzle/plugin-backoff": "self.version",
-                "guzzle/plugin-cache": "self.version",
-                "guzzle/plugin-cookie": "self.version",
-                "guzzle/plugin-curlauth": "self.version",
-                "guzzle/plugin-error-response": "self.version",
-                "guzzle/plugin-history": "self.version",
-                "guzzle/plugin-log": "self.version",
-                "guzzle/plugin-md5": "self.version",
-                "guzzle/plugin-mock": "self.version",
-                "guzzle/plugin-oauth": "self.version",
-                "guzzle/service": "self.version",
-                "guzzle/stream": "self.version"
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
             },
             "require-dev": {
-                "doctrine/cache": "~1.3",
-                "monolog/monolog": "~1.0",
-                "phpunit/phpunit": "3.7.*",
-                "psr/log": "~1.0",
-                "symfony/class-loader": "~2.1",
-                "zendframework/zend-cache": "2.*,<2.3",
-                "zendframework/zend-log": "2.*,<2.3"
-            },
-            "suggest": {
-                "guzzlehttp/guzzle": "Guzzle 5 has moved to a new package name. The package you have installed, Guzzle 3, is deprecated."
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.9-dev"
+                    "dev-master": "6.2-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Guzzle": "src/",
-                    "Guzzle\\Tests": "tests/"
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -741,13 +603,9 @@
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Guzzle Community",
-                    "homepage": "https://github.com/guzzle/guzzle/contributors"
                 }
             ],
-            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
+            "description": "Guzzle is a PHP HTTP client library",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
@@ -758,8 +616,58 @@
                 "rest",
                 "web service"
             ],
-            "abandoned": "guzzlehttp/guzzle",
-            "time": "2015-03-18 18:23:50"
+            "time": "2016-07-15 17:22:37"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-05-18 16:56:05"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -863,16 +771,16 @@
         },
         {
             "name": "mongodb/mongodb",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mongodb/mongo-php-library.git",
-                "reference": "faf8a1d86b5c10684ef91fa6c81475b0c7f95240"
+                "reference": "3c742f3ceffc4dc67fee02dc6ebfc2e7cb403b7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/faf8a1d86b5c10684ef91fa6c81475b0c7f95240",
-                "reference": "faf8a1d86b5c10684ef91fa6c81475b0c7f95240",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/3c742f3ceffc4dc67fee02dc6ebfc2e7cb403b7c",
+                "reference": "3c742f3ceffc4dc67fee02dc6ebfc2e7cb403b7c",
                 "shasum": ""
             },
             "require": {
@@ -914,7 +822,62 @@
                 "mongodb",
                 "persistence"
             ],
-            "time": "2016-03-30 19:10:28"
+            "time": "2016-09-23 19:38:29"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/192f93e43c2c97acde7694993ab171b3de284093",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                },
+                "files": [
+                    "src/JmesPath.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "time": "2016-01-05 18:25:05"
         },
         {
             "name": "paragonie/random_compat",
@@ -1153,66 +1116,6 @@
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
             "time": "2016-09-06 10:55:00"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v2.8.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/889983a79a043dfda68f38c38b6dba092dd49cd8",
-                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
-                "symfony/dependency-injection": "~2.6|~3.0.0",
-                "symfony/expression-language": "~2.6|~3.0.0",
-                "symfony/stopwatch": "~2.3|~3.0.0"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-07-28 16:56:28"
         },
         {
             "name": "symfony/http-foundation",
@@ -1804,6 +1707,102 @@
                 "parser"
             ],
             "time": "2015-10-04 16:44:32"
+        },
+        {
+            "name": "guzzle/guzzle",
+            "version": "v3.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle3.git",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.3.3",
+                "symfony/event-dispatcher": "~2.1"
+            },
+            "replace": {
+                "guzzle/batch": "self.version",
+                "guzzle/cache": "self.version",
+                "guzzle/common": "self.version",
+                "guzzle/http": "self.version",
+                "guzzle/inflection": "self.version",
+                "guzzle/iterator": "self.version",
+                "guzzle/log": "self.version",
+                "guzzle/parser": "self.version",
+                "guzzle/plugin": "self.version",
+                "guzzle/plugin-async": "self.version",
+                "guzzle/plugin-backoff": "self.version",
+                "guzzle/plugin-cache": "self.version",
+                "guzzle/plugin-cookie": "self.version",
+                "guzzle/plugin-curlauth": "self.version",
+                "guzzle/plugin-error-response": "self.version",
+                "guzzle/plugin-history": "self.version",
+                "guzzle/plugin-log": "self.version",
+                "guzzle/plugin-md5": "self.version",
+                "guzzle/plugin-mock": "self.version",
+                "guzzle/plugin-oauth": "self.version",
+                "guzzle/service": "self.version",
+                "guzzle/stream": "self.version"
+            },
+            "require-dev": {
+                "doctrine/cache": "~1.3",
+                "monolog/monolog": "~1.0",
+                "phpunit/phpunit": "3.7.*",
+                "psr/log": "~1.0",
+                "symfony/class-loader": "~2.1",
+                "zendframework/zend-cache": "2.*,<2.3",
+                "zendframework/zend-log": "2.*,<2.3"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Guzzle 5 has moved to a new package name. The package you have installed, Guzzle 3, is deprecated."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Guzzle": "src/",
+                    "Guzzle\\Tests": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Guzzle Community",
+                    "homepage": "https://github.com/guzzle/guzzle/contributors"
+                }
+            ],
+            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "abandoned": "guzzlehttp/guzzle",
+            "time": "2015-03-18 18:23:50"
         },
         {
             "name": "herrera-io/json",
@@ -3573,7 +3572,6 @@
             "time": "2015-12-08 07:14:41"
         },
         {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "sebastian/environment",
             "version": "1.3.8",
             "source": {
@@ -3585,34 +3583,13 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-=======
-            "name": "doctrine/dbal",
-            "version": "v2.5.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/dbal.git",
-                "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
-                "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
                 "phpunit/phpunit": "^4.8 || ^5.0"
-=======
-                "phpunit/phpunit": "4.*",
-                "symfony/console": "2.*||^3.0"
-            },
-            "suggest": {
-                "symfony/console": "For helpful console commands such as SQL execution and import of files."
->>>>>>> Bump composer.lock to new versions
             },
             "type": "library",
             "extra": {
@@ -3642,11 +3619,7 @@
                 "environment",
                 "hhvm"
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-08-18 05:49:44"
-=======
-            "time": "2016-09-09 19:13:33"
->>>>>>> Bump composer.lock to new versions
         },
         {
             "name": "sebastian/exporter",
@@ -3843,7 +3816,6 @@
                     "email": "sebastian@phpunit.de"
                 }
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "Snapshotting of global state",
             "homepage": "http://www.github.com/sebastianbergmann/global-state",
             "keywords": [
@@ -3854,138 +3826,6 @@
         {
             "name": "sebastian/phpcpd",
             "version": "2.0.4",
-=======
-            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
-            ],
-            "abandoned": "guzzlehttp/guzzle",
-            "time": "2015-03-18 18:23:50"
-        },
-        {
-            "name": "guzzlehttp/guzzle",
-            "version": "6.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.3.1",
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
-                "psr/log": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.2-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
-            ],
-            "time": "2016-07-15 17:22:37"
-        },
-        {
-            "name": "guzzlehttp/promises",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/promises.git",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle promises library",
-            "keywords": [
-                "promise"
-            ],
-            "time": "2016-05-18 16:56:05"
-        },
-        {
-            "name": "mikey179/vfsStream",
-            "version": "v1.5.0",
->>>>>>> Bump composer.lock to new versions
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpcpd.git",
@@ -4035,68 +3875,8 @@
             "time": "2016-04-17 19:32:49"
         },
         {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "sebastian/recursion-context",
             "version": "1.0.2",
-=======
-            "name": "mtdowling/jmespath.php",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "192f93e43c2c97acde7694993ab171b3de284093"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/192f93e43c2c97acde7694993ab171b3de284093",
-                "reference": "192f93e43c2c97acde7694993ab171b3de284093",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "bin": [
-                "bin/jp.php"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "JmesPath\\": "src/"
-                },
-                "files": [
-                    "src/JmesPath.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Declaratively specify how to extract elements from a JSON document",
-            "keywords": [
-                "json",
-                "jsonpath"
-            ],
-            "time": "2016-01-05 18:25:05"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
->>>>>>> Bump composer.lock to new versions
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
@@ -4421,6 +4201,66 @@
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
             "time": "2016-09-06 23:19:39"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.8.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/889983a79a043dfda68f38c38b6dba092dd49cd8",
+                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-07-28 16:56:28"
         },
         {
             "name": "symfony/filesystem",
@@ -4845,18 +4685,17 @@
             "time": "2015-05-27 22:58:02"
         },
         {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "twig/twig",
-            "version": "v1.24.2",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7"
+                "reference": "f16a634ab08d87e520da5671ec52153d627f10f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
-                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/f16a634ab08d87e520da5671ec52153d627f10f6",
+                "reference": "f16a634ab08d87e520da5671ec52153d627f10f6",
                 "shasum": ""
             },
             "require": {
@@ -4865,31 +4704,11 @@
             "require-dev": {
                 "symfony/debug": "~2.7",
                 "symfony/phpunit-bridge": "~2.7"
-=======
-            "name": "sebastian/environment",
-            "version": "1.3.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
->>>>>>> Bump composer.lock to new versions
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.24-dev"
+                    "dev-master": "1.25-dev"
                 }
             },
             "autoload": {
@@ -4924,11 +4743,7 @@
             "keywords": [
                 "templating"
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
-            "time": "2016-09-01 17:50:53"
-=======
-            "time": "2016-08-18 05:49:44"
->>>>>>> Bump composer.lock to new versions
+            "time": "2016-09-21 23:05:12"
         },
         {
             "name": "zendframework/zend-cache",
@@ -5170,7 +4985,6 @@
             "time": "2016-04-18 18:32:43"
         },
         {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "zendframework/zend-hydrator",
             "version": "1.1.0",
             "source": {
@@ -5182,19 +4996,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-hydrator/zipball/22652e1661a5a10b3f564cf7824a2206cf5a4a65",
                 "reference": "22652e1661a5a10b3f564cf7824a2206cf5a4a65",
-=======
-            "name": "symfony/config",
-            "version": "v2.8.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/config.git",
-                "reference": "005bf10c156335ede2e89fb9a9ee10a0b742bc84"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/005bf10c156335ede2e89fb9a9ee10a0b742bc84",
-                "reference": "005bf10c156335ede2e89fb9a9ee10a0b742bc84",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -5239,7 +5040,6 @@
                 "hydrator",
                 "zf2"
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-02-18 22:38:26"
         },
         {
@@ -5254,24 +5054,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/b2db0d8246a865c659f93199f90f5fc2cd2f3cd8",
                 "reference": "b2db0d8246a865c659f93199f90f5fc2cd2f3cd8",
-=======
-            "description": "Symfony Config Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-08-16 14:56:08"
-        },
-        {
-            "name": "symfony/dependency-injection",
-            "version": "v2.8.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "0a732a9cafc30e54077967da4d019e1d618a8cb9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/0a732a9cafc30e54077967da4d019e1d618a8cb9",
-                "reference": "0a732a9cafc30e54077967da4d019e1d618a8cb9",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -5325,21 +5107,11 @@
                 "i18n",
                 "zf2"
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-06-07 21:08:30"
         },
         {
             "name": "zendframework/zend-json",
             "version": "3.0.0",
-=======
-            "description": "Symfony DependencyInjection Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-06 23:19:39"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v2.8.11",
->>>>>>> Bump composer.lock to new versions
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-json.git",
@@ -5388,7 +5160,6 @@
             "time": "2016-04-01 02:34:00"
         },
         {
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "zendframework/zend-serializer",
             "version": "2.8.0",
             "source": {
@@ -5400,19 +5171,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-serializer/zipball/ff74ea020f5f90866eb28365327e9bc765a61a6e",
                 "reference": "ff74ea020f5f90866eb28365327e9bc765a61a6e",
-=======
-            "name": "symfony/filesystem",
-            "version": "v2.8.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "44b499521defddf2eae17a18c811bbdae4f98bdf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/44b499521defddf2eae17a18c811bbdae4f98bdf",
-                "reference": "44b499521defddf2eae17a18c811bbdae4f98bdf",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -5456,7 +5214,6 @@
                 "serializer",
                 "zf2"
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-06-21 17:01:55"
         },
         {
@@ -5471,24 +5228,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/eeecb78945c2a9f653caded36ba5274e8a8f5468",
                 "reference": "eeecb78945c2a9f653caded36ba5274e8a8f5468",
-=======
-            "description": "Symfony Filesystem Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v2.8.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "bec5533e6ed650547d6ec8de4b541dc9929066f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/bec5533e6ed650547d6ec8de4b541dc9929066f7",
-                "reference": "bec5533e6ed650547d6ec8de4b541dc9929066f7",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -5527,7 +5266,6 @@
                 "servicemanager",
                 "zf2"
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-09-01 19:03:15"
         },
         {
@@ -5542,24 +5280,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/0e44eb46788f65e09e077eb7f44d2659143bcc1f",
                 "reference": "0e44eb46788f65e09e077eb7f44d2659143bcc1f",
-=======
-            "description": "Symfony Finder Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-08-26 11:57:43"
-        },
-        {
-            "name": "symfony/translation",
-            "version": "v2.8.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "bf0ff95faa9b6c0708efc1986255e3608d0ed3c7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/bf0ff95faa9b6c0708efc1986255e3608d0ed3c7",
-                "reference": "bf0ff95faa9b6c0708efc1986255e3608d0ed3c7",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -5605,7 +5325,6 @@
                 "stdlib",
                 "zf2"
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-04-12 21:17:31"
         },
         {
@@ -5620,24 +5339,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zetacomponents/Base/zipball/f20df24e8de3e48b6b69b2503f917e457281e687",
                 "reference": "f20df24e8de3e48b6b69b2503f917e457281e687",
-=======
-            "description": "Symfony Translation Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v2.8.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
->>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require-dev": {
@@ -5685,7 +5386,6 @@
                     "name": "Alexandru Stanoi"
                 }
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "The Base package provides the basic infrastructure that all packages rely on. Therefore every component relies on this package.",
             "homepage": "https://github.com/zetacomponents",
             "time": "2014-09-19 03:28:34"
@@ -5711,39 +5411,6 @@
                 "zetacomponents/unit-test": "dev-master"
             },
             "type": "library",
-=======
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-02 01:57:56"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3|^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2-dev"
-                }
-            },
->>>>>>> Bump composer.lock to new versions
             "autoload": {
                 "classmap": [
                     "src"
@@ -5770,19 +5437,9 @@
                     "name": "Alexandru Stanoi"
                 }
             ],
-<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "The Document components provides a general conversion framework for different semantic document markup languages like XHTML, Docbook, RST and similar.",
             "homepage": "https://github.com/zetacomponents",
             "time": "2013-12-19 11:40:00"
-=======
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-08-09 15:02:57"
->>>>>>> Bump composer.lock to new versions
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,13 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
     "hash": "d05c52c9b6801324f97ed603de072315",
     "content-hash": "3b9d5e20752d7455c4a4f4cb595ce14d",
+=======
+    "hash": "3f7a59ec27ea8e8279aa41890f70c81e",
+    "content-hash": "08b223b1b871d55aac5b0a1768e08981",
+>>>>>>> Bump composer.lock to new versions
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -139,6 +144,7 @@
             "time": "2015-08-31 12:32:49"
         },
         {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "doctrine/cache",
             "version": "v1.6.0",
             "source": {
@@ -150,6 +156,19 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
                 "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+=======
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -200,13 +219,22 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "Caching library offering an object-oriented API for many cache backends",
             "homepage": "http://www.doctrine-project.org",
+=======
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+>>>>>>> Bump composer.lock to new versions
             "keywords": [
                 "cache",
                 "caching"
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2015-12-31 16:37:02"
+=======
+            "time": "2016-08-06 14:39:51"
+>>>>>>> Bump composer.lock to new versions
         },
         {
             "name": "doctrine/collections",
@@ -275,6 +303,7 @@
             "time": "2015-04-14 22:21:58"
         },
         {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "doctrine/common",
             "version": "v2.6.1",
             "source": {
@@ -286,6 +315,19 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/doctrine/common/zipball/a579557bc689580c19fee4e27487a67fe60defc0",
                 "reference": "a579557bc689580c19fee4e27487a67fe60defc0",
+=======
+            "name": "symfony/console",
+            "version": "v2.7.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "cc3d188345b84d27a931db0969b0ff36272f451c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cc3d188345b84d27a931db0969b0ff36272f451c",
+                "reference": "cc3d188345b84d27a931db0969b0ff36272f451c",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -336,6 +378,7 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "Common Library for Doctrine projects",
             "homepage": "http://www.doctrine-project.org",
             "keywords": [
@@ -359,6 +402,24 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/doctrine/dbal/zipball/9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
                 "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
+=======
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-06 07:26:07"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v2.7.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "4b590c1e6f8045befac815b41a924b9b815f97bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/4b590c1e6f8045befac815b41a924b9b815f97bd",
+                "reference": "4b590c1e6f8045befac815b41a924b9b815f97bd",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -408,6 +469,7 @@
                     "email": "jonwage@gmail.com"
                 }
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "Database Abstraction Layer",
             "homepage": "http://www.doctrine-project.org",
             "keywords": [
@@ -417,6 +479,11 @@
                 "queryobject"
             ],
             "time": "2016-09-09 19:13:33"
+=======
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-06 09:29:51"
+>>>>>>> Bump composer.lock to new versions
         },
         {
             "name": "doctrine/inflector",
@@ -486,6 +553,7 @@
             "time": "2015-11-06 14:35:42"
         },
         {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "doctrine/lexer",
             "version": "v1.0.1",
             "source": {
@@ -501,17 +569,71 @@
             },
             "require": {
                 "php": ">=5.3.2"
+=======
+            "name": "aws/aws-sdk-php",
+            "version": "3.19.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "34060bf0db260031697b17dbb37fa1bbec92f1c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/34060bf0db260031697b17dbb37fa1bbec92f1c4",
+                "reference": "34060bf0db260031697b17dbb37fa1bbec92f1c4",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "~1.3.1",
+                "mtdowling/jmespath.php": "~2.2",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "ext-spl": "*",
+                "nette/neon": "^2.3",
+                "phpunit/phpunit": "~4.0|~5.0",
+                "psr/cache": "^1.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages"
+>>>>>>> Bump composer.lock to new versions
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
                     "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
                     "Doctrine\\Common\\Lexer\\": "lib/"
+=======
+                    "dev-master": "3.0-dev"
+>>>>>>> Bump composer.lock to new versions
                 }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -537,7 +659,11 @@
                 "lexer",
                 "parser"
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2014-09-09 13:34:57"
+=======
+            "time": "2016-09-08 20:27:15"
+>>>>>>> Bump composer.lock to new versions
         },
         {
             "name": "guzzle/guzzle",
@@ -3447,6 +3573,7 @@
             "time": "2015-12-08 07:14:41"
         },
         {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "sebastian/environment",
             "version": "1.3.8",
             "source": {
@@ -3458,13 +3585,34 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
                 "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+=======
+            "name": "doctrine/dbal",
+            "version": "v2.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
+                "reference": "9f8c05cd5225a320d56d4bfdb4772f10d045a0c9",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
                 "phpunit/phpunit": "^4.8 || ^5.0"
+=======
+                "phpunit/phpunit": "4.*",
+                "symfony/console": "2.*||^3.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+>>>>>>> Bump composer.lock to new versions
             },
             "type": "library",
             "extra": {
@@ -3494,7 +3642,11 @@
                 "environment",
                 "hhvm"
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-08-18 05:49:44"
+=======
+            "time": "2016-09-09 19:13:33"
+>>>>>>> Bump composer.lock to new versions
         },
         {
             "name": "sebastian/exporter",
@@ -3691,6 +3843,7 @@
                     "email": "sebastian@phpunit.de"
                 }
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "Snapshotting of global state",
             "homepage": "http://www.github.com/sebastianbergmann/global-state",
             "keywords": [
@@ -3701,6 +3854,138 @@
         {
             "name": "sebastian/phpcpd",
             "version": "2.0.4",
+=======
+            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "abandoned": "guzzlehttp/guzzle",
+            "time": "2015-03-18 18:23:50"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2016-07-15 17:22:37"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-05-18 16:56:05"
+        },
+        {
+            "name": "mikey179/vfsStream",
+            "version": "v1.5.0",
+>>>>>>> Bump composer.lock to new versions
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpcpd.git",
@@ -3750,8 +4035,68 @@
             "time": "2016-04-17 19:32:49"
         },
         {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "sebastian/recursion-context",
             "version": "1.0.2",
+=======
+            "name": "mtdowling/jmespath.php",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/192f93e43c2c97acde7694993ab171b3de284093",
+                "reference": "192f93e43c2c97acde7694993ab171b3de284093",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                },
+                "files": [
+                    "src/JmesPath.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "time": "2016-01-05 18:25:05"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+>>>>>>> Bump composer.lock to new versions
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
@@ -4500,6 +4845,7 @@
             "time": "2015-05-27 22:58:02"
         },
         {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "twig/twig",
             "version": "v1.24.2",
             "source": {
@@ -4519,6 +4865,26 @@
             "require-dev": {
                 "symfony/debug": "~2.7",
                 "symfony/phpunit-bridge": "~2.7"
+=======
+            "name": "sebastian/environment",
+            "version": "1.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+>>>>>>> Bump composer.lock to new versions
             },
             "type": "library",
             "extra": {
@@ -4558,7 +4924,11 @@
             "keywords": [
                 "templating"
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-09-01 17:50:53"
+=======
+            "time": "2016-08-18 05:49:44"
+>>>>>>> Bump composer.lock to new versions
         },
         {
             "name": "zendframework/zend-cache",
@@ -4800,6 +5170,7 @@
             "time": "2016-04-18 18:32:43"
         },
         {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "zendframework/zend-hydrator",
             "version": "1.1.0",
             "source": {
@@ -4811,6 +5182,19 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-hydrator/zipball/22652e1661a5a10b3f564cf7824a2206cf5a4a65",
                 "reference": "22652e1661a5a10b3f564cf7824a2206cf5a4a65",
+=======
+            "name": "symfony/config",
+            "version": "v2.8.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "005bf10c156335ede2e89fb9a9ee10a0b742bc84"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/005bf10c156335ede2e89fb9a9ee10a0b742bc84",
+                "reference": "005bf10c156335ede2e89fb9a9ee10a0b742bc84",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -4855,6 +5239,7 @@
                 "hydrator",
                 "zf2"
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-02-18 22:38:26"
         },
         {
@@ -4869,6 +5254,24 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/b2db0d8246a865c659f93199f90f5fc2cd2f3cd8",
                 "reference": "b2db0d8246a865c659f93199f90f5fc2cd2f3cd8",
+=======
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-08-16 14:56:08"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v2.8.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "0a732a9cafc30e54077967da4d019e1d618a8cb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/0a732a9cafc30e54077967da4d019e1d618a8cb9",
+                "reference": "0a732a9cafc30e54077967da4d019e1d618a8cb9",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -4922,11 +5325,21 @@
                 "i18n",
                 "zf2"
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-06-07 21:08:30"
         },
         {
             "name": "zendframework/zend-json",
             "version": "3.0.0",
+=======
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-06 23:19:39"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.8.11",
+>>>>>>> Bump composer.lock to new versions
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-json.git",
@@ -4975,6 +5388,7 @@
             "time": "2016-04-01 02:34:00"
         },
         {
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "name": "zendframework/zend-serializer",
             "version": "2.8.0",
             "source": {
@@ -4986,6 +5400,19 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-serializer/zipball/ff74ea020f5f90866eb28365327e9bc765a61a6e",
                 "reference": "ff74ea020f5f90866eb28365327e9bc765a61a6e",
+=======
+            "name": "symfony/filesystem",
+            "version": "v2.8.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "44b499521defddf2eae17a18c811bbdae4f98bdf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/44b499521defddf2eae17a18c811bbdae4f98bdf",
+                "reference": "44b499521defddf2eae17a18c811bbdae4f98bdf",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -5029,6 +5456,7 @@
                 "serializer",
                 "zf2"
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-06-21 17:01:55"
         },
         {
@@ -5043,6 +5471,24 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/eeecb78945c2a9f653caded36ba5274e8a8f5468",
                 "reference": "eeecb78945c2a9f653caded36ba5274e8a8f5468",
+=======
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-06 10:55:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v2.8.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "bec5533e6ed650547d6ec8de4b541dc9929066f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/bec5533e6ed650547d6ec8de4b541dc9929066f7",
+                "reference": "bec5533e6ed650547d6ec8de4b541dc9929066f7",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -5081,6 +5527,7 @@
                 "servicemanager",
                 "zf2"
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-09-01 19:03:15"
         },
         {
@@ -5095,6 +5542,24 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/0e44eb46788f65e09e077eb7f44d2659143bcc1f",
                 "reference": "0e44eb46788f65e09e077eb7f44d2659143bcc1f",
+=======
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-08-26 11:57:43"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v2.8.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "bf0ff95faa9b6c0708efc1986255e3608d0ed3c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/bf0ff95faa9b6c0708efc1986255e3608d0ed3c7",
+                "reference": "bf0ff95faa9b6c0708efc1986255e3608d0ed3c7",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require": {
@@ -5140,6 +5605,7 @@
                 "stdlib",
                 "zf2"
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "time": "2016-04-12 21:17:31"
         },
         {
@@ -5154,6 +5620,24 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zetacomponents/Base/zipball/f20df24e8de3e48b6b69b2503f917e457281e687",
                 "reference": "f20df24e8de3e48b6b69b2503f917e457281e687",
+=======
+            "description": "Symfony Translation Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-06 10:55:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.8.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
+                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
+>>>>>>> Bump composer.lock to new versions
                 "shasum": ""
             },
             "require-dev": {
@@ -5201,6 +5685,7 @@
                     "name": "Alexandru Stanoi"
                 }
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "The Base package provides the basic infrastructure that all packages rely on. Therefore every component relies on this package.",
             "homepage": "https://github.com/zetacomponents",
             "time": "2014-09-19 03:28:34"
@@ -5226,6 +5711,39 @@
                 "zetacomponents/unit-test": "dev-master"
             },
             "type": "library",
+=======
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-02 01:57:56"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+>>>>>>> Bump composer.lock to new versions
             "autoload": {
                 "classmap": [
                     "src"
@@ -5252,9 +5770,19 @@
                     "name": "Alexandru Stanoi"
                 }
             ],
+<<<<<<< 55876dbb187187a044df10b471480cef9265047c
             "description": "The Document components provides a general conversion framework for different semantic document markup languages like XHTML, Docbook, RST and similar.",
             "homepage": "https://github.com/zetacomponents",
             "time": "2013-12-19 11:40:00"
+=======
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-08-09 15:02:57"
+>>>>>>> Bump composer.lock to new versions
         }
     ],
     "aliases": [],

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -408,6 +408,9 @@ This adapter stores your images in a bucket in the Amazon Simple Storage Service
 ``bucket``
     The name of the bucket you want to store your images in. Imbo will **not** create this for you.
 
+``region``
+    The name of the region your bucket resides in. Required for Imbo 3.
+
 This adapter creates subdirectories in the bucket in the same fashion as the :ref:`Filesystem storage adapter <filesystem-storage-adapter>` stores the files on the local filesystem.
 
 Examples
@@ -424,6 +427,7 @@ Examples
                 'key' => '<aws access key>'
                 'secret' => '<aws secret key>',
                 'bucket' => 'my-imbo-bucket',
+                'region' => 'eu-central-1',
             ]);
         },
 

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -9,14 +9,10 @@ If you did a :ref:`git clone <git-clone>` you could simply do a ``git pull`` to 
 
 From time to time Imbo will introduce new features or fix bugs that might require you to update the contents of the database you choose to use. This chapter will contain all information you need to keep your installation up to date. Each of the following sections include the necessary steps you need to execute when upgrading to the different versions.
 
-.. contents::
-    :local:
-    :depth: 2
-
 Imbo-3.0.0
 ----------
 
-Below are the changes you need to be aware of when upgrading to Imbo-2.0.0.
+Below are the changes you need to be aware of when upgrading to Imbo-3.0.0.
 
 .. contents::
     :local:
@@ -24,11 +20,30 @@ Below are the changes you need to be aware of when upgrading to Imbo-2.0.0.
 
 XML-support has been removed
 ++++++++++++++++++++++++++++
+
 Imbo-3 no longer supports XML output. The only supported response format is JSON.
 
 ``auth`` is removed from the configuration
 ++++++++++++++++++++++++++++++++++++++++++
+
 Imbo-3 no longer provides support for using the ``auth`` part of the configuration file. You will need to use the :ref:`Access Control adapters <access-control-configuration>` from now on.
+
+S3 Library Upgraded
++++++++++++++++++++
+
+The dependency on ``aws-sdk-php`` has been upgraded to the most recent version at the time of release. The updated library requires the ``region`` parameter to be supplied when connecting to S3. This also applies to the Image Variations support if you're storing the variations in S3.
+
+Example
+^^^^^^^
+
+.. code-block:: php
+
+    new Imbo\Storage\S3([
+        'key' => '<aws access key>'
+        'secret' => '<aws secret key>',
+        'bucket' => 'my-imbo-bucket',
+        'region' => 'eu-central-1',
+    ]);
 
 Imbo-2.0.0
 ----------

--- a/src/EventListener/ImageVariations/Storage/S3.php
+++ b/src/EventListener/ImageVariations/Storage/S3.php
@@ -12,7 +12,6 @@ namespace Imbo\EventListener\ImageVariations\Storage;
 
 use Imbo\Exception\StorageException,
     Aws\S3\S3Client,
-    Aws\S3\Exception\NoSuchKeyException,
     Aws\S3\Exception\S3Exception,
     DateTime,
     DateTimeZone;
@@ -56,6 +55,9 @@ class S3 implements StorageInterface {
 
         // Region
         'region' => null,
+
+        // Version of API
+        'version' => '2006-03-01',
     ];
 
     /**
@@ -100,7 +102,7 @@ class S3 implements StorageInterface {
                 'Bucket' => $this->params['bucket'],
                 'Key' => $this->getImagePath($user, $imageIdentifier, $width),
             ]);
-        } catch (NoSuchKeyException $e) {
+        } catch (S3Exception $e) {
             return null;
         }
 
@@ -181,15 +183,18 @@ class S3 implements StorageInterface {
     private function getClient() {
         if ($this->client === null) {
             $params = [
-                'key' => $this->params['key'],
-                'secret' => $this->params['secret'],
+                'credentials' => [
+                    'key' => $this->params['key'],
+                    'secret' => $this->params['secret'],
+                ],
+                'version' => $this->params['version'],
             ];
 
             if ($this->params['region']) {
                 $params['region'] = $this->params['region'];
             }
 
-            $this->client = S3Client::factory($params);
+            $this->client = new S3Client($params);
         }
 
         return $this->client;

--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -12,7 +12,6 @@ namespace Imbo\Storage;
 
 use Imbo\Exception\StorageException,
     Aws\S3\S3Client,
-    Aws\S3\Exception\NoSuchKeyException,
     Aws\S3\Exception\S3Exception,
     DateTime,
     DateTimeZone;
@@ -119,7 +118,7 @@ class S3 implements StorageInterface {
                 'Bucket' => $this->getParams()['bucket'],
                 'Key' => $this->getImagePath($user, $imageIdentifier),
             ]);
-        } catch (NoSuchKeyException $e) {
+        } catch (S3Exception $e) {
             throw new StorageException('File not found', 404);
         }
 
@@ -135,7 +134,7 @@ class S3 implements StorageInterface {
                 'Bucket' => $this->getParams()['bucket'],
                 'Key' => $this->getImagePath($user, $imageIdentifier),
             ]);
-        } catch (NoSuchKeyException $e) {
+        } catch (S3Exception $e) {
             throw new StorageException('File not found', 404);
         }
 
@@ -166,7 +165,7 @@ class S3 implements StorageInterface {
                 'Bucket' => $this->getParams()['bucket'],
                 'Key' => $this->getImagePath($user, $imageIdentifier),
             ]);
-        } catch (NoSuchKeyException $e) {
+        } catch (S3Exception $e) {
             return false;
         }
 

--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -56,6 +56,9 @@ class S3 implements StorageInterface {
 
         // Region
         'region' => null,
+
+        // Version of API
+        'version' => '2006-03-01',
     ];
 
     /**
@@ -208,15 +211,18 @@ class S3 implements StorageInterface {
     protected function getClient() {
         if ($this->client === null) {
             $params = [
-                'key' => $this->getParams()['key'],
-                'secret' => $this->getParams()['secret'],
+                'credentials' => [
+                    'key' => $this->params['key'],
+                    'secret' => $this->params['secret'],
+                ],
+                'version' => $this->params['version'],
             ];
 
-            if ($this->getParams()['region']) {
-                $params['region'] = $this->getParams()['region'];
+            if ($this->params['region']) {
+                $params['region'] = $this->params['region'];
             }
 
-            $this->client = S3Client::factory($params);
+            $this->client = new S3Client($params);
         }
 
         return $this->client;

--- a/tests/phpunit/integration/EventListener/ImageVariations/Storage/S3Test.php
+++ b/tests/phpunit/integration/EventListener/ImageVariations/Storage/S3Test.php
@@ -11,6 +11,7 @@
 namespace ImboIntegrationTest\EventListener\ImageVariations\Storage;
 
 use Imbo\EventListener\ImageVariations\Storage\S3,
+    ImboIntegrationTest\Storage\S3Test as S3TestMain,
     Aws\S3\S3Client;
 
 /**
@@ -28,6 +29,8 @@ class S3Test extends StorageTests {
             'key' => $GLOBALS['AWS_S3_KEY'],
             'secret' => $GLOBALS['AWS_S3_SECRET'],
             'bucket' => $GLOBALS['AWS_S3_BUCKET'],
+            'region' => $GLOBALS['AWS_S3_REGION'],
+            'version' => '2006-03-01',
         ]);
     }
 
@@ -41,11 +44,16 @@ class S3Test extends StorageTests {
             }
         }
 
-        $client = S3Client::factory([
-            'key' => $GLOBALS['AWS_S3_KEY'],
-            'secret' => $GLOBALS['AWS_S3_SECRET'],
+        $client = new S3Client([
+            'credentials' => [
+                'key' => $GLOBALS['AWS_S3_KEY'],
+                'secret' => $GLOBALS['AWS_S3_SECRET'],
+            ],
+            'region' => $GLOBALS['AWS_S3_REGION'],
+            'version' => '2006-03-01',
         ]);
-        $client->clearBucket($GLOBALS['AWS_S3_BUCKET']);
+
+        S3TestMain::clearBucket($client, $GLOBALS['AWS_S3_BUCKET']);
 
         parent::setUp();
     }

--- a/tests/phpunit/phpunit.xml.dist
+++ b/tests/phpunit/phpunit.xml.dist
@@ -14,6 +14,7 @@
     <var name="AWS_S3_KEY" value="" />
     <var name="AWS_S3_SECRET" value="" />
     <var name="AWS_S3_BUCKET" value="" />
+    <var name="AWS_S3_REGION" value="" />
   </php>
 
   <filter>


### PR DESCRIPTION
The AWS SDK library changed significantly between 2.x and 3.x, and to support the new version we have to include the current version of the API we're talking to, as well as change the structure for how we're providing credentials for authentication. 

The changes are almost backwards compatible on an API level, but requires any configuration that uses S3 to provide the region of the S3 bucket.

The NoSuchKeyException has been removed and the API now throws the general S3Exception instead. The factory method has been deprecated, so we now use the constructor to provide settings instead.

As the clearBucket command has been removed, a custom method has been added to retrieve and remove the content of a bucket manually instead.

Partially fixes #476.