### PR TITLE
ImageTransformationCache: Increase method visibility for subclassing

### DIFF
--- a/src/EventListener/ImageTransformationCache.php
+++ b/src/EventListener/ImageTransformationCache.php
@@ -213,10 +213,10 @@ class ImageTransformationCache implements ListenerInterface {
     /**
      * Set whether the current request already did a cache hit
      *
-     * @param boolean Whether the request has already triggered a cache hit
+     * @param boolean $cacheHit Whether the request has already triggered a cache hit
      */
     protected function setCacheHit($cacheHit) {
-        $this->cacheHit = $cacheHit;
+        $this->cacheHit = (boolean) $cacheHit;
     }
 
     /**

--- a/src/EventListener/ImageTransformationCache.php
+++ b/src/EventListener/ImageTransformationCache.php
@@ -75,7 +75,7 @@ class ImageTransformationCache implements ListenerInterface {
             );
         }
 
-        $this->path = $path;
+        $this->setPath($path);
     }
 
     /**
@@ -229,6 +229,24 @@ class ImageTransformationCache implements ListenerInterface {
     }
 
     /**
+     * Get the base path for the cache.
+     *
+     * @return string
+     */
+    protected function getPath() {
+        return $this->path;
+    }
+
+    /**
+     * Set the current base path for the cache.
+     *
+     * @param string $path
+     */
+    protected function setPath($path) {
+        $this->path = $path;
+    }
+
+    /**
      * Get the path to the current image cache dir
      *
      * @param string $user The user which the image belongs to
@@ -239,7 +257,7 @@ class ImageTransformationCache implements ListenerInterface {
         $userPath = str_pad($user, 3, '0', STR_PAD_LEFT);
         return sprintf(
             '%s/%s/%s/%s/%s/%s/%s/%s/%s',
-            $this->path,
+            $this->getPath(),
             $userPath[0],
             $userPath[1],
             $userPath[2],


### PR DESCRIPTION
To allow for easy implementation of custom adapters for the ImageTransformationCache, this PR increases the visibility of the `getCacheDir`, `getCachePath`/`isWritable`/`rmdir` methods. In addition I've added a getter and setter for the `cacheHit` variable, allowing it to be manipulated from a sub class.
