### PR TITLE
Upgrade PHPUnit to ^5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   },
   "require-dev": {
     "mikey179/vfsStream": "^1.5.0",
-    "phpunit/phpunit": "^4.8",
+    "phpunit/phpunit": "^5.6",
     "behat/behat": "^2.0",
     "guzzle/guzzle": "^3.9.3",
     "phploc/phploc": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c92f99c1d7ac55598536a8b360f2deeb",
-    "content-hash": "713ab3bd9126cd865ef92ee00fdad0cd",
+    "hash": "f5e4f1b8e72be96f21803f1da372f1a2",
+    "content-hash": "95787b38a1dc3d0b153d90033c727e5a",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.19.10",
+            "version": "3.19.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "eb9488f671175e708cf68c74cc04bd9115c96761"
+                "reference": "b3657b6d2519bc8838be072c759ca5e272527877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/eb9488f671175e708cf68c74cc04bd9115c96761",
-                "reference": "eb9488f671175e708cf68c74cc04bd9115c96761",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b3657b6d2519bc8838be072c759ca5e272527877",
+                "reference": "b3657b6d2519bc8838be072c759ca5e272527877",
                 "shasum": ""
             },
             "require": {
@@ -85,39 +85,39 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-09-22 19:32:03"
+            "time": "2016-11-14 22:45:48"
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.2.7",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535"
+                "reference": "30e07cf03edc3cd3ef579d0dd4dd8c58250799a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/30e07cf03edc3cd3ef579d0dd4dd8c58250799a5",
+                "reference": "30e07cf03edc3cd3ef579d0dd4dd8c58250799a5",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
-                "php": ">=5.3.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^5.6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Annotations\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -153,20 +153,20 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2016-10-24 11:45:47"
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.6.0",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b6f544a20f4807e81f7044d31e679ccbb1866dc3",
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3",
                 "shasum": ""
             },
             "require": {
@@ -223,7 +223,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31 16:37:02"
+            "time": "2016-10-29 11:16:17"
         },
         {
             "name": "doctrine/collections",
@@ -558,16 +558,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.1",
+            "version": "6.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
-                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
                 "shasum": ""
             },
             "require": {
@@ -616,7 +616,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-07-15 17:22:37"
+            "time": "2016-10-08 15:01:37"
         },
         {
             "name": "guzzlehttp/promises",
@@ -881,16 +881,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.2",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf"
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/088c04e2f261c33bed6ca5245491cfca69195ccf",
-                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
                 "shasum": ""
             },
             "require": {
@@ -925,7 +925,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-04-03 06:00:07"
+            "time": "2016-11-07 23:38:38"
         },
         {
             "name": "psr/http-message",
@@ -978,17 +978,64 @@
             "time": "2016-08-06 14:39:51"
         },
         {
-            "name": "ramsey/uuid",
-            "version": "3.5.0",
+            "name": "psr/log",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/ramsey/uuid.git",
-                "reference": "a6d15c8618ea3951fd54d34e326b68d3d0bc0786"
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/a6d15c8618ea3951fd54d34e326b68d3d0bc0786",
-                "reference": "a6d15c8618ea3951fd54d34e326b68d3d0bc0786",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10 12:19:37"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "a07797b986671b0dc823885a81d5e3516b931599"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/a07797b986671b0dc823885a81d5e3516b931599",
+                "reference": "a07797b986671b0dc823885a81d5e3516b931599",
                 "shasum": ""
             },
             "require": {
@@ -1055,24 +1102,25 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2016-08-02 18:39:32"
+            "time": "2016-10-02 15:51:17"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "3d3e4fa5f0614c8e45220e5de80332322e33bd90"
+                "reference": "7350016c8abcab897046f1aead2b766b84d3eff8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3d3e4fa5f0614c8e45220e5de80332322e33bd90",
-                "reference": "3d3e4fa5f0614c8e45220e5de80332322e33bd90",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7350016c8abcab897046f1aead2b766b84d3eff8",
+                "reference": "7350016c8abcab897046f1aead2b766b84d3eff8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
+                "symfony/debug": "~2.7,>=2.7.2|~3.0.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
@@ -1115,20 +1163,77 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
+            "time": "2016-10-06 01:43:09"
         },
         {
-            "name": "symfony/http-foundation",
-            "version": "v2.8.11",
+            "name": "symfony/debug",
+            "version": "v3.0.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "1d4ab8de2215e44e57fddc1e6b5d122546769e7d"
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "697c527acd9ea1b2d3efac34d9806bf255278b0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/1d4ab8de2215e44e57fddc1e6b5d122546769e7d",
-                "reference": "1d4ab8de2215e44e57fddc1e6b5d122546769e7d",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/697c527acd9ea1b2d3efac34d9806bf255278b0a",
+                "reference": "697c527acd9ea1b2d3efac34d9806bf255278b0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/class-loader": "~2.8|~3.0",
+                "symfony/http-kernel": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-07-30 07:22:48"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v2.8.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "a6e6c34d337f3c74c39b29c5f54d33023de8897c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/a6e6c34d337f3c74c39b29c5f54d33023de8897c",
+                "reference": "a6e6c34d337f3c74c39b29c5f54d33023de8897c",
                 "shasum": ""
             },
             "require": {
@@ -1170,20 +1275,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
+            "time": "2016-10-24 15:52:36"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
                 "shasum": ""
             },
             "require": {
@@ -1195,7 +1300,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1229,20 +1334,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php54",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php54.git",
-                "reference": "34d761992f6f2cc6092cc0e5e93f38b53ba5e4f1"
+                "reference": "90e085822963fdcc9d1c5b73deb3d2e5783b16a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php54/zipball/34d761992f6f2cc6092cc0e5e93f38b53ba5e4f1",
-                "reference": "34d761992f6f2cc6092cc0e5e93f38b53ba5e4f1",
+                "url": "https://api.github.com/repos/symfony/polyfill-php54/zipball/90e085822963fdcc9d1c5b73deb3d2e5783b16a0",
+                "reference": "90e085822963fdcc9d1c5b73deb3d2e5783b16a0",
                 "shasum": ""
             },
             "require": {
@@ -1251,7 +1356,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1287,20 +1392,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php55",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php55.git",
-                "reference": "bf2ff9ad6be1a4772cb873e4eea94d70daa95c6d"
+                "reference": "03e3f0350bca2220e3623a0e340eef194405fc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php55/zipball/bf2ff9ad6be1a4772cb873e4eea94d70daa95c6d",
-                "reference": "bf2ff9ad6be1a4772cb873e4eea94d70daa95c6d",
+                "url": "https://api.github.com/repos/symfony/polyfill-php55/zipball/03e3f0350bca2220e3623a0e340eef194405fc67",
+                "reference": "03e3f0350bca2220e3623a0e340eef194405fc67",
                 "shasum": ""
             },
             "require": {
@@ -1310,7 +1415,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1343,7 +1448,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         }
     ],
     "packages-dev": [
@@ -1721,17 +1826,20 @@
         },
         {
             "name": "erusev/parsedown",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/erusev/parsedown.git",
-                "reference": "3ebbd730b5c2cf5ce78bc1bf64071407fc6674b7"
+                "reference": "20ff8bbb57205368b4b42d094642a3e52dac85fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/3ebbd730b5c2cf5ce78bc1bf64071407fc6674b7",
-                "reference": "3ebbd730b5c2cf5ce78bc1bf64071407fc6674b7",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/20ff8bbb57205368b4b42d094642a3e52dac85fb",
+                "reference": "20ff8bbb57205368b4b42d094642a3e52dac85fb",
                 "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
             },
             "type": "library",
             "autoload": {
@@ -1756,7 +1864,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2015-10-04 16:44:32"
+            "time": "2016-11-02 15:56:58"
         },
         {
             "name": "guzzle/guzzle",
@@ -2098,16 +2206,16 @@
         },
         {
             "name": "jms/serializer",
-            "version": "1.3.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "705d0b4633b9c44e6253aa18306b3972282cd3a3"
+                "reference": "f39d8b4660d5cef43b0c3265ce642173d9b2c58b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/705d0b4633b9c44e6253aa18306b3972282cd3a3",
-                "reference": "705d0b4633b9c44e6253aa18306b3972282cd3a3",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/f39d8b4660d5cef43b0c3265ce642173d9b2c58b",
+                "reference": "f39d8b4660d5cef43b0c3265ce642173d9b2c58b",
                 "shasum": ""
             },
             "require": {
@@ -2125,6 +2233,7 @@
             "require-dev": {
                 "doctrine/orm": "~2.1",
                 "doctrine/phpcr-odm": "^1.3|^2.0",
+                "ext-pdo_sqlite": "*",
                 "jackalope/jackalope-doctrine-dbal": "^1.1.5",
                 "phpunit/phpunit": "^4.8|^5.0",
                 "propel/propel1": "~1.7",
@@ -2141,7 +2250,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -2168,7 +2277,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2016-08-23 17:20:24"
+            "time": "2016-11-13 10:20:11"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -2401,6 +2510,48 @@
                 "psr-3"
             ],
             "time": "2016-07-29 03:23:52"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/399c1f9781e222f6eb6cc238796f5200d1b7f108",
+                "reference": "399c1f9781e222f6eb6cc238796f5200d1b7f108",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2016-10-31 17:19:45"
         },
         {
             "name": "nikic/php-parser",
@@ -3043,39 +3194,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "6cba06ff75a1a63a71033e1a01b89056f3af1e8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6cba06ff75a1a63a71033e1a01b89056f3af1e8d",
+                "reference": "6cba06ff75a1a63a71033e1a01b89056f3af1e8d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": "^5.6 || ^7.0",
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "~1.0|~2.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
+                "ext-xdebug": ">=2.4.0",
                 "ext-xmlwriter": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -3101,7 +3253,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2016-11-01 05:06:24"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3286,40 +3438,50 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.27",
+            "version": "5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
+                "reference": "a9de0dbafeb6b1391b391fbb034734cb0af9f67c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9de0dbafeb6b1391b391fbb034734cb0af9f67c",
+                "reference": "a9de0dbafeb6b1391b391fbb034734cb0af9f67c",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "phpunit/php-code-coverage": "^4.0.1",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
+                "phpunit/phpunit-mock-objects": "^3.2",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
+                "sebastian/environment": "^1.3 || ^2.0",
                 "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
+                "sebastian/object-enumerator": "~1.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
             "suggest": {
+                "ext-xdebug": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -3328,7 +3490,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.6.x-dev"
                 }
             },
             "autoload": {
@@ -3354,30 +3516,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21 06:48:14"
+            "time": "2016-11-14 06:39:40"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
+                "reference": "238d7a2723bce689c79eeac9c7d5e1d623bb9dc2",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -3385,7 +3550,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -3410,7 +3575,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2016-10-09 07:01:45"
         },
         {
             "name": "pimple/pimple",
@@ -3459,21 +3624,24 @@
             "time": "2013-11-22 08:30:29"
         },
         {
-            "name": "psr/log",
-            "version": "1.0.1",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "5277094ed527a1c4477177d102fe4c53551953e0"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/5277094ed527a1c4477177d102fe4c53551953e0",
-                "reference": "5277094ed527a1c4477177d102fe4c53551953e0",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
             },
             "type": "library",
             "extra": {
@@ -3482,28 +3650,23 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2016-09-19 16:02:08"
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13 06:45:14"
         },
         {
             "name": "sebastian/comparator",
@@ -3874,6 +4037,52 @@
             "time": "2015-10-12 03:26:01"
         },
         {
+            "name": "sebastian/object-enumerator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-01-28 13:25:10"
+        },
+        {
             "name": "sebastian/phpcpd",
             "version": "2.0.4",
             "source": {
@@ -3926,16 +4135,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "938df7a6478e72795e5f8266cff24d06e3136f2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/938df7a6478e72795e5f8266cff24d06e3136f2e",
+                "reference": "938df7a6478e72795e5f8266cff24d06e3136f2e",
                 "shasum": ""
             },
             "require": {
@@ -3975,23 +4184,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-11-15 06:55:36"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -4010,20 +4269,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2016-02-04 12:56:52"
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "e827b5254d3e58c736ea2c5616710983d80b0b70"
+                "reference": "19495c181d6d53a0a13414154e52817e3b504189"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/e827b5254d3e58c736ea2c5616710983d80b0b70",
-                "reference": "e827b5254d3e58c736ea2c5616710983d80b0b70",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/19495c181d6d53a0a13414154e52817e3b504189",
+                "reference": "19495c181d6d53a0a13414154e52817e3b504189",
                 "shasum": ""
             },
             "require": {
@@ -4056,7 +4315,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2016-09-14 15:17:56"
+            "time": "2016-11-14 17:59:58"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -4138,16 +4397,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "005bf10c156335ede2e89fb9a9ee10a0b742bc84"
+                "reference": "f8b1922bbda9d2ac86aecd649399040bce849fde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/005bf10c156335ede2e89fb9a9ee10a0b742bc84",
-                "reference": "005bf10c156335ede2e89fb9a9ee10a0b742bc84",
+                "url": "https://api.github.com/repos/symfony/config/zipball/f8b1922bbda9d2ac86aecd649399040bce849fde",
+                "reference": "f8b1922bbda9d2ac86aecd649399040bce849fde",
                 "shasum": ""
             },
             "require": {
@@ -4187,20 +4446,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-16 14:56:08"
+            "time": "2016-09-14 20:31:12"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "0a732a9cafc30e54077967da4d019e1d618a8cb9"
+                "reference": "3d61c765daa1a5832f1d7c767f48886b8d8ea64c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/0a732a9cafc30e54077967da4d019e1d618a8cb9",
-                "reference": "0a732a9cafc30e54077967da4d019e1d618a8cb9",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/3d61c765daa1a5832f1d7c767f48886b8d8ea64c",
+                "reference": "3d61c765daa1a5832f1d7c767f48886b8d8ea64c",
                 "shasum": ""
             },
             "require": {
@@ -4250,20 +4509,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 23:19:39"
+            "time": "2016-10-24 15:52:36"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8"
+                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/889983a79a043dfda68f38c38b6dba092dd49cd8",
-                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
+                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
                 "shasum": ""
             },
             "require": {
@@ -4310,7 +4569,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-28 16:56:28"
+            "time": "2016-10-13 01:43:15"
         },
         {
             "name": "symfony/filesystem",
@@ -4363,16 +4622,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "bec5533e6ed650547d6ec8de4b541dc9929066f7"
+                "reference": "bc24c8f5674c6f6841f2856b70e5d60784be5691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/bec5533e6ed650547d6ec8de4b541dc9929066f7",
-                "reference": "bec5533e6ed650547d6ec8de4b541dc9929066f7",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/bc24c8f5674c6f6841f2856b70e5d60784be5691",
+                "reference": "bc24c8f5674c6f6841f2856b70e5d60784be5691",
                 "shasum": ""
             },
             "require": {
@@ -4408,20 +4667,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-26 11:57:43"
+            "time": "2016-09-28 00:10:16"
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "05a03ed27073638658cab9405d99a67dd1014987"
+                "reference": "024de37f8a6b9e5e8244d9eb3fcf3e467dd2a93f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/05a03ed27073638658cab9405d99a67dd1014987",
-                "reference": "05a03ed27073638658cab9405d99a67dd1014987",
+                "url": "https://api.github.com/repos/symfony/process/zipball/024de37f8a6b9e5e8244d9eb3fcf3e467dd2a93f",
+                "reference": "024de37f8a6b9e5e8244d9eb3fcf3e467dd2a93f",
                 "shasum": ""
             },
             "require": {
@@ -4457,11 +4716,11 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
+            "time": "2016-09-29 14:03:54"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -4510,16 +4769,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "bf0ff95faa9b6c0708efc1986255e3608d0ed3c7"
+                "reference": "cca6ff892355876534b01a927f789bac9601c935"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/bf0ff95faa9b6c0708efc1986255e3608d0ed3c7",
-                "reference": "bf0ff95faa9b6c0708efc1986255e3608d0ed3c7",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/cca6ff892355876534b01a927f789bac9601c935",
+                "reference": "cca6ff892355876534b01a927f789bac9601c935",
                 "shasum": ""
             },
             "require": {
@@ -4570,20 +4829,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
+            "time": "2016-10-18 04:28:30"
         },
         {
             "name": "symfony/validator",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "53b1b1d3f7550e4b1e365dbad39a0b6c60bfcf85"
+                "reference": "987bf3a7d585680773bc79f6cf3d9e78340cb02c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/53b1b1d3f7550e4b1e365dbad39a0b6c60bfcf85",
-                "reference": "53b1b1d3f7550e4b1e365dbad39a0b6c60bfcf85",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/987bf3a7d585680773bc79f6cf3d9e78340cb02c",
+                "reference": "987bf3a7d585680773bc79f6cf3d9e78340cb02c",
                 "shasum": ""
             },
             "require": {
@@ -4643,20 +4902,20 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
+            "time": "2016-10-19 22:37:24"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.11",
+            "version": "v2.8.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c"
+                "reference": "396784cd06b91f3db576f248f2402d547a077787"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
-                "reference": "e7540734bad981fe59f8ef14b6fc194ae9df8d9c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/396784cd06b91f3db576f248f2402d547a077787",
+                "reference": "396784cd06b91f3db576f248f2402d547a077787",
                 "shasum": ""
             },
             "require": {
@@ -4692,7 +4951,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-02 01:57:56"
+            "time": "2016-10-21 20:59:10"
         },
         {
             "name": "theseer/fdomdocument",
@@ -4736,16 +4995,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.25.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "f16a634ab08d87e520da5671ec52153d627f10f6"
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/f16a634ab08d87e520da5671ec52153d627f10f6",
-                "reference": "f16a634ab08d87e520da5671ec52153d627f10f6",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
                 "shasum": ""
             },
             "require": {
@@ -4758,7 +5017,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.25-dev"
+                    "dev-master": "1.27-dev"
                 }
             },
             "autoload": {
@@ -4793,7 +5052,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-09-21 23:05:12"
+            "time": "2016-10-25 19:17:17"
         },
         {
             "name": "zendframework/zend-cache",

--- a/tests/phpunit/integration/Auth/AccessControl/Adapter/AdapterTests.php
+++ b/tests/phpunit/integration/Auth/AccessControl/Adapter/AdapterTests.php
@@ -41,7 +41,7 @@ abstract class AdapterTests extends \PHPUnit_Framework_TestCase {
     }
 
     public function testReturnsEmptyArrayWhenThereIsNoGroups() {
-        $model = $this->getMock('Imbo\Model\Groups');
+        $model = $this->createMock('Imbo\Model\Groups');
         $model->expects($this->once())->method('setHits')->with(0);
 
         $this->assertSame([], $this->adapter->getGroups(null, $model));
@@ -57,7 +57,7 @@ abstract class AdapterTests extends \PHPUnit_Framework_TestCase {
         $this->assertSame(['images.get', 'images.head'], $this->adapter->getGroup('g1'));
         $this->assertSame(['status.get'], $this->adapter->getGroup('g2'));
 
-        $model = $this->getMock('Imbo\Model\Groups');
+        $model = $this->createMock('Imbo\Model\Groups');
         $model->expects($this->once())->method('setHits')->with(2);
 
         $groups = $this->adapter->getGroups(null, $model);

--- a/tests/phpunit/integration/Database/DatabaseTests.php
+++ b/tests/phpunit/integration/Database/DatabaseTests.php
@@ -107,7 +107,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($this->adapter->insertImage($user, $imageIdentifier, $this->getImage()));
         $this->assertTrue($this->adapter->deleteImage($user, $imageIdentifier));
 
-        $this->adapter->load($user, $imageIdentifier, $this->getMock('Imbo\Model\Image'));
+        $this->adapter->load($user, $imageIdentifier, $this->createMock('Imbo\Model\Image'));
     }
 
     /**
@@ -125,7 +125,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionMessage Image not found
      */
     public function testLoadImageThatDoesNotExist() {
-        $this->adapter->load('user', 'id', $this->getMock('Imbo\Model\Image'));
+        $this->adapter->load('user', 'id', $this->createMock('Imbo\Model\Image'));
     }
 
     /**
@@ -367,7 +367,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
 
         // Empty query
         $query = new Query();
-        $model = $this->getMock('Imbo\Model\Images');
+        $model = $this->createMock('Imbo\Model\Images');
         $model->expects($this->once())->method('setHits')->with(6);
         $images = $this->adapter->getImages(['user'], $query, $model);
         $this->assertCount(6, $images);
@@ -413,7 +413,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $query = new Query();
         $query->returnMetadata(true);
 
-        $images = $this->adapter->getImages(['user', 'user2'], $query, $this->getMock('Imbo\Model\Images'));
+        $images = $this->adapter->getImages(['user', 'user2'], $query, $this->createMock('Imbo\Model\Images'));
         $this->assertCount(6, $images, 'Incorrect length. Expected 6, got ' . count($images));
 
         foreach ($images as $image) {
@@ -456,7 +456,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
     public function testGetImagesReturnsImagesWithDateTimeInstances() {
         $this->insertImages();
 
-        $images = $this->adapter->getImages(['user'], new Query(), $this->getMock('Imbo\Model\Images'));
+        $images = $this->adapter->getImages(['user'], new Query(), $this->createMock('Imbo\Model\Images'));
 
         foreach (['added', 'updated'] as $dateField) {
             foreach ($images as $image) {
@@ -512,7 +512,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
             $query->limit($limit);
         }
 
-        $model = $this->getMock('Imbo\Model\Images');
+        $model = $this->createMock('Imbo\Model\Images');
         $model->expects($this->once())->method('setHits')->with(6);
 
         $images = $this->adapter->getImages(['user'], $query, $model);
@@ -844,7 +844,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
             $query->sort($sort);
         }
 
-        $images = $this->adapter->getImages(['user'], $query, $this->getMock('Imbo\Model\Images'));
+        $images = $this->adapter->getImages(['user'], $query, $this->createMock('Imbo\Model\Images'));
 
         foreach ($images as $i => $image) {
             $this->assertSame($values[$i], $image[$field]);

--- a/tests/phpunit/integration/EventListener/ExifMetadataTest.php
+++ b/tests/phpunit/integration/EventListener/ExifMetadataTest.php
@@ -29,9 +29,9 @@ class ExifMetadataTest extends \PHPUnit_Framework_TestCase {
         $image = new Image();
         $image->setBlob(file_get_contents(FIXTURES_DIR . '/exif-logo.jpg'));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
 
         $properties = $listener->populate($event);
@@ -59,9 +59,9 @@ class ExifMetadataTest extends \PHPUnit_Framework_TestCase {
         $image = new Image();
         $image->setBlob(file_get_contents(FIXTURES_DIR . '/exif-logo.jpg'));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
 
         $properties = $listener->populate($event);
@@ -83,9 +83,9 @@ class ExifMetadataTest extends \PHPUnit_Framework_TestCase {
         $image = new Image();
         $image->setBlob(file_get_contents(FIXTURES_DIR . '/exif-logo.jpg'));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
 
         $properties = $listener->populate($event);
@@ -109,18 +109,18 @@ class ExifMetadataTest extends \PHPUnit_Framework_TestCase {
         $image->setBlob(file_get_contents(FIXTURES_DIR . '/exif-logo.jpg'));
         $image->setImageIdentifier($imageIdentifier);
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->exactly(2))->method('getImage')->will($this->returnValue($image));
         $request->expects($this->once())->method('getUser')->will($this->returnValue($user));
 
-        $database = $this->getMock('Imbo\Database\DatabaseInterface');
+        $database = $this->createMock('Imbo\Database\DatabaseInterface');
         $database->expects($this->once())->method('updateMetadata')->with(
             $this->equalTo($user),
             $this->equalTo($imageIdentifier),
             $this->arrayHasKey('gps:location')
         );
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->exactly(2))->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->once())->method('getDatabase')->will($this->returnValue($database));
 

--- a/tests/phpunit/integration/EventListener/ImageTransformationLimiterTest.php
+++ b/tests/phpunit/integration/EventListener/ImageTransformationLimiterTest.php
@@ -26,12 +26,12 @@ class ImageTransformationLimiterTest extends \PHPUnit_Framework_TestCase {
     public function testLimitsTransformationCount() {
         $listener = new ImageTransformationLimiter(['limit' => 2]);
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
 
         // content of array isn't important, the check is done on the count of the array
         $request->expects($this->any())->method('getTransformations')->will($this->returnValue([1, 2, 3, 4, 5]));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
 
         $this->setExpectedException('Imbo\Exception\ResourceException', '', 403);
@@ -46,12 +46,12 @@ class ImageTransformationLimiterTest extends \PHPUnit_Framework_TestCase {
     public function testAllowsTransformationCount() {
         $listener = new ImageTransformationLimiter(['limit' => 2]);
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
 
         // content of array isn't important, the check is done on the count of the array
         $request->expects($this->any())->method('getTransformations')->will($this->returnValue([1, 2]));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
 
         $listener->checkTransformationCount($event);
@@ -65,12 +65,12 @@ class ImageTransformationLimiterTest extends \PHPUnit_Framework_TestCase {
     public function testAllowsAnyTransformationCount() {
         $listener = new ImageTransformationLimiter(['limit' => 0]);
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
 
         // content of array isn't important, the check is done on the count of the array
         $request->expects($this->any())->method('getTransformations')->will($this->returnValue([1, 2, 3, 4, 5, 6, 7, 8, 9]));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
 
         $listener->checkTransformationCount($event);

--- a/tests/phpunit/integration/Image/Transformation/AutoRotateTest.php
+++ b/tests/phpunit/integration/Image/Transformation/AutoRotateTest.php
@@ -78,7 +78,7 @@ class AutoRotateTest extends TransformationTests {
          */
         $blob = file_get_contents($file);
 
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
 
         if ($changeDimensions) {
             $image->expects($this->once())->method('setWidth')->with(350)->will($this->returnValue($image));
@@ -94,7 +94,7 @@ class AutoRotateTest extends TransformationTests {
             $image->expects($this->never())->method('hasBeenTransformed');
         }
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         // Perform the auto rotate transformation on the image

--- a/tests/phpunit/integration/Image/Transformation/BorderTest.php
+++ b/tests/phpunit/integration/Image/Transformation/BorderTest.php
@@ -42,12 +42,12 @@ class BorderTest extends TransformationTests {
      * @dataProvider getBorderParams
      */
     public function testTransformationSupportsDifferentModes($expectedWidth, $expectedHeight, $borderWidth, $borderHeight, $borderMode) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('setWidth')->with($expectedWidth)->will($this->returnValue($image));
         $image->expects($this->once())->method('setHeight')->with($expectedHeight)->will($this->returnValue($image));
         $image->expects($this->once())->method('hasBeenTransformed')->with(true);
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))
               ->method('getArgument')
               ->with('image')

--- a/tests/phpunit/integration/Image/Transformation/CanvasTest.php
+++ b/tests/phpunit/integration/Image/Transformation/CanvasTest.php
@@ -83,7 +83,7 @@ class CanvasTest extends TransformationTests {
     public function testTransformWithDifferentParameters($width, $height, $mode = 'free', $resultingWidth = 665, $resultingHeight = 463) {
         $blob = file_get_contents(FIXTURES_DIR . '/image.png');
 
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->any())->method('getBlob')->will($this->returnValue($blob));
         $image->expects($this->any())->method('getWidth')->will($this->returnValue(665));
         $image->expects($this->any())->method('getHeight')->will($this->returnValue(463));
@@ -92,7 +92,7 @@ class CanvasTest extends TransformationTests {
         $image->expects($this->once())->method('setHeight')->with($resultingHeight)->will($this->returnValue($image));
         $image->expects($this->once())->method('hasBeenTransformed')->with(true);
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))
               ->method('getArgument')
               ->with('image')

--- a/tests/phpunit/integration/Image/Transformation/CompressTest.php
+++ b/tests/phpunit/integration/Image/Transformation/CompressTest.php
@@ -27,11 +27,11 @@ class CompressTest extends TransformationTests {
     }
 
     public function testCanTransformTheImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true);
         $image->expects($this->once())->method('getMimeType')->will($this->returnValue('image/jpeg'));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('params')->will($this->returnValue(['level' => 50]));
         $event->expects($this->at(1))->method('getArgument')->with('image')->will($this->returnValue($image));
 

--- a/tests/phpunit/integration/Image/Transformation/ConvertTest.php
+++ b/tests/phpunit/integration/Image/Transformation/ConvertTest.php
@@ -27,13 +27,13 @@ class ConvertTest extends TransformationTests {
     }
 
     public function testCanConvertAnImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getExtension')->will($this->returnValue('png'));
         $image->expects($this->once())->method('setMimeType')->with('image/gif')->will($this->returnValue($image));
         $image->expects($this->once())->method('setExtension')->with('gif')->will($this->returnValue($image));
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue(['type' => 'gif']));
 

--- a/tests/phpunit/integration/Image/Transformation/CropTest.php
+++ b/tests/phpunit/integration/Image/Transformation/CropTest.php
@@ -45,7 +45,7 @@ class CropTest extends TransformationTests {
      * @dataProvider getCropParams
      */
     public function testCanCropImages($params, $endWidth, $endHeight, $transformed) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->any())->method('getWidth')->will($this->returnValue(665));
         $image->expects($this->any())->method('getHeight')->will($this->returnValue(463));
 
@@ -55,7 +55,7 @@ class CropTest extends TransformationTests {
             $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
         }
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue($params));
 

--- a/tests/phpunit/integration/Image/Transformation/DesaturateTest.php
+++ b/tests/phpunit/integration/Image/Transformation/DesaturateTest.php
@@ -30,10 +30,10 @@ class DesaturateTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Desaturate::transform
      */
     public function testCanDesaturateImages() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $imagick = new Imagick();

--- a/tests/phpunit/integration/Image/Transformation/FlipHorizontallyTest.php
+++ b/tests/phpunit/integration/Image/Transformation/FlipHorizontallyTest.php
@@ -30,10 +30,10 @@ class FlipHorizontallyTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\FlipHorizontally::transform
      */
     public function testCanFlipTheImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $imagick = new Imagick();

--- a/tests/phpunit/integration/Image/Transformation/FlipVerticallyTest.php
+++ b/tests/phpunit/integration/Image/Transformation/FlipVerticallyTest.php
@@ -30,10 +30,10 @@ class FlipVerticallyTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\FlipVertically::transform
      */
     public function testCanFlipTheImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $imagick = new Imagick();

--- a/tests/phpunit/integration/Image/Transformation/HistogramTest.php
+++ b/tests/phpunit/integration/Image/Transformation/HistogramTest.php
@@ -46,7 +46,7 @@ class HistogramTest extends TransformationTests {
     public function testTransformWithDifferentParameters($scale, $resultingWidth = 256) {
         $blob = file_get_contents(FIXTURES_DIR . '/512x512.png');
 
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->any())->method('getBlob')->will($this->returnValue($blob));
         $image->expects($this->any())->method('getWidth')->will($this->returnValue(512));
         $image->expects($this->any())->method('getHeight')->will($this->returnValue(512));
@@ -55,7 +55,7 @@ class HistogramTest extends TransformationTests {
         $image->expects($this->once())->method('setHeight')->will($this->returnValue($image));
         $image->expects($this->once())->method('hasBeenTransformed')->with(true);
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))
               ->method('getArgument')
               ->with('image')

--- a/tests/phpunit/integration/Image/Transformation/MaxSizeTest.php
+++ b/tests/phpunit/integration/Image/Transformation/MaxSizeTest.php
@@ -107,7 +107,7 @@ class MaxSizeTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\MaxSize::transform
      */
     public function testCanTransformImages($file, $params, $width, $height, $transformedWidth, $transformedHeight, $transformation = true) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getWidth')->will($this->returnValue($width));
         $image->expects($this->once())->method('getHeight')->will($this->returnValue($height));
 
@@ -121,7 +121,7 @@ class MaxSizeTest extends TransformationTests {
             $image->expects($this->never())->method('hasBeenTransformed');
         }
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue($params));
 

--- a/tests/phpunit/integration/Image/Transformation/ModulateTest.php
+++ b/tests/phpunit/integration/Image/Transformation/ModulateTest.php
@@ -49,10 +49,10 @@ class ModulateTest extends TransformationTests {
      * @dataProvider getModulateParams
      */
     public function testCanModulateImages(array $params) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('params')->will($this->returnValue($params));
         $event->expects($this->at(1))->method('getArgument')->with('image')->will($this->returnValue($image));
 

--- a/tests/phpunit/integration/Image/Transformation/ProgressiveTest.php
+++ b/tests/phpunit/integration/Image/Transformation/ProgressiveTest.php
@@ -30,10 +30,10 @@ class ProgressiveTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Progressive::transform
      */
     public function testCanMakeTheImageProgressive() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $imagick = new Imagick();

--- a/tests/phpunit/integration/Image/Transformation/ResizeTest.php
+++ b/tests/phpunit/integration/Image/Transformation/ResizeTest.php
@@ -63,7 +63,7 @@ class ResizeTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Resize::transform
      */
     public function testCanTransformImage($params, $transformation, $resizedWidth = null, $resizedHeight = null) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getWidth')->will($this->returnValue(665));
         $image->expects($this->once())->method('getHeight')->will($this->returnValue(463));
 
@@ -77,7 +77,7 @@ class ResizeTest extends TransformationTests {
             $image->expects($this->never())->method('hasBeenTransformed');
         }
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue($params));
 

--- a/tests/phpunit/integration/Image/Transformation/RotateTest.php
+++ b/tests/phpunit/integration/Image/Transformation/RotateTest.php
@@ -38,13 +38,13 @@ class RotateTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Rotate::transform
      */
     public function testCanTransformImage($angle, $width, $height) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
 
         $image->expects($this->once())->method('setWidth')->with($width)->will($this->returnValue($image));
         $image->expects($this->once())->method('setHeight')->with($height)->will($this->returnValue($image));
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue([
             'angle' => $angle,

--- a/tests/phpunit/integration/Image/Transformation/SepiaTest.php
+++ b/tests/phpunit/integration/Image/Transformation/SepiaTest.php
@@ -30,10 +30,10 @@ class SepiaTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Sepia::transform
      */
     public function testCanTransformImageWithoutParams() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true);
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('params')->will($this->returnValue([]));
         $event->expects($this->at(1))->method('getArgument')->with('image')->will($this->returnValue($image));
 
@@ -47,10 +47,10 @@ class SepiaTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Sepia::transform
      */
     public function testCanTransformImageWithParams() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true);
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('params')->will($this->returnValue(['threshold' => 10]));
         $event->expects($this->at(1))->method('getArgument')->with('image')->will($this->returnValue($image));
 

--- a/tests/phpunit/integration/Image/Transformation/StripTest.php
+++ b/tests/phpunit/integration/Image/Transformation/StripTest.php
@@ -30,10 +30,10 @@ class StripTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Strip::transform
      */
     public function testStripMetadata() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $imagick = new Imagick();

--- a/tests/phpunit/integration/Image/Transformation/ThumbnailTest.php
+++ b/tests/phpunit/integration/Image/Transformation/ThumbnailTest.php
@@ -76,12 +76,12 @@ class ThumbnailTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Thumbnail::transform
      */
     public function testCanTransformImage($params, $width, $height) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('setWidth')->with($width)->will($this->returnValue($image));
         $image->expects($this->once())->method('setHeight')->with($height)->will($this->returnValue($image));
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue($params));
 

--- a/tests/phpunit/integration/Image/Transformation/TransposeTest.php
+++ b/tests/phpunit/integration/Image/Transformation/TransposeTest.php
@@ -30,10 +30,10 @@ class TransposeTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Transpose::transform
      */
     public function testCanTransformImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $imagick = new Imagick();

--- a/tests/phpunit/integration/Image/Transformation/TransverseTest.php
+++ b/tests/phpunit/integration/Image/Transformation/TransverseTest.php
@@ -30,10 +30,10 @@ class TransverseTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Transverse::transform
      */
     public function testCanTransformImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $imagick = new Imagick();

--- a/tests/phpunit/integration/Image/Transformation/VignetteTest.php
+++ b/tests/phpunit/integration/Image/Transformation/VignetteTest.php
@@ -30,12 +30,12 @@ class VignetteTest extends TransformationTests {
      * @covers Imbo\Image\Transformation\Vignette::transform
      */
     public function testCanVignetteImages() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
         $image->expects($this->once())->method('getWidth')->will($this->returnValue(640));
         $image->expects($this->once())->method('getHeight')->will($this->returnValue(480));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('params')->will($this->returnValue([]));
         $event->expects($this->at(1))->method('getArgument')->with('image')->will($this->returnValue($image));
 

--- a/tests/phpunit/integration/Image/Transformation/WatermarkTest.php
+++ b/tests/phpunit/integration/Image/Transformation/WatermarkTest.php
@@ -235,13 +235,13 @@ class WatermarkTest extends TransformationTests {
             $expectedWatermark = $params['img'];
         }
 
-        $storage = $this->getMock('Imbo\Storage\StorageInterface');
+        $storage = $this->createMock('Imbo\Storage\StorageInterface');
         $storage->expects($this->once())
                 ->method('getImage')
                 ->with('someUser', $expectedWatermark)
                 ->will($this->returnValue(file_get_contents(FIXTURES_DIR . '/black.png')));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getUser')->will($this->returnValue('someUser'));
 
         $event = new Event();

--- a/tests/phpunit/unit/ApplicationTest.php
+++ b/tests/phpunit/unit/ApplicationTest.php
@@ -61,7 +61,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
      */
     public function testThrowsExceptionWhenConfigurationHasInvalidStorageAdapter() {
         $this->application->run([
-            'database' => $this->getMock('Imbo\Database\DatabaseInterface'),
+            'database' => $this->createMock('Imbo\Database\DatabaseInterface'),
             'storage' => function() { return new \stdClass(); },
             'trustedProxies' => [],
         ]);
@@ -75,8 +75,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
      */
     public function testThrowsExceptionWhenConfigurationHasInvalidAccessControlAdapter() {
         $this->application->run([
-            'database' => $this->getMock('Imbo\Database\DatabaseInterface'),
-            'storage' => $this->getMock('Imbo\Storage\StorageInterface'),
+            'database' => $this->createMock('Imbo\Database\DatabaseInterface'),
+            'storage' => $this->createMock('Imbo\Storage\StorageInterface'),
             'routes' => [],
             'trustedProxies' => [],
             'accessControl' => function() { return new \stdClass(); },
@@ -91,9 +91,9 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertEmpty(Request::getTrustedProxies());
         $this->application->run([
-            'database' => $this->getMock('Imbo\Database\DatabaseInterface'),
-            'storage' => $this->getMock('Imbo\Storage\StorageInterface'),
-            'accessControl' => $this->getMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface'),
+            'database' => $this->createMock('Imbo\Database\DatabaseInterface'),
+            'storage' => $this->createMock('Imbo\Storage\StorageInterface'),
+            'accessControl' => $this->createMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface'),
             'eventListenerInitializers' => [],
             'eventListeners' => [],
             'contentNegotiateImages' => false,
@@ -118,19 +118,19 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
                 $this->assertInstanceOf('Imbo\Http\Request\Request', $request);
                 $this->assertInstanceOf('Imbo\Http\Response\Response', $response);
 
-                return $this->getMock('Imbo\Database\DatabaseInterface');
+                return $this->createMock('Imbo\Database\DatabaseInterface');
             },
             'storage' => function ($request, $response) {
                 $this->assertInstanceOf('Imbo\Http\Request\Request', $request);
                 $this->assertInstanceOf('Imbo\Http\Response\Response', $response);
 
-                return $this->getMock('Imbo\Storage\StorageInterface');
+                return $this->createMock('Imbo\Storage\StorageInterface');
             },
             'accessControl' => function ($request, $response) {
                 $this->assertInstanceOf('Imbo\Http\Request\Request', $request);
                 $this->assertInstanceOf('Imbo\Http\Response\Response', $response);
 
-                return $this->getMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface');
+                return $this->createMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface');
             },
             'eventListeners' => [
                 'test' => function ($request, $response) {

--- a/tests/phpunit/unit/Auth/AccessControl/Adapter/ArrayAdapterTest.php
+++ b/tests/phpunit/unit/Auth/AccessControl/Adapter/ArrayAdapterTest.php
@@ -208,7 +208,7 @@ class ArrayAdapterTest extends \PHPUnit_Framework_TestCase {
     public function testCanGetGroups(array $groups, array $result, $query = null) {
         $numGroups = count($groups);
 
-        $model = $this->getMock('Imbo\Model\Groups');
+        $model = $this->createMock('Imbo\Model\Groups');
         $model->expects($this->once())->method('setHits')->with($numGroups);
 
         $adapter = new ArrayAdapter([], $groups);

--- a/tests/phpunit/unit/Auth/AccessControl/Adapter/MongoDBTest.php
+++ b/tests/phpunit/unit/Auth/AccessControl/Adapter/MongoDBTest.php
@@ -43,9 +43,9 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
      * Set up
      */
     public function setUp() {
-        $this->client = $this->getMock('MongoClient');
-        $this->aclCollection = $this->getMockBuilder('MongoCollection')->disableOriginalConstructor()->getMock();
-        $this->aclGroupCollection = $this->getMockBuilder('MongoCollection')->disableOriginalConstructor()->getMock();
+        $this->client = $this->createMock('MongoClient');
+        $this->aclCollection = $this->createMock('MongoCollection');
+        $this->aclGroupCollection = $this->createMock('MongoCollection');
         $this->adapter = new MongoDB(null, $this->client, $this->aclCollection, $this->aclGroupCollection);
     }
 

--- a/tests/phpunit/unit/CliCommand/AddPublicKeyTest.php
+++ b/tests/phpunit/unit/CliCommand/AddPublicKeyTest.php
@@ -38,7 +38,7 @@ class AddPublicKeyTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\CliCommand\AddPublicKey::__construct
      */
     public function setUp() {
-        $this->adapter = $this->getMock('Imbo\Auth\AccessControl\Adapter\MutableAdapterInterface');
+        $this->adapter = $this->createMock('Imbo\Auth\AccessControl\Adapter\MutableAdapterInterface');
 
         $this->command = new AddPublicKey();
         $this->command->setConfig([
@@ -97,7 +97,7 @@ class AddPublicKeyTest extends \PHPUnit_Framework_TestCase {
     public function testThrowsOnImmutableAdapter() {
         $command = new AddPublicKey();
         $command->setConfig([
-            'accessControl' => $this->getMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface')
+            'accessControl' => $this->createMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface')
         ]);
 
         $commandTester = new CommandTester($command);

--- a/tests/phpunit/unit/Database/DoctrineTest.php
+++ b/tests/phpunit/unit/Database/DoctrineTest.php
@@ -40,7 +40,7 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
             $this->markTestSkipped('Doctrine is required to run this test');
         }
 
-        $this->connection = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $this->connection = $this->createMock('Doctrine\DBAL\Connection');
         $this->driver = new Doctrine([], $this->connection);
     }
 

--- a/tests/phpunit/unit/Database/MongoDBTest.php
+++ b/tests/phpunit/unit/Database/MongoDBTest.php
@@ -49,9 +49,9 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
             $this->markTestSkipped('pecl/mongo >= 1.3.0 is required to run this test');
         }
 
-        $this->mongoClient = $this->getMockBuilder('MongoClient')->disableOriginalConstructor()->getMock();
-        $this->imageCollection = $this->getMockBuilder('MongoCollection')->disableOriginalConstructor()->getMock();
-        $this->shortUrlCollection = $this->getMockBuilder('MongoCollection')->disableOriginalConstructor()->getMock();
+        $this->mongoClient = $this->createMock('MongoClient');
+        $this->imageCollection = $this->createMock('MongoCollection');
+        $this->shortUrlCollection = $this->createMock('MongoCollection');
         $this->driver = new MongoDB([], $this->mongoClient, $this->imageCollection, $this->shortUrlCollection);
     }
 
@@ -95,7 +95,7 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
                               ->method('insert')
                               ->will($this->throwException(new MongoException()));
 
-        $this->driver->insertImage('key', 'identifier', $this->getMock('Imbo\Model\Image'));
+        $this->driver->insertImage('key', 'identifier', $this->createMock('Imbo\Model\Image'));
     }
 
     /**
@@ -112,7 +112,7 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
                               ->method('update')
                               ->will($this->throwException(new MongoException()));
 
-        $this->driver->insertImage('key', 'identifier', $this->getMock('Imbo\Model\Image'));
+        $this->driver->insertImage('key', 'identifier', $this->createMock('Imbo\Model\Image'));
     }
 
     /**
@@ -186,7 +186,7 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
                               ->method('find')
                               ->will($this->throwException(new MongoException()));
 
-        $this->driver->getImages(['key'], $this->getMock('Imbo\Resource\Images\Query'), $this->getMock('Imbo\Model\Images'));
+        $this->driver->getImages(['key'], $this->createMock('Imbo\Resource\Images\Query'), $this->createMock('Imbo\Model\Images'));
     }
 
     /**
@@ -200,7 +200,7 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
                               ->method('findOne')
                               ->will($this->throwException(new MongoException()));
 
-        $this->driver->load('key', 'identifier', $this->getMock('Imbo\Model\Image'));
+        $this->driver->load('key', 'identifier', $this->createMock('Imbo\Model\Image'));
     }
 
     /**

--- a/tests/phpunit/unit/EventListener/AccessTokenTest.php
+++ b/tests/phpunit/unit/EventListener/AccessTokenTest.php
@@ -34,15 +34,15 @@ class AccessTokenTest extends ListenerTests {
      * Set up the listener
      */
     public function setUp() {
-        $this->query = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $this->query = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
 
-        $this->accessControl = $this->getMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface');
+        $this->accessControl = $this->createMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface');
 
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
         $this->request->query = $this->query;
 
-        $this->responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
+        $this->responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
         $this->response->headers = $this->responseHeaders;
 
         $this->event = $this->getEventMock();
@@ -402,7 +402,7 @@ class AccessTokenTest extends ListenerTests {
     }
 
     protected function getEventMock($config = null) {
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getAccessControl')->will($this->returnValue($this->accessControl));
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));

--- a/tests/phpunit/unit/EventListener/AuthenticateTest.php
+++ b/tests/phpunit/unit/EventListener/AuthenticateTest.php
@@ -34,15 +34,16 @@ class AuthenticateTest extends ListenerTests {
      * Set up the listener
      */
     public function setUp() {
-        $this->query = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
-        $this->headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
-        $this->accessControl = $this->getMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface');
+        $this->query = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $this->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $this->accessControl = $this->createMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface');
 
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
         $this->request->query = $this->query;
         $this->request->headers = $this->headers;
 
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->response->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
 
         $this->event = $this->getEventMock();
 
@@ -57,7 +58,7 @@ class AuthenticateTest extends ListenerTests {
     }
 
     protected function getEventMock($config = null) {
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $event->expects($this->any())->method('getAccessControl')->will($this->returnValue($this->accessControl));
@@ -179,7 +180,7 @@ class AuthenticateTest extends ListenerTests {
         $this->request->expects($this->once())->method('getPublicKey')->will($this->returnValue($publicKey));
         $this->request->expects($this->once())->method('getMethod')->will($this->returnValue($httpMethod));
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
         $responseHeaders->expects($this->once())->method('set')->with('X-Imbo-AuthUrl', $url);
 
         $this->response->headers = $responseHeaders;
@@ -215,7 +216,7 @@ class AuthenticateTest extends ListenerTests {
         $this->request->expects($this->once())->method('getPublicKey')->will($this->returnValue($publicKey));
         $this->request->expects($this->once())->method('getMethod')->will($this->returnValue($httpMethod));
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
         $responseHeaders->expects($this->once())->method('set')->with('X-Imbo-AuthUrl', $url);
 
         $this->response->headers = $responseHeaders;
@@ -350,7 +351,7 @@ class AuthenticateTest extends ListenerTests {
         $this->request->expects($this->once())->method('getPublicKey')->will($this->returnValue('christer'));
         $this->request->expects($this->any())->method('getMethod')->will($this->returnValue('PUT'));
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
         $responseHeaders->expects($this->once())->method('set')->with('X-Imbo-AuthUrl', $authHeader);
 
         $this->response->headers = $responseHeaders;

--- a/tests/phpunit/unit/EventListener/AutoRotateImageTest.php
+++ b/tests/phpunit/unit/EventListener/AutoRotateImageTest.php
@@ -52,15 +52,15 @@ class AutoRotateImageTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\EventListener\AutoRotateImage::autoRotate
      */
     public function testTriggersAnEventForRotatingTheImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));
 
-        $eventManager = $this->getMock('Imbo\EventManager\EventManager');
+        $eventManager = $this->createMock('Imbo\EventManager\EventManager');
         $eventManager->expects($this->once())->method('trigger')->with('image.transformation.autorotate', ['image' => $image]);
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->once())->method('getManager')->will($this->returnValue($eventManager));
 

--- a/tests/phpunit/unit/EventListener/CorsTest.php
+++ b/tests/phpunit/unit/EventListener/CorsTest.php
@@ -33,15 +33,16 @@ class CorsTest extends ListenerTests {
      * @covers Imbo\EventListener\Cors::__construct
      */
     public function setUp() {
-        $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $requestHeaders->expects($this->any())->method('get')->with('Origin')->will($this->returnValue('http://imbo-project.org'));
 
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
         $this->request->headers = $requestHeaders;
 
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->response->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
 
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
 
@@ -96,7 +97,7 @@ class CorsTest extends ListenerTests {
      * @covers Imbo\EventListener\Cors::originIsAllowed
      */
     public function testDoesNotAddHeadersWhenOriginIsDisallowedAndHttpMethodIsOptions() {
-        $headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $headers->expects($this->never())->method('add');
         $this->response->headers = $headers;
 
@@ -121,14 +122,14 @@ class CorsTest extends ListenerTests {
             'allowedOrigins' => ['*']
         ]);
 
-        $headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $headers->expects($this->once())->method('add')->with([
             'Access-Control-Allow-Origin' => 'http://imbo-project.org',
         ]);
 
         $this->response->headers = $headers;
         $this->request->expects($this->once())->method('getMethod')->will($this->returnValue('GET'));
-        $route = $this->getMock('Imbo\Router\Route');
+        $route = $this->createMock('Imbo\Router\Route');
         $route->expects($this->once())->method('__toString')->will($this->returnValue('index'));
         $this->request->expects($this->once())->method('getRoute')->will($this->returnValue($route));
         $listener->invoke($this->event);
@@ -143,7 +144,7 @@ class CorsTest extends ListenerTests {
             'allowedOrigins' => ['http://imbo-project.org']
         ]);
 
-        $headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
 
         $headers->expects($this->once())->method('add')->with([
             'Access-Control-Allow-Origin' => 'http://imbo-project.org',
@@ -151,7 +152,7 @@ class CorsTest extends ListenerTests {
 
         $this->response->headers = $headers;
         $this->request->expects($this->once())->method('getMethod')->will($this->returnValue('GET'));
-        $route = $this->getMock('Imbo\Router\Route');
+        $route = $this->createMock('Imbo\Router\Route');
         $route->expects($this->once())->method('__toString')->will($this->returnValue('index'));
         $this->request->expects($this->once())->method('getRoute')->will($this->returnValue($route));
         $listener->invoke($this->event);
@@ -168,7 +169,7 @@ class CorsTest extends ListenerTests {
 
         $headerIterator = new \ArrayIterator(['x-imbo-something' => 'value', 'not-included' => 'foo']);
 
-        $headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $headers->expects($this->once())->method('getIterator')->will($this->returnValue($headerIterator));
         $headers->expects($this->at(0))->method('add')->with([
             'Access-Control-Allow-Origin' => 'http://imbo-project.org',
@@ -179,7 +180,7 @@ class CorsTest extends ListenerTests {
 
         $this->response->headers = $headers;
         $this->request->expects($this->once())->method('getMethod')->will($this->returnValue('GET'));
-        $route = $this->getMock('Imbo\Router\Route');
+        $route = $this->createMock('Imbo\Router\Route');
         $route->expects($this->once())->method('__toString')->will($this->returnValue('index'));
         $this->request->expects($this->once())->method('getRoute')->will($this->returnValue($route));
         $listener->invoke($this->event);
@@ -192,7 +193,7 @@ class CorsTest extends ListenerTests {
     public function testDoesNotAddExposeHeadersHeaderWhenOriginIsInvalid() {
         $listener = new Cors([]);
 
-        $headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $headers->expects($this->never())->method('add');
 
         $this->response->headers = $headers;
@@ -211,11 +212,11 @@ class CorsTest extends ListenerTests {
             'maxAge' => 60,
         ]);
 
-        $route = $this->getMock('Imbo\Router\Route');
+        $route = $this->createMock('Imbo\Router\Route');
         $route->expects($this->once())->method('__toString')->will($this->returnValue('image'));
         $this->request->expects($this->once())->method('getRoute')->will($this->returnValue($route));
 
-        $this->request->headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $this->request->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $this->request->headers
             ->expects($this->at(0))
             ->method('get')
@@ -228,7 +229,7 @@ class CorsTest extends ListenerTests {
             ->with('Access-Control-Request-Headers', '')
             ->will($this->returnValue('x-imbo-signature,something-else'));
 
-        $headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $headers->expects($this->once())->method('add')->with([
             'Access-Control-Allow-Origin' => 'http://imbo-project.org',
             'Access-Control-Allow-Methods' => 'OPTIONS, HEAD',
@@ -254,18 +255,18 @@ class CorsTest extends ListenerTests {
      * @covers Imbo\EventListener\Cors::invoke
      */
     public function testDoesNotAddAccessControlHeadersWhenOriginIsNotAllowed() {
-        $route = $this->getMock('Imbo\Router\Route');
+        $route = $this->createMock('Imbo\Router\Route');
         $route->expects($this->once())->method('__toString')->will($this->returnValue('image'));
 
-        $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $requestHeaders->expects($this->any())->method('get')->with('Origin')->will($this->returnValue('http://somehost'));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getRoute')->will($this->returnValue($route));
         $request->expects($this->once())->method('getMethod')->will($this->returnValue('GET'));
         $request->headers = $requestHeaders;
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->once())->method('getResponse')->will($this->returnValue($this->response));
 
@@ -354,16 +355,16 @@ class CorsTest extends ListenerTests {
     public function testWillSubscribeToTheCorrectEventsBasedOnParams($params, $events) {
         $listener = new Cors($params);
 
-        $headers = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $headers = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
         $headers->expects($this->once())->method('set')->with('Allow', 'OPTIONS', false);
 
-        $response = $this->getMock('Imbo\Http\Response\Response');
+        $response = $this->createMock('Imbo\Http\Response\Response');
         $response->headers = $headers;
 
-        $manager = $this->getMock('Imbo\EventManager\EventManager');
+        $manager = $this->createMock('Imbo\EventManager\EventManager');
         $manager->expects($this->once())->method('addCallbacks')->with('handler', $events);
 
-        $event = $this->getMock('Imbo\EventManager\EventInterface');
+        $event = $this->createMock('Imbo\EventManager\EventInterface');
         $event->expects($this->once())->method('getManager')->will($this->returnValue($manager));
         $event->expects($this->once())->method('getHandler')->will($this->returnValue('handler'));
         $event->expects($this->once())->method('getResponse')->will($this->returnValue($response));
@@ -376,7 +377,7 @@ class CorsTest extends ListenerTests {
      */
     public function testAddsVaryHeaderContainingOriginRegardlessOfAllowedStatus() {
         $this->request->expects($this->any())->method('getMethod')->will($this->returnValue('GET'));
-        $route = $this->getMock('Imbo\Router\Route');
+        $route = $this->createMock('Imbo\Router\Route');
         $route->expects($this->any())->method('__toString')->will($this->returnValue('index'));
         $this->request->expects($this->any())->method('getRoute')->will($this->returnValue($route));
 
@@ -385,10 +386,11 @@ class CorsTest extends ListenerTests {
             'allowedOrigins' => ['http://imbo-project.org']
         ]);
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
 
-        $response = $this->getMock('Imbo\Http\Response\Response');
+        $response = $this->createMock('Imbo\Http\Response\Response');
+        $response->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $response->expects($this->once())->method('setVary')->with('Origin', false);
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
 
@@ -399,10 +401,10 @@ class CorsTest extends ListenerTests {
             'allowedOrigins' => []
         ]);
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
 
-        $response = $this->getMock('Imbo\Http\Response\Response');
+        $response = $this->createMock('Imbo\Http\Response\Response');
         $response->expects($this->once())->method('setVary')->with('Origin', false);
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
 

--- a/tests/phpunit/unit/EventListener/DatabaseOperationsTest.php
+++ b/tests/phpunit/unit/EventListener/DatabaseOperationsTest.php
@@ -39,17 +39,17 @@ class DatabaseOperationsTest extends ListenerTests {
      * Set up the listener
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->accessControl = $this->getMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface');
-        $this->image = $this->getMock('Imbo\Model\Image');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->accessControl = $this->createMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface');
+        $this->image = $this->createMock('Imbo\Model\Image');
 
         $this->request->expects($this->any())->method('getUser')->will($this->returnValue($this->user));
         $this->request->expects($this->any())->method('getUsers')->will($this->returnValue([$this->user]));
         $this->request->expects($this->any())->method('getImageIdentifier')->will($this->returnValue($this->imageIdentifier));
 
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getDatabase')->will($this->returnValue($this->database));
@@ -190,7 +190,7 @@ class DatabaseOperationsTest extends ListenerTests {
 
         $date = new DateTime();
 
-        $query = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $query = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
         $query->expects($this->at(0))->method('has')->with('page')->will($this->returnValue(true));
         $query->expects($this->at(1))->method('get')->with('page')->will($this->returnValue(1));
         $query->expects($this->at(2))->method('has')->with('limit')->will($this->returnValue(true));
@@ -211,7 +211,7 @@ class DatabaseOperationsTest extends ListenerTests {
         $query->expects($this->at(17))->method('get')->with('originalChecksums')->will($this->returnValue(['checksum1', 'checksum2', 'checksum3']));
         $this->request->query = $query;
 
-        $imagesQuery = $this->getMock('Imbo\Resource\Images\Query');
+        $imagesQuery = $this->createMock('Imbo\Resource\Images\Query');
         $this->listener->setImagesQuery($imagesQuery);
 
         $this->database->expects($this->once())->method('getImages')->with([$this->user], $imagesQuery)->will($this->returnValue($images));
@@ -254,7 +254,7 @@ class DatabaseOperationsTest extends ListenerTests {
      * @covers Imbo\EventListener\DatabaseOperations::setImagesQuery
      */
     public function testCanCreateItsOwnImagesQuery() {
-        $query = $this->getMock('Imbo\Resource\Images\Query');
+        $query = $this->createMock('Imbo\Resource\Images\Query');
         $this->assertInstanceOf('Imbo\Resource\Images\Query', $this->listener->getImagesQuery());
         $this->listener->getImagesQuery();
         $this->assertSame($this->listener, $this->listener->setImagesQuery($query));

--- a/tests/phpunit/unit/EventListener/ExifMetadataTest.php
+++ b/tests/phpunit/unit/EventListener/ExifMetadataTest.php
@@ -139,22 +139,22 @@ class ExifMetadataTest extends ListenerTests {
         $imageIdentifier = 'imageIdentifier';
         $blob = 'blob';
 
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue($imageIdentifier));
         $image->expects($this->once())->method('getBlob')->will($this->returnValue($blob));
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->once())->method('readImageBlob')->will($this->returnValue($blob));
         $imagick->expects($this->once())->method('getImageProperties')->will($this->returnValue($data));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getUser')->will($this->returnValue($user));
         $request->expects($this->any())->method('getImage')->will($this->returnValue($image));
 
-        $database = $this->getMock('Imbo\Database\DatabaseInterface');
+        $database = $this->createMock('Imbo\Database\DatabaseInterface');
         $database->expects($this->once())->method('updateMetadata')->with($user, $imageIdentifier, $expectedData);
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->exactly(2))->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->once())->method('getDatabase')->will($this->returnValue($database));
 
@@ -171,19 +171,19 @@ class ExifMetadataTest extends ListenerTests {
      * @expectedExceptionCode 500
      */
     public function testWillDeleteImageWhenUpdatingMetadataFails() {
-        $databaseException = $this->getMock('Imbo\Exception\DatabaseException');
-        $database = $this->getMock('Imbo\Database\DatabaseInterface');
+        $databaseException = $this->createMock('Imbo\Exception\DatabaseException');
+        $database = $this->createMock('Imbo\Database\DatabaseInterface');
         $database->expects($this->once())->method('updateMetadata')->with('user', 'imageidentifier', [])->will($this->throwException($databaseException));
         $database->expects($this->once())->method('deleteImage')->with('user', 'imageidentifier');
 
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageidentifier'));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getUser')->will($this->returnValue('user'));
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->once())->method('getDatabase')->will($this->returnValue($database));
 

--- a/tests/phpunit/unit/EventListener/ImageTransformationCacheTest.php
+++ b/tests/phpunit/unit/EventListener/ImageTransformationCacheTest.php
@@ -50,20 +50,20 @@ class ImageTransformationCacheTest extends ListenerTests {
             $this->markTestSkipped('This testcase requires vfsStream to run');
         }
 
-        $this->responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
-        $this->requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
-        $this->query = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $this->responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $this->requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $this->query = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
 
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
         $this->response->headers = $this->responseHeaders;
 
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
         $this->request->query = $this->query;
         $this->request->headers = $this->requestHeaders;
         $this->request->expects($this->any())->method('getUser')->will($this->returnValue($this->user));
         $this->request->expects($this->any())->method('getImageIdentifier')->will($this->returnValue($this->imageIdentifier));
 
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
 
@@ -97,8 +97,8 @@ class ImageTransformationCacheTest extends ListenerTests {
      * @covers Imbo\EventListener\ImageTransformationCache::getCacheFilePath
      */
     public function testChangesTheImageInstanceOnCacheHit() {
-        $imageFromCache = $this->getMock('Imbo\Model\Image');
-        $headersFromCache = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $imageFromCache = $this->createMock('Imbo\Model\Image');
+        $headersFromCache = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
         $cachedData = serialize([
             'image' => $imageFromCache,
             'headers' => $headersFromCache,
@@ -183,7 +183,7 @@ class ImageTransformationCacheTest extends ListenerTests {
      * @covers Imbo\EventListener\ImageTransformationCache::storeInCache
      */
     public function testDoesNotStoreNonImageModelsInTheCache() {
-        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->getMock('Imbo\Model\Error')));
+        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->createMock('Imbo\Model\Error')));
         $this->request->expects($this->never())->method('getUser');
         $this->listener->storeInCache($this->event);
     }
@@ -195,9 +195,9 @@ class ImageTransformationCacheTest extends ListenerTests {
      * @covers Imbo\EventListener\ImageTransformationCache::getCacheFilePath
      */
     public function testStoresImageInCache() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
 
-        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->getMock('Imbo\Model\Image')));
+        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->createMock('Imbo\Model\Image')));
         $this->requestHeaders->expects($this->once())
                              ->method('get')
                              ->with('Accept', '*/*')
@@ -225,7 +225,7 @@ class ImageTransformationCacheTest extends ListenerTests {
         // Reusing the same logic as this test
         $this->testChangesTheImageInstanceOnCacheHit();
 
-        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->getMock('Imbo\Model\Image')));
+        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->createMock('Imbo\Model\Image')));
 
         // Overwrite cached file
         $dir = 'vfs://cacheDir/u/s/e/user/7/b/f/7bf2e67f09de203da740a86cd37bbe8d/b/c/6';

--- a/tests/phpunit/unit/EventListener/ImageTransformerTest.php
+++ b/tests/phpunit/unit/EventListener/ImageTransformerTest.php
@@ -33,12 +33,12 @@ class ImageTransformerTest extends ListenerTests {
      * Set up the listener
      */
     public function setUp() {
-        $this->eventManager = $this->getMock('Imbo\EventManager\EventManager');
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->image = $this->getMock('Imbo\Model\Image');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
+        $this->eventManager = $this->createMock('Imbo\EventManager\EventManager');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->image = $this->createMock('Imbo\Model\Image');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
         $this->response->expects($this->any())->method('getModel')->will($this->returnValue($this->image));
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getManager')->will($this->returnValue($this->eventManager));

--- a/tests/phpunit/unit/EventListener/ImageVariations/Database/DoctrineTest.php
+++ b/tests/phpunit/unit/EventListener/ImageVariations/Database/DoctrineTest.php
@@ -24,7 +24,7 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\EventListener\ImageVariations\Database\Doctrine::setConnection
      */
     public function testCanSetConnection() {
-        $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $connection = $this->createMock('Doctrine\DBAL\Connection');
         $connection->expects($this->once())->method('insert')->will($this->returnValue(false));
 
         $adapter = new Doctrine([], $connection);

--- a/tests/phpunit/unit/EventListener/ImageVariations/Database/MongoDBTest.php
+++ b/tests/phpunit/unit/EventListener/ImageVariations/Database/MongoDBTest.php
@@ -37,8 +37,8 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionCode 500
      */
     public function testInsertFailureThrowsDatabaseException() {
-        $client = $this->getMockBuilder('MongoClient')->disableOriginalConstructor()->getMock();
-        $collection = $this->getMockBuilder('MongoCollection')->disableOriginalConstructor()->getMock();
+        $client = $this->createMock('MongoClient');
+        $collection = $this->createMock('MongoCollection');
 
         $collection
             ->expects($this->once())
@@ -60,7 +60,7 @@ class MongoDBTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionCode 500
      */
     public function testThrowsExceptionWhenNotAbleToGetCollection() {
-        $client = $this->getMockBuilder('MongoClient')->disableOriginalConstructor()->getMock();
+        $client = $this->createMock('MongoClient');
 
         $client
             ->expects($this->once())

--- a/tests/phpunit/unit/EventListener/ImageVariations/Storage/DoctrineTest.php
+++ b/tests/phpunit/unit/EventListener/ImageVariations/Storage/DoctrineTest.php
@@ -24,7 +24,7 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\EventListener\ImageVariations\Storage\Doctrine::setConnection
      */
     public function testCanSetConnection() {
-        $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $connection = $this->createMock('Doctrine\DBAL\Connection');
         $connection->expects($this->once())->method('insert')->will($this->returnValue(false));
 
         $adapter = new Doctrine([], $connection);

--- a/tests/phpunit/unit/EventListener/ImageVariations/Storage/GridFSTest.php
+++ b/tests/phpunit/unit/EventListener/ImageVariations/Storage/GridFSTest.php
@@ -36,7 +36,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionCode 500
      */
     public function testThrowsExceptionWhenNotAbleToGetDatabase() {
-        $client = $this->getMockBuilder('MongoClient')->disableOriginalConstructor()->getMock();
+        $client = $this->createMock('MongoClient');
 
         $client
             ->expects($this->once())
@@ -55,8 +55,8 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\EventListener\ImageVariations\Storage\GridFS::getGrid
      */
     public function testCanPassGridInstance() {
-        $client = $this->getMockBuilder('MongoClient')->disableOriginalConstructor()->getMock();
-        $grid = $this->getMockBuilder('MongoGridFS')->disableOriginalConstructor()->getMock();
+        $client = $this->createMock('MongoClient');
+        $grid = $this->createMock('MongoGridFS');
 
         $grid
             ->expects($this->once())

--- a/tests/phpunit/unit/EventListener/ImageVariationsTest.php
+++ b/tests/phpunit/unit/EventListener/ImageVariationsTest.php
@@ -59,28 +59,28 @@ class ImageVariationsTest extends ListenerTests {
      * Set up the listener
      */
     public function setUp() {
-        $this->db = $this->getMock('Imbo\EventListener\ImageVariations\Database\DatabaseInterface');
-        $this->storage = $this->getMock('Imbo\EventListener\ImageVariations\Storage\StorageInterface');
+        $this->db = $this->createMock('Imbo\EventListener\ImageVariations\Database\DatabaseInterface');
+        $this->storage = $this->createMock('Imbo\EventListener\ImageVariations\Storage\StorageInterface');
 
-        $this->query = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
-        $this->imageModel = $this->getMock('Imbo\Model\Image');
-        $this->eventManager = $this->getMock('Imbo\EventManager\EventManager');
-        $this->imageStorage = $this->getMock('Imbo\Storage\StorageInterface');
+        $this->query = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
+        $this->imageModel = $this->createMock('Imbo\Model\Image');
+        $this->eventManager = $this->createMock('Imbo\EventManager\EventManager');
+        $this->imageStorage = $this->createMock('Imbo\Storage\StorageInterface');
 
         $this->imageModel->method('getImageIdentifier')->willReturn($this->imageIdentifier);
 
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
         $this->request->expects($this->any())->method('getUser')->will($this->returnValue($this->user));
         $this->request->expects($this->any())->method('getImageIdentifier')->will($this->returnValue($this->imageIdentifier));
         $this->request->expects($this->any())->method('getImage')->will($this->returnValue($this->imageModel));
         $this->request->query = $this->query;
 
-        $this->responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
+        $this->responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
         $this->response->headers = $this->responseHeaders;
         $this->response->expects($this->any())->method('getModel')->will($this->returnValue($this->imageModel));
 
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getManager')->will($this->returnValue($this->eventManager));

--- a/tests/phpunit/unit/EventListener/ImagickTest.php
+++ b/tests/phpunit/unit/EventListener/ImagickTest.php
@@ -31,9 +31,9 @@ class ImagickTest extends ListenerTests {
      * Set up the listener
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
 
@@ -63,12 +63,12 @@ class ImagickTest extends ListenerTests {
      * @covers Imbo\EventListener\Imagick::setImagick
      */
     public function testFetchesImageFromRequest() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image'));
 
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->once())->method('readImageBlob')->with('image');
 
         $this->event->expects($this->once())->method('getName')->will($this->returnValue('images.post'));
@@ -81,12 +81,12 @@ class ImagickTest extends ListenerTests {
      * @covers Imbo\EventListener\Imagick::setImagick
      */
     public function testFetchesImageFromResponse() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image'));
 
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($image));
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->once())->method('readImageBlob')->with('image');
 
         $this->event->expects($this->once())->method('getName')->will($this->returnValue('storage.image.load'));
@@ -112,10 +112,10 @@ class ImagickTest extends ListenerTests {
      * @dataProvider hasImageBeenTransformed
      */
     public function testUpdatesModelBeforeStoring($hasBeenTransformed) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->will($this->returnValue($hasBeenTransformed));
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
 
         if ($hasBeenTransformed) {
             $imagick->expects($this->once())->method('getImageBlob')->will($this->returnValue('image'));
@@ -137,10 +137,10 @@ class ImagickTest extends ListenerTests {
      * @dataProvider hasImageBeenTransformed
      */
     public function testUpdatesModelBeforeSendingResponse($hasBeenTransformed) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->will($this->returnValue($hasBeenTransformed));
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
 
         if ($hasBeenTransformed) {
             $imagick->expects($this->once())->method('getImageBlob')->will($this->returnValue('image'));

--- a/tests/phpunit/unit/EventListener/Initializer/ImagickTest.php
+++ b/tests/phpunit/unit/EventListener/Initializer/ImagickTest.php
@@ -29,7 +29,7 @@ class ImagickTest extends \PHPUnit_Framework_TestCase {
      * Set up the initializer
      */
     public function setUp() {
-        $this->imagick = $this->getMock('Imagick');
+        $this->imagick = $this->createMock('Imagick');
         $this->initializer = new Imagick($this->imagick);
     }
 
@@ -48,8 +48,8 @@ class ImagickTest extends \PHPUnit_Framework_TestCase {
      */
     public function getListeners() {
         return [
-            'image transformation' => [$this->getMock('Imbo\Image\Transformation\Border'), true],
-            'regular transformation' => [$this->getMock('Imbo\EventListener\ListenerInterface'), false],
+            'image transformation' => [$this->createMock('Imbo\Image\Transformation\Border'), true],
+            'regular transformation' => [$this->createMock('Imbo\EventListener\ListenerInterface'), false],
         ];
     }
 
@@ -70,7 +70,7 @@ class ImagickTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\EventListener\Initializer\Imagick::initialize
      */
     public function testCanCreateAnImagickInstanceByItself() {
-        $listener = $this->getMock('Imbo\Image\Transformation\Border');
+        $listener = $this->createMock('Imbo\Image\Transformation\Border');
         $listener->expects($this->once())->method('setImagick')->with($this->isInstanceOf('Imagick'));
 
         $initializer = new Imagick();

--- a/tests/phpunit/unit/EventListener/MaxImageSizeTest.php
+++ b/tests/phpunit/unit/EventListener/MaxImageSizeTest.php
@@ -63,18 +63,18 @@ class MaxImageSizeTest extends ListenerTests {
      * @covers Imbo\EventListener\MaxImageSize::enforceMaxSize
      */
     public function testWillTriggerTransformationWhenImageIsAboveTheLimits($imageWidth, $imageHeight, $maxWidth, $maxHeight, $willTrigger) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getWidth')->will($this->returnValue($imageWidth));
         $image->expects($this->once())->method('getHeight')->will($this->returnValue($imageHeight));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
 
         if ($willTrigger) {
-            $eventManager = $this->getMock('Imbo\EventManager\EventManager');
+            $eventManager = $this->createMock('Imbo\EventManager\EventManager');
             $eventManager->expects($this->once())->method('trigger')->with('image.transformation.maxsize', ['image' => $image, 'params' => ['width' => $maxWidth, 'height' => $maxHeight]]);
             $event->expects($this->once())->method('getManager')->will($this->returnValue($eventManager));
         }

--- a/tests/phpunit/unit/EventListener/ResponseETagTest.php
+++ b/tests/phpunit/unit/EventListener/ResponseETagTest.php
@@ -60,7 +60,7 @@ class ResponseETagTest extends ListenerTests {
      * @dataProvider getTaintedHeaders
      */
     public function testCanFixATaintedInNoneMatchHeader($incoming, $real, $willFix) {
-        $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $requestHeaders->expects($this->once())->method('get')->with('if-none-match', false)->will($this->returnValue($incoming));
 
         if ($willFix) {
@@ -69,10 +69,10 @@ class ResponseETagTest extends ListenerTests {
             $requestHeaders->expects($this->never())->method('set');
         }
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->headers = $requestHeaders;
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
 
         $this->listener->fixIfNoneMatchHeader($event);
@@ -101,9 +101,9 @@ class ResponseETagTest extends ListenerTests {
      * @dataProvider getRoutesForETags
      */
     public function testWillSetETagForSomeRoutes($route, $hasETag, $isOk = false, $content = null) {
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getRoute')->will($this->returnValue($route));
-        $response = $this->getMock('Imbo\Http\Response\Response');
+        $response = $this->createMock('Imbo\Http\Response\Response');
 
         if ($hasETag) {
             $response->expects($this->once())->method('isOk')->will($this->returnValue($isOk));
@@ -116,7 +116,7 @@ class ResponseETagTest extends ListenerTests {
             $response->expects($this->never())->method('isOk');
         }
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->once())->method('getResponse')->will($this->returnValue($response));
 

--- a/tests/phpunit/unit/EventListener/ResponseSenderTest.php
+++ b/tests/phpunit/unit/EventListener/ResponseSenderTest.php
@@ -48,19 +48,19 @@ class ResponseSenderTest extends ListenerTests {
      * @covers Imbo\EventListener\ResponseSender::send
      */
     public function testCanSendTheResponse() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('checksum'));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));
 
-        $response = $this->getMock('Imbo\Http\Response\Response');
+        $response = $this->createMock('Imbo\Http\Response\Response');
         $response->expects($this->once())->method('isNotModified')->with($request);
         $response->expects($this->once())->method('send');
-        $response->headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $response->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $response->headers->expects($this->once())->method('set')->with('X-Imbo-ImageIdentifier', 'checksum');
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
 
@@ -71,16 +71,16 @@ class ResponseSenderTest extends ListenerTests {
      * @covers Imbo\EventListener\ResponseSender::send
      */
     public function testCanSendTheResponseAndInjectTheCorrectImageIdentifier() {
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('checksum'));
 
-        $response = $this->getMock('Imbo\Http\Response\Response');
+        $response = $this->createMock('Imbo\Http\Response\Response');
         $response->expects($this->once())->method('isNotModified')->with($request);
         $response->expects($this->once())->method('send');
-        $response->headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $response->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $response->headers->expects($this->once())->method('set')->with('X-Imbo-ImageIdentifier', 'checksum');
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($request));
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($response));
 

--- a/tests/phpunit/unit/EventListener/StatsAccessTest.php
+++ b/tests/phpunit/unit/EventListener/StatsAccessTest.php
@@ -33,9 +33,9 @@ class StatsAccessTest extends ListenerTests {
      * Set up the listener
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
 
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
 
         $this->listener = new StatsAccess();

--- a/tests/phpunit/unit/EventListener/StorageOperationsTest.php
+++ b/tests/phpunit/unit/EventListener/StorageOperationsTest.php
@@ -36,12 +36,12 @@ class StorageOperationsTest extends ListenerTests {
      * Set up the listener
      */
     public function setUp() {
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
         $this->request->expects($this->any())->method('getUser')->will($this->returnValue($this->user));
         $this->request->expects($this->any())->method('getImageIdentifier')->will($this->returnValue($this->imageIdentifier));
-        $this->storage = $this->getMock('Imbo\Storage\StorageInterface');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->storage = $this->createMock('Imbo\Storage\StorageInterface');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getStorage')->will($this->returnValue($this->storage));
@@ -83,11 +83,11 @@ class StorageOperationsTest extends ListenerTests {
         $this->storage->expects($this->once())->method('getImage')->with($this->user, $this->imageIdentifier)->will($this->returnValue('image data'));
         $this->storage->expects($this->once())->method('getLastModified')->with($this->user, $this->imageIdentifier)->will($this->returnValue($date));
         $this->response->expects($this->once())->method('setLastModified')->with($date)->will($this->returnSelf());
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('setBlob')->with('image data');
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($image));
 
-        $eventManager = $this->getMock('Imbo\EventManager\EventManager');
+        $eventManager = $this->createMock('Imbo\EventManager\EventManager');
         $eventManager->expects($this->once())->method('trigger')->with('image.loaded');
         $this->event->expects($this->once())->method('getManager')->will($this->returnValue($eventManager));
 
@@ -98,7 +98,7 @@ class StorageOperationsTest extends ListenerTests {
      * @covers Imbo\EventListener\StorageOperations::insertImage
      */
     public function testCanInsertImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image data'));
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageId'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
@@ -113,7 +113,7 @@ class StorageOperationsTest extends ListenerTests {
      * @covers Imbo\EventListener\StorageOperations::insertImage
      */
     public function testCanInsertImageThatAlreadyExists() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image data'));
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageId'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
@@ -131,14 +131,14 @@ class StorageOperationsTest extends ListenerTests {
      * @covers Imbo\EventListener\StorageOperations::insertImage
      */
     public function testWillDeleteImageFromDatabaseAndThrowExceptionWhenStoringFails() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image data'));
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageId'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
         $this->storage->expects($this->once())->method('store')->with($this->user, 'imageId', 'image data')->will($this->throwException(
             new StorageException('Could not store image', 500)
         ));
-        $database = $this->getMock('Imbo\Database\DatabaseInterface');
+        $database = $this->createMock('Imbo\Database\DatabaseInterface');
         $database->expects($this->once())->method('deleteImage')->with($this->user, 'imageId');
         $this->event->expects($this->once())->method('getDatabase')->will($this->returnValue($database));
 

--- a/tests/phpunit/unit/EventListener/VarnishHashTwoTest.php
+++ b/tests/phpunit/unit/EventListener/VarnishHashTwoTest.php
@@ -32,13 +32,13 @@ class VarnishHashTwoTest extends ListenerTests {
      * Set up the listener
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
 
-        $this->responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
+        $this->responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
         $this->response->headers = $this->responseHeaders;
 
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
 
@@ -68,7 +68,7 @@ class VarnishHashTwoTest extends ListenerTests {
      */
     public function testCanSendAHashTwoHeader() {
         $this->request->expects($this->once())->method('getUser')->will($this->returnValue('user'));
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('id'));
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($image));
         $this->responseHeaders->expects($this->once())->method('set')->with('X-HashTwo', [
@@ -87,7 +87,7 @@ class VarnishHashTwoTest extends ListenerTests {
         $listener = new VarnishHashTwo(['headerName' => 'X-CustomHeader']);
 
         $this->request->expects($this->once())->method('getUser')->will($this->returnValue('user'));
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('id'));
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($image));
         $this->responseHeaders->expects($this->once())->method('set')->with('X-CustomHeader', [

--- a/tests/phpunit/unit/EventManager/EventManagerTest.php
+++ b/tests/phpunit/unit/EventManager/EventManagerTest.php
@@ -33,7 +33,7 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase {
      * Set up the event manager
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
         $this->event = new Event(['request' => $this->request]);
         $this->manager = new EventManager();
         $this->manager->setEventTemplate($this->event);

--- a/tests/phpunit/unit/EventManager/EventTest.php
+++ b/tests/phpunit/unit/EventManager/EventTest.php
@@ -45,22 +45,22 @@ class EventTest extends \PHPUnit_Framework_TestCase {
     public function getArguments() {
         return [
             'request' => [
-                'getRequest', 'request', $this->getMock('Imbo\Http\Request\Request'),
+                'getRequest', 'request', $this->createMock('Imbo\Http\Request\Request'),
             ],
             'response' => [
-                'getResponse', 'response', $this->getMock('Imbo\Http\Response\Response'),
+                'getResponse', 'response', $this->createMock('Imbo\Http\Response\Response'),
             ],
             'database' => [
-                'getDatabase', 'database', $this->getMock('Imbo\Database\DatabaseInterface'),
+                'getDatabase', 'database', $this->createMock('Imbo\Database\DatabaseInterface'),
             ],
             'storage' => [
-                'getStorage', 'storage', $this->getMock('Imbo\Storage\StorageInterface'),
+                'getStorage', 'storage', $this->createMock('Imbo\Storage\StorageInterface'),
             ],
             'accessControl' => [
-                'getAccessControl', 'accessControl', $this->getMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface'),
+                'getAccessControl', 'accessControl', $this->createMock('Imbo\Auth\AccessControl\Adapter\AdapterInterface'),
             ],
             'manager' => [
-                'getManager', 'manager', $this->getMockBuilder('Imbo\EventManager\EventManager')->disableOriginalConstructor()->getMock(),
+                'getManager', 'manager', $this->createMock('Imbo\EventManager\EventManager'),
             ],
             'config' => [
                 'getConfig', 'config', ['some' => 'config'],

--- a/tests/phpunit/unit/Http/Request/RequestTest.php
+++ b/tests/phpunit/unit/Http/Request/RequestTest.php
@@ -202,7 +202,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Request\Request::setImage
      */
     public function testCanSetAndGetAnImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $this->assertSame($this->request, $this->request->setImage($image));
         $this->assertSame($image, $this->request->getImage());
     }
@@ -213,7 +213,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
      */
     public function testCanSetAndGetARoute() {
         $this->assertNull($this->request->getRoute());
-        $route = $this->getMockBuilder('Imbo\Router\Route')->disableOriginalConstructor()->getMock();
+        $route = $this->createMock('Imbo\Router\Route');
         $this->assertSame($this->request, $this->request->setRoute($route));
         $this->assertSame($route, $this->request->getRoute());
     }

--- a/tests/phpunit/unit/Http/Response/Formatter/FormatterTest.php
+++ b/tests/phpunit/unit/Http/Response/Formatter/FormatterTest.php
@@ -26,7 +26,7 @@ class FormatterTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionCode 500
      */
     public function testThrowsExceptionWhenModelIsNotSupported() {
-        $formatter = new JSON($this->getMock('Imbo\Helpers\DateFormatter'));
-        $formatter->format($this->getMock('Imbo\Model\ModelInterface'));
+        $formatter = new JSON($this->createMock('Imbo\Helpers\DateFormatter'));
+        $formatter->format($this->createMock('Imbo\Model\ModelInterface'));
     }
 }

--- a/tests/phpunit/unit/Http/Response/Formatter/JSONTest.php
+++ b/tests/phpunit/unit/Http/Response/Formatter/JSONTest.php
@@ -33,7 +33,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Formatter\Formatter::__construct
      */
     public function setUp() {
-        $this->dateFormatter = $this->getMock('Imbo\Helpers\DateFormatter');
+        $this->dateFormatter = $this->createMock('Imbo\Helpers\DateFormatter');
         $this->formatter = new JSON($this->dateFormatter);
     }
 
@@ -61,7 +61,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
         $formattedDate = 'Wed, 30 Jan 2013 10:53:11 GMT';
         $date = new DateTime($formattedDate);
 
-        $model = $this->getMock('Imbo\Model\Error');
+        $model = $this->createMock('Imbo\Model\Error');
         $model->expects($this->once())->method('getHttpCode')->will($this->returnValue(404));
         $model->expects($this->once())->method('getErrorMessage')->will($this->returnValue('Public key not found'));
         $model->expects($this->once())->method('getDate')->will($this->returnValue($date));
@@ -86,7 +86,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
     public function testCanFormatAnErrorModelWhenNoImageIdentifierExists() {
         $date = new DateTime();
 
-        $model = $this->getMock('Imbo\Model\Error');
+        $model = $this->createMock('Imbo\Model\Error');
         $model->expects($this->once())->method('getDate')->will($this->returnValue($date));
         $model->expects($this->once())->method('getImageIdentifier')->will($this->returnValue(null));
 
@@ -104,7 +104,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
         $formattedDate = 'Wed, 30 Jan 2013 10:53:11 GMT';
         $date = new DateTime($formattedDate);
 
-        $model = $this->getMock('Imbo\Model\Status');
+        $model = $this->createMock('Imbo\Model\Status');
         $model->expects($this->once())->method('getDate')->will($this->returnValue($date));
         $model->expects($this->once())->method('getDatabaseStatus')->will($this->returnValue(true));
         $model->expects($this->once())->method('getStorageStatus')->will($this->returnValue(false));
@@ -127,7 +127,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
         $formattedDate = 'Wed, 30 Jan 2013 10:53:11 GMT';
         $date = new DateTime($formattedDate);
 
-        $model = $this->getMock('Imbo\Model\User');
+        $model = $this->createMock('Imbo\Model\User');
         $model->expects($this->once())->method('getLastModified')->will($this->returnValue($date));
         $model->expects($this->once())->method('getNumImages')->will($this->returnValue(123));
         $model->expects($this->once())->method('getUserId')->will($this->returnValue('christer'));
@@ -166,7 +166,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
             'some other key' => 'some other value',
         ];
 
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getUser')->will($this->returnValue($user));
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue($imageIdentifier));
         $image->expects($this->once())->method('getChecksum')->will($this->returnValue($checksum));
@@ -180,7 +180,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
         $image->expects($this->once())->method('getMetadata')->will($this->returnValue($metadata));
 
         $images = [$image];
-        $model = $this->getMock('Imbo\Model\Images');
+        $model = $this->createMock('Imbo\Model\Images');
         $model->expects($this->once())->method('getImages')->will($this->returnValue($images));
         $model->expects($this->once())->method('getHits')->will($this->returnValue(100));
         $model->expects($this->once())->method('getPage')->will($this->returnValue(2));
@@ -214,13 +214,13 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Formatter\JSON::formatImages
      */
     public function testCanFormatAnImagesModelWithNoMetadataSet() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getMetadata')->will($this->returnValue(null));
         $image->expects($this->once())->method('getAddedDate')->will($this->returnValue(new DateTime()));
         $image->expects($this->once())->method('getUpdatedDate')->will($this->returnValue(new DateTime()));
 
         $images = [$image];
-        $model = $this->getMock('Imbo\Model\Images');
+        $model = $this->createMock('Imbo\Model\Images');
         $model->expects($this->once())->method('getImages')->will($this->returnValue($images));
 
         $json = $this->formatter->format($model);
@@ -237,13 +237,13 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Formatter\JSON::formatImages
      */
     public function testCanFormatAnImagesModelWithNoMetadata() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getMetadata')->will($this->returnValue([]));
         $image->expects($this->once())->method('getAddedDate')->will($this->returnValue(new DateTime()));
         $image->expects($this->once())->method('getUpdatedDate')->will($this->returnValue(new DateTime()));
 
         $images = [$image];
-        $model = $this->getMock('Imbo\Model\Images');
+        $model = $this->createMock('Imbo\Model\Images');
         $model->expects($this->once())->method('getImages')->will($this->returnValue($images));
 
         $json = $this->formatter->format($model);
@@ -260,7 +260,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Formatter\JSON::formatImages
      */
     public function testCanFormatAnImagesModelWithNoImages() {
-        $model = $this->getMock('Imbo\Model\Images');
+        $model = $this->createMock('Imbo\Model\Images');
         $model->expects($this->once())->method('getImages')->will($this->returnValue([]));
 
         $json = $this->formatter->format($model);
@@ -274,12 +274,12 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Formatter\JSON::formatImages
      */
     public function testCanFormatAnImagesModelWithSomefields() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getAddedDate')->will($this->returnValue(new DateTime()));
         $image->expects($this->once())->method('getUpdatedDate')->will($this->returnValue(new DateTime()));
 
         $images = [$image];
-        $model = $this->getMock('Imbo\Model\Images');
+        $model = $this->createMock('Imbo\Model\Images');
         $model->expects($this->once())->method('getImages')->will($this->returnValue($images));
         $fields = ['size', 'width', 'height'];
         $model->expects($this->once())->method('getFields')->will($this->returnValue($fields));
@@ -306,7 +306,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
             'some key' => 'some value',
             'some other key' => 'some other value',
         ];
-        $model = $this->getMock('Imbo\Model\Metadata');
+        $model = $this->createMock('Imbo\Model\Metadata');
         $model->expects($this->once())->method('getData')->will($this->returnValue($metadata));
 
         $json = $this->formatter->format($model);
@@ -320,7 +320,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Formatter\JSON::formatMetadataModel
      */
     public function testCanFormatAMetadataModelWithNoMetadata() {
-        $model = $this->getMock('Imbo\Model\Metadata');
+        $model = $this->createMock('Imbo\Model\Metadata');
         $model->expects($this->once())->method('getData')->will($this->returnValue([]));
 
         $json = $this->formatter->format($model);
@@ -343,7 +343,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
                 ],
             ],
         ];
-        $model = $this->getMock('Imbo\Model\ArrayModel');
+        $model = $this->createMock('Imbo\Model\ArrayModel');
         $model->expects($this->once())->method('getData')->will($this->returnValue($data));
 
         $json = $this->formatter->format($model);
@@ -356,7 +356,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Formatter\JSON::formatArrayModel
      */
     public function testCanFormatAnEmptyArrayModel() {
-        $model = $this->getMock('Imbo\Model\ArrayModel');
+        $model = $this->createMock('Imbo\Model\ArrayModel');
         $model->expects($this->once())->method('getData')->will($this->returnValue([]));
 
         $json = $this->formatter->format($model);
@@ -372,7 +372,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
     public function testCanFormatAListModel() {
         $list = [1, 2, 3];
         $container = 'foo';
-        $model = $this->getMock('Imbo\Model\ListModel');
+        $model = $this->createMock('Imbo\Model\ListModel');
         $model->expects($this->once())->method('getList')->will($this->returnValue($list));
         $model->expects($this->once())->method('getContainer')->will($this->returnValue($container));
 
@@ -386,7 +386,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
     public function testCanFormatAnEmptyListModel() {
         $list = [];
         $container = 'foo';
-        $model = $this->getMock('Imbo\Model\ListModel');
+        $model = $this->createMock('Imbo\Model\ListModel');
         $model->expects($this->once())->method('getList')->will($this->returnValue($list));
         $model->expects($this->once())->method('getContainer')->will($this->returnValue($container));
 
@@ -404,7 +404,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
         $limit = 5;
         $page = 1;
 
-        $model = $this->getMock('Imbo\Model\Groups');
+        $model = $this->createMock('Imbo\Model\Groups');
         $model->expects($this->once())->method('getHits')->will($this->returnValue($hits));
         $model->expects($this->once())->method('getPage')->will($this->returnValue($page));
         $model->expects($this->once())->method('getLimit')->will($this->returnValue($limit));
@@ -425,7 +425,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
             'user.head',
         ];
 
-        $model = $this->getMock('Imbo\Model\Group');
+        $model = $this->createMock('Imbo\Model\Group');
         $model->expects($this->once())->method('getName')->will($this->returnValue($name));
         $model->expects($this->once())->method('getResources')->will($this->returnValue($resources));
 
@@ -441,7 +441,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
         $users = ['user1', 'user2'];
         $group = 'group';
 
-        $model = $this->getMock('Imbo\Model\AccessRule');
+        $model = $this->createMock('Imbo\Model\AccessRule');
         $model->expects($this->once())->method('getId')->will($this->returnValue($id));
         $model->expects($this->once())->method('getUsers')->will($this->returnValue($users));
         $model->expects($this->once())->method('getGroup')->will($this->returnValue($group));
@@ -458,7 +458,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
         $users = ['user1', 'user2'];
         $resources = ['resource1', 'resource2'];
 
-        $model = $this->getMock('Imbo\Model\AccessRule');
+        $model = $this->createMock('Imbo\Model\AccessRule');
         $model->expects($this->once())->method('getId')->will($this->returnValue($id));
         $model->expects($this->once())->method('getUsers')->will($this->returnValue($users));
         $model->expects($this->once())->method('getResources')->will($this->returnValue($resources));
@@ -483,7 +483,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
                 'users' => ['user3', 'user4'],
             ],
         ];
-        $model = $this->getMock('Imbo\Model\AccessRules');
+        $model = $this->createMock('Imbo\Model\AccessRules');
         $model->expects($this->once())->method('getRules')->will($this->returnValue($rules));
 
         $this->assertSame('[{"id":1,"group":"group","users":["user1","user2"]},{"id":2,"resources":["image.get","image.head"],"users":["user3","user4"]}]', $this->formatter->format($model));
@@ -524,7 +524,7 @@ class JSONTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Formatter\JSON::formatStats
      */
     public function testCanFormatAStatsModel($images, $users, $bytes, $customStats, $expectedJson) {
-        $model = $this->getMock('Imbo\Model\Stats');
+        $model = $this->createMock('Imbo\Model\Stats');
         $model->expects($this->once())->method('getNumImages')->will($this->returnValue($images));
         $model->expects($this->once())->method('getNumUsers')->will($this->returnValue($users));
         $model->expects($this->once())->method('getNumBytes')->will($this->returnValue($bytes));

--- a/tests/phpunit/unit/Http/Response/ResponseFormatterTest.php
+++ b/tests/phpunit/unit/Http/Response/ResponseFormatterTest.php
@@ -40,17 +40,17 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
      * Set up the response formatter
      */
     public function setUp() {
-        $this->event = $this->getMock('Imbo\EventManager\Event');
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getConfig')->will($this->returnValue(['contentNegotiateImages' => true]));
-        $this->formatter = $this->getMock('Imbo\Http\Response\Formatter\FormatterInterface');
+        $this->formatter = $this->createMock('Imbo\Http\Response\Formatter\FormatterInterface');
         $this->formatters = [
             'format' => $this->formatter,
         ];
-        $this->contentNegotiation = $this->getMock('Imbo\Http\ContentNegotiation');
+        $this->contentNegotiation = $this->createMock('Imbo\Http\ContentNegotiation');
         $this->responseFormatter = new ResponseFormatter([
             'formatters' => $this->formatters,
             'contentNegotiation' => $this->contentNegotiation,
@@ -125,7 +125,7 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
             $expectedContent = sprintf('%s(%s)', $callback, $json);
         }
 
-        $model = $this->getMock('Imbo\Model\ModelInterface');
+        $model = $this->createMock('Imbo\Model\ModelInterface');
 
         $this->formatter->expects($this->once())->method('format')->with($model)->will($this->returnValue($json));
         $this->formatter->expects($this->once())->method('getContentType')->will($this->returnValue($contentType));
@@ -136,7 +136,7 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
 
         $this->request->expects($this->once())->method('getMethod')->will($this->returnValue('GET'));
         $this->request->query = $query;
-        $this->response->headers = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $this->response->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $this->response->headers->expects($this->once())->method('add')->with([
             'Content-Type' => $contentType,
             'Content-Length' => strlen($expectedContent),
@@ -163,7 +163,7 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
      */
     public function testDoesNotDoContentNegotiationWhenTheRequestedPathIncludesAnExtension() {
         $this->request->expects($this->once())->method('getExtension')->will($this->returnValue('json'));
-        $model = $this->getMock('Imbo\Model\Stats');
+        $model = $this->createMock('Imbo\Model\Stats');
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($model));
         $this->contentNegotiation->expects($this->never())->method('isAcceptable');
 
@@ -176,8 +176,9 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
      */
     public function testDoesNotSetResponseContentWhenHttpMethodIsHead() {
         $this->response->expects($this->once())->method('getStatusCode')->will($this->returnValue(200));
-        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->getMock('Imbo\Model\Stats')));
+        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->createMock('Imbo\Model\Stats')));
         $this->response->expects($this->never())->method('setContent');
+        $this->response->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $this->request->expects($this->once())->method('getMethod')->will($this->returnValue('HEAD'));
 
         $this->responseFormatter->format($this->event);
@@ -192,7 +193,7 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
     public function testThrowsAnExceptionInStrictModeWhenTheUserAgentDoesNotSupportAnyOfImbosMediaTypes() {
         $this->contentNegotiation->expects($this->any())->method('isAcceptable')->will($this->returnValue(false));
         $this->response->expects($this->once())->method('setVary')->with('Accept');
-        $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $requestHeaders->expects($this->once())->method('get')->with('Accept', '*/*')->will($this->returnValue('text/xml'));
         $this->request->headers = $requestHeaders;
 
@@ -204,7 +205,7 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
      */
     public function testUsesDefaultMediaTypeInNonStrictModeWhenTheUserAgentDoesNotSupportAnyMediaTypes() {
         $this->event->expects($this->once())->method('hasArgument')->with('noStrict')->will($this->returnValue(true));
-        $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $requestHeaders->expects($this->once())->method('get')->with('Accept', '*/*')->will($this->returnValue('text/xml'));
         $this->request->headers = $requestHeaders;
         $this->contentNegotiation->expects($this->any())->method('isAcceptable')->will($this->returnValue(false));
@@ -218,7 +219,7 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\ResponseFormatter::negotiate
      */
     public function testPicksThePrioritizedMediaTypeIfMoreThanOneWithSameQualityAreSupportedByTheUserAgent() {
-        $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $requestHeaders->expects($this->once())->method('get')->with('Accept', '*/*')->will($this->returnValue('application/*'));
         $this->request->headers = $requestHeaders;
         $this->contentNegotiation->expects($this->any())->method('isAcceptable')->will($this->returnValue(1));
@@ -251,7 +252,7 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
         $image = new Image();
         $image->setMimeType($originalMimeType);
 
-        $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $requestHeaders->expects($this->once())->method('get')->with('Accept', '*/*')->will($this->returnValue('image/*'));
         $this->request->headers = $requestHeaders;
         $this->contentNegotiation->expects($this->any())->method('isAcceptable')->will($this->returnValue(1));
@@ -272,13 +273,13 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
         $image = new Image();
         $image->setMimeType($originalMimeType);
 
-        $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $this->request->headers = $requestHeaders;
         $this->contentNegotiation->expects($this->any())->method('isAcceptable')->will($this->returnValue(1));
         $this->response->expects($this->never())->method('setVary');
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($image));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $event->expects($this->any())->method('getConfig')->will($this->returnValue(['contentNegotiateImages' => false]));
@@ -302,14 +303,14 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
         $route = new Route();
         $route->setName($routeName);
 
-        $requestHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $requestHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $requestHeaders->expects($this->once())->method('get')->with('Accept', '*/*')->will($this->returnValue('*/*'));
         $this->request->headers = $requestHeaders;
         $this->request->expects($this->once())->method('getExtension')->will($this->returnValue('jpg'));
         $this->request->expects($this->once())->method('getRoute')->will($this->returnValue($route));
 
         $this->response->expects($this->once())->method('setVary')->with('Accept');
-        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->getMock('Imbo\Model\Error')));
+        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->createMock('Imbo\Model\Error')));
         $this->contentNegotiation->expects($this->any())->method('isAcceptable')->will($this->returnValue(1));
 
         $this->responseFormatter->negotiate($this->event);
@@ -326,7 +327,7 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
         $this->request->expects($this->once())->method('getExtension')->will($this->returnValue('json'));
         $this->request->expects($this->once())->method('getRoute')->will($this->returnValue($route));
         $this->response->expects($this->never())->method('setVary');
-        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->getMock('Imbo\Model\Error')));
+        $this->response->expects($this->once())->method('getModel')->will($this->returnValue($this->createMock('Imbo\Model\Error')));
 
         $this->responseFormatter->negotiate($this->event);
         $this->assertSame('json', $this->responseFormatter->getFormatter());
@@ -336,14 +337,15 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\ResponseFormatter::format
      */
     public function testTriggersAConversionTransformationIfNeededWhenTheModelIsAnImage() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->exactly(2))->method('getMimeType')->will($this->returnValue('image/jpeg'));
         $image->expects($this->once())->method('getBlob')->will($this->returnValue('image blob'));
 
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($image));
+        $this->response->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $this->responseFormatter->setFormatter('png');
 
-        $eventManager = $this->getMock('Imbo\EventManager\EventManager');
+        $eventManager = $this->createMock('Imbo\EventManager\EventManager');
         $eventManager->expects($this->at(0))
                      ->method('trigger')
                      ->with(
@@ -366,13 +368,14 @@ class ResponseFormatterTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\ResponseFormatter::format
      */
     public function testDoesNotTriggerAnImageConversionWhenTheImageHasTheCorrectMimeType() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->at(0))->method('getMimeType')->will($this->returnValue('image/jpeg'));
 
         $this->response->expects($this->once())->method('getModel')->will($this->returnValue($image));
+        $this->response->headers = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $this->responseFormatter->setFormatter('jpg');
 
-        $eventManager = $this->getMock('Imbo\EventManager\EventManager');
+        $eventManager = $this->createMock('Imbo\EventManager\EventManager');
         $eventManager->expects($this->once())
                      ->method('trigger')
                      ->with('image.transformed', ['image' => $image]);

--- a/tests/phpunit/unit/Http/Response/ResponseTest.php
+++ b/tests/phpunit/unit/Http/Response/ResponseTest.php
@@ -46,7 +46,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Response::getModel
      */
     public function testCanSetAndGetModel() {
-        $model = $this->getMock('Imbo\Model\ModelInterface');
+        $model = $this->createMock('Imbo\Model\ModelInterface');
         $this->assertNull($this->response->getModel());
         $this->assertSame($this->response, $this->response->setModel($model));
         $this->assertSame($model, $this->response->getModel());
@@ -59,7 +59,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Http\Response\Response::setNotModified
      */
     public function testRemovesModelWhenMarkedAsNotModified() {
-        $model = $this->getMock('Imbo\Model\ModelInterface');
+        $model = $this->createMock('Imbo\Model\ModelInterface');
         $this->assertSame($this->response, $this->response->setModel($model));
         $this->assertSame($this->response, $this->response->setNotModified());
         $this->assertSame(304, $this->response->getStatusCode());
@@ -75,7 +75,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
         $imboErrorCode = 123;
         $date = new DateTime('@1361614522', new DateTimeZone('UTC'));
 
-        $error = $this->getMock('Imbo\Model\Error');
+        $error = $this->createMock('Imbo\Model\Error');
         $error->expects($this->once())->method('getHttpCode')->will($this->returnValue($code));
         $error->expects($this->once())->method('getImboErrorCode')->will($this->returnValue($imboErrorCode));
         $error->expects($this->once())->method('getErrorMessage')->will($this->returnValue($message));

--- a/tests/phpunit/unit/Image/Identifier/Generator/Md5Test.php
+++ b/tests/phpunit/unit/Image/Identifier/Generator/Md5Test.php
@@ -19,7 +19,7 @@ use Imbo\Image\Identifier\Generator\Md5 as Md5Generator,
  */
 class Md5Test extends \PHPUnit_Framework_TestCase {
     public function testGeneratesCorrectMd5ForBlob() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->any())->method('getBlob')->will($this->returnValue('foobar'));
 
         $generator = new Md5Generator();

--- a/tests/phpunit/unit/Image/Identifier/Generator/RandomStringTest.php
+++ b/tests/phpunit/unit/Image/Identifier/Generator/RandomStringTest.php
@@ -21,7 +21,7 @@ class RandomStringTest extends \PHPUnit_Framework_TestCase {
     public function testGeneratesUniqueStrings() {
         $stringLength = 15;
 
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $generator = new RandomStringGenerator($stringLength);
         $generated = [];
 

--- a/tests/phpunit/unit/Image/Identifier/Generator/UuidTest.php
+++ b/tests/phpunit/unit/Image/Identifier/Generator/UuidTest.php
@@ -19,7 +19,7 @@ use Imbo\Image\Identifier\Generator\Uuid as UuidGenerator,
  */
 class UuidTest extends \PHPUnit_Framework_TestCase {
     public function testGeneratesUniqueUuidV4() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $generator = new UuidGenerator();
         $generated = [];
 

--- a/tests/phpunit/unit/Image/ImagePreparationTest.php
+++ b/tests/phpunit/unit/Image/ImagePreparationTest.php
@@ -36,13 +36,13 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
      * Set up the image preparation instance
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->headers = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->headers = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
         $this->response->headers = $this->headers;
-        $this->imageIdentifierGenerator = $this->getMock('Imbo\Image\Identifier\Generator\GeneratorInterface');
+        $this->imageIdentifierGenerator = $this->createMock('Imbo\Image\Identifier\Generator\GeneratorInterface');
         $this->config = ['imageIdentifierGenerator' => $this->imageIdentifierGenerator];
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
@@ -165,7 +165,7 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
             return $generator;
         };
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $event->expects($this->any())->method('getConfig')->will($this->returnValue($config));
@@ -186,7 +186,7 @@ class ImagePreparationTest extends \PHPUnit_Framework_TestCase {
 
         $config['imageIdentifierGenerator'] = new CallableImageIdentifierGenerator();
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $event->expects($this->any())->method('getConfig')->will($this->returnValue($config));

--- a/tests/phpunit/unit/Image/Transformation/AutoRotateTest.php
+++ b/tests/phpunit/unit/Image/Transformation/AutoRotateTest.php
@@ -22,13 +22,13 @@ class AutoRotateTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Image\Transformation\AutoRotate::transform
      */
     public function testWillNotUpdateTheImageWhenNotNeeded() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->once())->method('getImageOrientation')->will($this->returnValue(0));
         $imagick->expects($this->never())->method('setImageOrientation');
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $transformation = new AutoRotate();

--- a/tests/phpunit/unit/Image/Transformation/CompressTest.php
+++ b/tests/phpunit/unit/Image/Transformation/CompressTest.php
@@ -43,20 +43,20 @@ class CompressTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionCode 400
      */
     public function testThrowsExceptionOnMissingLevelParameter() {
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('params')->will($this->returnValue([]));
         $this->transformation->transform($event);
     }
 
     public function testDoesNotApplyCompressionToGifImages() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getMimeType')->will($this->returnValue('image/gif'));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('params')->will($this->returnValue(['level' => 40]));
         $event->expects($this->at(1))->method('getArgument')->with('image')->will($this->returnValue($image));
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->never())->method('setImageCompressionQuality');
 
         $this->transformation->setImagick($imagick)->transform($event);
@@ -64,11 +64,11 @@ class CompressTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testDoesNotApplyCompressionWhenLevelIsNotSet() {
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->never())->method('setImageCompressionQuality');
 
         $this->transformation->setImagick($imagick)
-                             ->compress($this->getMock('Imbo\EventManager\Event'));
+                             ->compress($this->createMock('Imbo\EventManager\Event'));
     }
 
     /**
@@ -77,7 +77,7 @@ class CompressTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionCode 400
      */
     public function testThrowsExceptionOnInvalidLevel() {
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->once())->method('getArgument')->with('params')->will($this->returnValue(['level' => 200]));
         $this->transformation->transform($event);
     }

--- a/tests/phpunit/unit/Image/Transformation/ContrastTest.php
+++ b/tests/phpunit/unit/Image/Transformation/ContrastTest.php
@@ -67,8 +67,8 @@ class ContrastTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider getContrastParams
      */
     public function testSetsTheCorrectContrast(array $params, $shouldTransform) {
-        $image = $this->getMock('Imbo\Model\Image');
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $image = $this->createMock('Imbo\Model\Image');
+        $event = $this->createMock('Imbo\EventManager\Event');
 
         $imagick = new \Imagick();
         $imagick->newImage(16, 16, '#fff');

--- a/tests/phpunit/unit/Image/Transformation/ConvertTest.php
+++ b/tests/phpunit/unit/Image/Transformation/ConvertTest.php
@@ -41,11 +41,11 @@ class ConvertTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Image\Transformation\Convert::transform
      */
     public function testWillNotConvertImageIfNotNeeded() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getExtension')->will($this->returnValue('png'));
         $image->expects($this->never())->method('getBlob');
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue(['type' => 'png']));
 

--- a/tests/phpunit/unit/Image/Transformation/CropTest.php
+++ b/tests/phpunit/unit/Image/Transformation/CropTest.php
@@ -25,8 +25,8 @@ class CropTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionMessage Missing required parameter: width
      */
     public function testThrowsExceptionWhenWidthIsMissing() {
-        $event = $this->getMock('Imbo\EventManager\Event');
-        $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($this->getMock('Imbo\Model\Image')));
+        $event = $this->createMock('Imbo\EventManager\Event');
+        $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($this->createMock('Imbo\Model\Image')));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue(['height' => 123]));
 
         $transformation = new Crop();
@@ -40,8 +40,8 @@ class CropTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionMessage Missing required parameter: height
      */
     public function testThrowsExceptionWhenHeightIsMissing() {
-        $event = $this->getMock('Imbo\EventManager\Event');
-        $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($this->getMock('Imbo\Model\Image')));
+        $event = $this->createMock('Imbo\EventManager\Event');
+        $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($this->createMock('Imbo\Model\Image')));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue(['width' => 123]));
 
         $transformation = new Crop();
@@ -66,8 +66,8 @@ class CropTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Image\Transformation\Crop::transform
      */
     public function testUsesAllParams($params, $originalWidth, $originalHeight, $width, $height, $x = 0, $y = 0, $shouldCrop = true) {
-        $image = $this->getMock('Imbo\Model\Image');
-        $imagick = $this->getMock('Imagick');
+        $image = $this->createMock('Imbo\Model\Image');
+        $imagick = $this->createMock('Imagick');
 
         $image->expects($this->any())->method('getWidth')->will($this->returnValue($originalWidth));
         $image->expects($this->any())->method('getHeight')->will($this->returnValue($originalHeight));
@@ -82,7 +82,7 @@ class CropTest extends \PHPUnit_Framework_TestCase {
             $imagick->expects($this->never())->method('cropImage');
         }
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue($params));
 
@@ -113,8 +113,8 @@ class CropTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Image\Transformation\Crop::transform
      */
     public function testThrowsOnInvalidCropParams($params, $originalWidth, $originalHeight, $errRegex) {
-        $image = $this->getMock('Imbo\Model\Image');
-        $imagick = $this->getMock('Imagick');
+        $image = $this->createMock('Imbo\Model\Image');
+        $imagick = $this->createMock('Imagick');
 
         $image->expects($this->any())->method('getWidth')->will($this->returnValue($originalWidth));
         $image->expects($this->any())->method('getHeight')->will($this->returnValue($originalHeight));
@@ -129,7 +129,7 @@ class CropTest extends \PHPUnit_Framework_TestCase {
             $imagick->expects($this->once())->method('cropImage');
         }
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue($params));
 

--- a/tests/phpunit/unit/Image/Transformation/DrawPoisTest.php
+++ b/tests/phpunit/unit/Image/Transformation/DrawPoisTest.php
@@ -24,11 +24,11 @@ class DrawPoisTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Image\Transformation\DrawPois::transform
      */
     public function testDoesNotModifyImageIfNoPoisAreFound() {
-        $image = $this->getMock('Imbo\Model\Image');
-        $database = $this->getMock('Imbo\Database\DatabaseInterface');
+        $image = $this->createMock('Imbo\Model\Image');
+        $database = $this->createMock('Imbo\Database\DatabaseInterface');
         $database->expects($this->once())->method('getMetadata')->will($this->returnValue([]));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->any())->method('getDatabase')->will($this->returnValue($database));
 
@@ -42,11 +42,11 @@ class DrawPoisTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Image\Transformation\DrawPois::transform
      */
     public function testDoesNotModifyImageIfNoPoiMetadataKeyIsNotAnArray() {
-        $image = $this->getMock('Imbo\Model\Image');
-        $database = $this->getMock('Imbo\Database\DatabaseInterface');
+        $image = $this->createMock('Imbo\Model\Image');
+        $database = $this->createMock('Imbo\Database\DatabaseInterface');
         $database->expects($this->once())->method('getMetadata')->will($this->returnValue(['poi' => 'wat']));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->any())->method('getDatabase')->will($this->returnValue($database));
 
@@ -62,13 +62,13 @@ class DrawPoisTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionMessage Point of interest had neither `width` and `height` nor `cx` and `cy`
      */
     public function testThrowsExceptionOnInvalidPoi() {
-        $image = $this->getMock('Imbo\Model\Image');
-        $database = $this->getMock('Imbo\Database\DatabaseInterface');
+        $image = $this->createMock('Imbo\Model\Image');
+        $database = $this->createMock('Imbo\Database\DatabaseInterface');
         $database->expects($this->once())->method('getMetadata')->will($this->returnValue([
             'poi' => [['foo' => 'bar']]
         ]));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->any())->method('getDatabase')->will($this->returnValue($database));
 
@@ -82,8 +82,8 @@ class DrawPoisTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Image\Transformation\DrawPois::transform
      */
     public function testDrawsSameAmountOfTimesAsPoisArePresent() {
-        $image = $this->getMock('Imbo\Model\Image');
-        $database = $this->getMock('Imbo\Database\DatabaseInterface');
+        $image = $this->createMock('Imbo\Model\Image');
+        $database = $this->createMock('Imbo\Database\DatabaseInterface');
         $database->expects($this->once())->method('getMetadata')->will($this->returnValue([
             'poi' => [[
                 'x' => 362,
@@ -105,13 +105,13 @@ class DrawPoisTest extends \PHPUnit_Framework_TestCase {
             ]]
         ]));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->any())->method('getDatabase')->will($this->returnValue($database));
 
         $image->expects($this->once())->method('hasBeenTransformed')->with(true);
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->exactly(3))->method('drawImage');
 
         $transformation = new DrawPois();
@@ -124,7 +124,7 @@ class DrawPoisTest extends \PHPUnit_Framework_TestCase {
      */
     public function testDrawPois() {
         return;
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->any())
                 ->method('cropImage')
                 ->with(
@@ -140,7 +140,7 @@ class DrawPoisTest extends \PHPUnit_Framework_TestCase {
 
         $response = new Response();
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue($params));
         $event->expects($this->at(2))->method('getResponse')->will($this->returnValue($response));

--- a/tests/phpunit/unit/Image/Transformation/ModulateTest.php
+++ b/tests/phpunit/unit/Image/Transformation/ModulateTest.php
@@ -60,13 +60,13 @@ class ModulateTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider getModulateParams
      */
     public function testUsesDefaultValuesWhenParametersAreNotSpecified(array $params, $brightness, $saturation, $hue) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('params')->will($this->returnValue($params));
         $event->expects($this->at(1))->method('getArgument')->with('image')->will($this->returnValue($image));
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->once())->method('modulateImage')->with($brightness, $saturation, $hue);
 
         $this->transformation->setImagick($imagick)->transform($event);

--- a/tests/phpunit/unit/Image/Transformation/SharpenTest.php
+++ b/tests/phpunit/unit/Image/Transformation/SharpenTest.php
@@ -61,15 +61,15 @@ class SharpenTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider getSharpenPresets
      */
     public function testProvidesSharpenPresets($preset, $radius, $sigma, $gain, $threshold) {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true);
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('params')->will($this->returnValue([
             'preset' => $preset,
         ]));
         $event->expects($this->at(1))->method('getArgument')->with('image')->will($this->returnValue($image));
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->once())->method('unsharpMaskImage')->with($radius, $sigma, $gain, $threshold);
 
         $this->transformation->setImagick($imagick);
@@ -77,9 +77,9 @@ class SharpenTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testParamsCanOverridePresetValues() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true);
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('params')->will($this->returnValue([
             'preset' => 'extreme',
             'gain' => 10,
@@ -87,7 +87,7 @@ class SharpenTest extends \PHPUnit_Framework_TestCase {
         ]));
         $event->expects($this->at(1))->method('getArgument')->with('image')->will($this->returnValue($image));
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->once())->method('unsharpMaskImage')->with(11, 1, 10, 0);
 
         $this->transformation->setImagick($imagick);

--- a/tests/phpunit/unit/Image/Transformation/SmartSizeTest.php
+++ b/tests/phpunit/unit/Image/Transformation/SmartSizeTest.php
@@ -142,7 +142,7 @@ class SmartSizeTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider getSmartSizeArguments
      */
     public function testSmartSize($imageDimensions, $params, $cropParams) {
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->any())
                 ->method('cropImage')
                 ->with(
@@ -158,7 +158,7 @@ class SmartSizeTest extends \PHPUnit_Framework_TestCase {
 
         $response = new Response();
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue($params));
         $event->expects($this->at(2))->method('getResponse')->will($this->returnValue($response));

--- a/tests/phpunit/unit/Image/Transformation/StripTest.php
+++ b/tests/phpunit/unit/Image/Transformation/StripTest.php
@@ -27,10 +27,10 @@ class StripTest extends \PHPUnit_Framework_TestCase {
     public function testThrowsCorrectExceptionWhenAnErrorOccurs() {
         $imagickException = new ImagickException('error');
 
-        $imagick = $this->getMock('Imagick');
+        $imagick = $this->createMock('Imagick');
         $imagick->expects($this->once())->method('stripImage')->will($this->throwException($imagickException));
 
         $transformation = new Strip();
-        $transformation->setImagick($imagick)->transform($this->getMock('Imbo\EventManager\Event'));
+        $transformation->setImagick($imagick)->transform($this->createMock('Imbo\EventManager\Event'));
     }
 }

--- a/tests/phpunit/unit/Image/Transformation/WatermarkTest.php
+++ b/tests/phpunit/unit/Image/Transformation/WatermarkTest.php
@@ -44,9 +44,9 @@ class WatermarkTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionMessage You must specify an image identifier to use for the watermark
      */
     public function testTransformThrowsExceptionIfNoImageSpecified() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue([]));
 
@@ -59,20 +59,20 @@ class WatermarkTest extends \PHPUnit_Framework_TestCase {
      * @expectedExceptionMessage Watermark image not found
      */
     public function testThrowsExceptionIfSpecifiedImageIsNotFound() {
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
 
         $e = new StorageException('File not found', 404);
 
-        $storage = $this->getMock('Imbo\Storage\StorageInterface');
+        $storage = $this->createMock('Imbo\Storage\StorageInterface');
         $storage->expects($this->once())
                 ->method('getImage')
                 ->with('someuser', 'foobar')
                 ->will($this->throwException($e));
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getUser')->will($this->returnValue('someuser'));
 
-        $event = $this->getMock('Imbo\EventManager\Event');
+        $event = $this->createMock('Imbo\EventManager\Event');
         $event->expects($this->at(0))->method('getArgument')->with('image')->will($this->returnValue($image));
         $event->expects($this->at(1))->method('getArgument')->with('params')->will($this->returnValue([
             'img' => 'foobar',

--- a/tests/phpunit/unit/Model/ErrorTest.php
+++ b/tests/phpunit/unit/Model/ErrorTest.php
@@ -95,7 +95,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Model\Error::createFromException
      */
     public function testCanCreateAnErrorBasedOnAnException() {
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
 
         $exception = new RuntimeException('You wronged', 400);
 
@@ -114,7 +114,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase {
         $exception = new RuntimeException('You wronged', 400);
         $exception->setImboErrorCode(123);
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
+        $request = $this->createMock('Imbo\Http\Request\Request');
         $request->expects($this->once())->method('getImage')->will($this->returnValue(null));
         $request->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageIdentifier'));
 
@@ -131,11 +131,11 @@ class ErrorTest extends \PHPUnit_Framework_TestCase {
         $exception = new RuntimeException('You wronged', 400);
         $exception->setImboErrorCode(123);
 
-        $request = $this->getMock('Imbo\Http\Request\Request');
-        $image = $this->getMock('Imbo\Model\Image');
+        $request = $this->createMock('Imbo\Http\Request\Request');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('imageId'));
         $request->expects($this->once())->method('getImage')->will($this->returnValue($image));
-        $request->expects($this->never())->method('imageId');
+        $request->expects($this->never())->method('getImageIdentifier');
 
         $model = Error::createFromException($exception, $request);
 

--- a/tests/phpunit/unit/Model/ImageTest.php
+++ b/tests/phpunit/unit/Model/ImageTest.php
@@ -122,7 +122,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Model\Image::getAddedDate
      */
     public function testCanSetAndGetTheAddedDate() {
-        $date = $this->getMock('DateTime');
+        $date = $this->createMock('DateTime');
         $this->assertNull($this->image->getAddedDate());
         $this->assertSame($this->image, $this->image->setAddedDate($date));
         $this->assertSame($date, $this->image->getAddedDate());
@@ -133,7 +133,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Model\Image::getUpdatedDate
      */
     public function testCanSetAndGetTheUpdatedDate() {
-        $date = $this->getMock('DateTime');
+        $date = $this->createMock('DateTime');
         $this->assertNull($this->image->getUpdatedDate());
         $this->assertSame($this->image, $this->image->setUpdatedDate($date));
         $this->assertSame($date, $this->image->getUpdatedDate());

--- a/tests/phpunit/unit/Model/ImagesTest.php
+++ b/tests/phpunit/unit/Model/ImagesTest.php
@@ -43,9 +43,9 @@ class ImagesTest extends \PHPUnit_Framework_TestCase {
      */
     public function testCanSetAndGetImages() {
         $images = [
-            $this->getMock('Imbo\Model\Image'),
-            $this->getMock('Imbo\Model\Image'),
-            $this->getMock('Imbo\Model\Image'),
+            $this->createMock('Imbo\Model\Image'),
+            $this->createMock('Imbo\Model\Image'),
+            $this->createMock('Imbo\Model\Image'),
         ];
         $this->assertSame([], $this->model->getImages());
         $this->assertSame($this->model, $this->model->setImages($images));
@@ -98,9 +98,9 @@ class ImagesTest extends \PHPUnit_Framework_TestCase {
     public function testCanCountImages() {
         $this->assertSame(0, $this->model->getCount());
         $images = [
-            $this->getMock('Imbo\Model\Image'),
-            $this->getMock('Imbo\Model\Image'),
-            $this->getMock('Imbo\Model\Image'),
+            $this->createMock('Imbo\Model\Image'),
+            $this->createMock('Imbo\Model\Image'),
+            $this->createMock('Imbo\Model\Image'),
         ];
         $this->model->setImages($images);
         $this->assertSame(3, $this->model->getCount());
@@ -111,9 +111,9 @@ class ImagesTest extends \PHPUnit_Framework_TestCase {
      */
     public function testGetData() {
         $images = [
-            $this->getMock('Imbo\Model\Image'),
-            $this->getMock('Imbo\Model\Image'),
-            $this->getMock('Imbo\Model\Image'),
+            $this->createMock('Imbo\Model\Image'),
+            $this->createMock('Imbo\Model\Image'),
+            $this->createMock('Imbo\Model\Image'),
         ];
         $fields = ['width', 'height'];
 

--- a/tests/phpunit/unit/Resource/GlobalShortUrlTest.php
+++ b/tests/phpunit/unit/Resource/GlobalShortUrlTest.php
@@ -40,11 +40,11 @@ class GlobalShortUrlTest extends ResourceTests {
      * Set up the resource
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
-        $this->manager = $this->getMockBuilder('Imbo\EventManager\EventManager')->disableOriginalConstructor()->getMock();
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
+        $this->manager = $this->createMock('Imbo\EventManager\EventManager');
 
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
@@ -80,7 +80,7 @@ class GlobalShortUrlTest extends ResourceTests {
             'accessToken' => 'some token',
         ];
 
-        $route = $this->getMock('Imbo\Router\Route');
+        $route = $this->createMock('Imbo\Router\Route');
         $route->expects($this->at(0))->method('get')->with('shortUrlId')->will($this->returnValue($id));
         $route->expects($this->at(1))->method('set')->with('user', $user);
         $route->expects($this->at(2))->method('set')->with('imageIdentifier', $imageIdentifier);
@@ -93,7 +93,7 @@ class GlobalShortUrlTest extends ResourceTests {
             'extension' => $extension,
             'query' => $query,
         ]));
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
         $responseHeaders->expects($this->once())->method('set')->with('X-Imbo-ShortUrl', 'http://imbo/s/' . $id);
         $this->response->headers = $responseHeaders;
 
@@ -109,7 +109,7 @@ class GlobalShortUrlTest extends ResourceTests {
      * @expectedExceptionCode 404
      */
     public function testRespondsWith404WhenShortUrlDoesNotExist() {
-        $route = $this->getMock('Imbo\Router\Route');
+        $route = $this->createMock('Imbo\Router\Route');
         $route->expects($this->once())->method('get')->with('shortUrlId')->will($this->returnValue('aaaaaaa'));
         $this->request->expects($this->once())->method('getRoute')->will($this->returnValue($route));
         $this->database->expects($this->once())->method('getShortUrlParams')->with('aaaaaaa')->will($this->returnValue(null));

--- a/tests/phpunit/unit/Resource/ImageTest.php
+++ b/tests/phpunit/unit/Resource/ImageTest.php
@@ -41,12 +41,12 @@ class ImageTest extends ResourceTests {
      * Set up the resource
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->storage = $this->getMock('Imbo\Storage\StorageInterface');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
-        $this->manager = $this->getMockBuilder('Imbo\EventManager\EventManager')->disableOriginalConstructor()->getMock();
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->storage = $this->createMock('Imbo\Storage\StorageInterface');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
+        $this->manager = $this->createMock('Imbo\EventManager\EventManager');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getDatabase')->will($this->returnValue($this->database));
@@ -87,7 +87,7 @@ class ImageTest extends ResourceTests {
         $user = 'christer';
         $imageIdentifier = 'imageIdentifier';
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
 
         $this->request->expects($this->once())->method('getUser')->will($this->returnValue($user));
         $this->request->expects($this->once())->method('getImageIdentifier')->will($this->returnValue($imageIdentifier));

--- a/tests/phpunit/unit/Resource/ImagesTest.php
+++ b/tests/phpunit/unit/Resource/ImagesTest.php
@@ -43,12 +43,12 @@ class ImagesTest extends ResourceTests {
      * Set up the resource
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->storage = $this->getMock('Imbo\Storage\StorageInterface');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
-        $this->manager = $this->getMockBuilder('Imbo\EventManager\EventManager')->disableOriginalConstructor()->getMock();
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->storage = $this->createMock('Imbo\Storage\StorageInterface');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
+        $this->manager = $this->createMock('Imbo\EventManager\EventManager');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getDatabase')->will($this->returnValue($this->database));
@@ -76,7 +76,7 @@ class ImagesTest extends ResourceTests {
     public function testSupportsHttpPost() {
         $this->manager->expects($this->at(0))->method('trigger')->with('db.image.insert');
         $this->manager->expects($this->at(1))->method('trigger')->with('storage.image.insert');
-        $image = $this->getMock('Imbo\Model\Image');
+        $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('getImageIdentifier')->will($this->returnValue('id'));
         $this->request->expects($this->once())->method('getImage')->will($this->returnValue($image));
         $this->response->expects($this->once())->method('setModel')->with($this->isInstanceOf('Imbo\Model\ArrayModel'));

--- a/tests/phpunit/unit/Resource/IndexTest.php
+++ b/tests/phpunit/unit/Resource/IndexTest.php
@@ -38,10 +38,10 @@ class IndexTest extends ResourceTests {
      * Set up the resource
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
 
@@ -69,7 +69,7 @@ class IndexTest extends ResourceTests {
         $this->response->expects($this->once())->method('setPrivate');
         $this->event->expects($this->any())->method('getConfig')->will($this->returnValue(['indexRedirect' => null]));
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
         $responseHeaders->expects($this->once())->method('addCacheControlDirective')->with('no-store');
 
         $this->response->headers = $responseHeaders;
@@ -81,7 +81,7 @@ class IndexTest extends ResourceTests {
         $url = 'http://imbo.io';
         $this->event->expects($this->any())->method('getConfig')->will($this->returnValue(['indexRedirect' => $url]));
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
         $responseHeaders->expects($this->once())->method('set')->with('Location', $url);
 
         $this->response->headers = $responseHeaders;

--- a/tests/phpunit/unit/Resource/MetadataTest.php
+++ b/tests/phpunit/unit/Resource/MetadataTest.php
@@ -43,12 +43,12 @@ class MetadataTest extends ResourceTests {
      * Set up the resource
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->storage = $this->getMock('Imbo\Storage\StorageInterface');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
-        $this->manager = $this->getMockBuilder('Imbo\EventManager\EventManager')->disableOriginalConstructor()->getMock();
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->storage = $this->createMock('Imbo\Storage\StorageInterface');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
+        $this->manager = $this->createMock('Imbo\EventManager\EventManager');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getDatabase')->will($this->returnValue($this->database));

--- a/tests/phpunit/unit/Resource/ShortUrlTest.php
+++ b/tests/phpunit/unit/Resource/ShortUrlTest.php
@@ -41,12 +41,12 @@ class ShortUrlTest extends ResourceTests {
      */
     public function setUp() {
         $this->resource = $this->getNewResource();
-        $this->route = $this->getMock('Imbo\Router\Route');
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
+        $this->route = $this->createMock('Imbo\Router\Route');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
         $this->request->expects($this->any())->method('getRoute')->will($this->returnValue($this->route));
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
 
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));

--- a/tests/phpunit/unit/Resource/ShortUrlsTest.php
+++ b/tests/phpunit/unit/Resource/ShortUrlsTest.php
@@ -40,10 +40,10 @@ class ShortUrlsTest extends ResourceTests {
      */
     public function setUp() {
         $this->resource = $this->getNewResource();
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
 
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));

--- a/tests/phpunit/unit/Resource/StatsTest.php
+++ b/tests/phpunit/unit/Resource/StatsTest.php
@@ -39,9 +39,9 @@ class StatsTest extends ResourceTests {
      * Set up the resource
      */
     public function setUp() {
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->eventManager = $this->getMockBuilder('Imbo\EventManager\EventManager')->disableOriginalConstructor()->getMock();
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->eventManager = $this->createMock('Imbo\EventManager\EventManager');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getManager')->will($this->returnValue($this->eventManager));
 
@@ -62,7 +62,7 @@ class StatsTest extends ResourceTests {
      * @covers Imbo\Resource\Stats::get
      */
     public function testTriggersTheCorrectEvent() {
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $responseHeaders->expects($this->once())->method('addCacheControlDirective')->with('no-store');
 
         $this->response->headers = $responseHeaders;

--- a/tests/phpunit/unit/Resource/StatusTest.php
+++ b/tests/phpunit/unit/Resource/StatusTest.php
@@ -39,10 +39,10 @@ class StatusTest extends ResourceTests {
      * Set up the resource
      */
     public function setUp() {
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->storage = $this->getMock('Imbo\Storage\StorageInterface');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->storage = $this->createMock('Imbo\Storage\StorageInterface');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getDatabase')->will($this->returnValue($this->database));
         $this->event->expects($this->any())->method('getStorage')->will($this->returnValue($this->storage));
@@ -68,7 +68,7 @@ class StatusTest extends ResourceTests {
         $this->database->expects($this->once())->method('getStatus')->will($this->returnValue(false));
         $this->storage->expects($this->once())->method('getStatus')->will($this->returnValue(true));
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $responseHeaders->expects($this->once())->method('addCacheControlDirective')->with('no-store');
 
         $this->response->headers = $responseHeaders;
@@ -87,7 +87,7 @@ class StatusTest extends ResourceTests {
         $this->database->expects($this->once())->method('getStatus')->will($this->returnValue(true));
         $this->storage->expects($this->once())->method('getStatus')->will($this->returnValue(false));
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $responseHeaders->expects($this->once())->method('addCacheControlDirective')->with('no-store');
 
         $this->response->headers = $responseHeaders;
@@ -106,7 +106,7 @@ class StatusTest extends ResourceTests {
         $this->database->expects($this->once())->method('getStatus')->will($this->returnValue(false));
         $this->storage->expects($this->once())->method('getStatus')->will($this->returnValue(false));
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $responseHeaders->expects($this->once())->method('addCacheControlDirective')->with('no-store');
 
         $this->response->headers = $responseHeaders;
@@ -125,7 +125,7 @@ class StatusTest extends ResourceTests {
         $this->database->expects($this->once())->method('getStatus')->will($this->returnValue(true));
         $this->storage->expects($this->once())->method('getStatus')->will($this->returnValue(true));
 
-        $responseHeaders = $this->getMock('Symfony\Component\HttpFoundation\HeaderBag');
+        $responseHeaders = $this->createMock('Symfony\Component\HttpFoundation\HeaderBag');
         $responseHeaders->expects($this->once())->method('addCacheControlDirective')->with('no-store');
 
         $this->response->headers = $responseHeaders;

--- a/tests/phpunit/unit/Resource/UserTest.php
+++ b/tests/phpunit/unit/Resource/UserTest.php
@@ -42,11 +42,11 @@ class UserTest extends ResourceTests {
      * Set up the resource
      */
     public function setUp() {
-        $this->request = $this->getMock('Imbo\Http\Request\Request');
-        $this->response = $this->getMock('Imbo\Http\Response\Response');
-        $this->database = $this->getMock('Imbo\Database\DatabaseInterface');
-        $this->storage = $this->getMock('Imbo\Storage\StorageInterface');
-        $this->event = $this->getMock('Imbo\EventManager\Event');
+        $this->request = $this->createMock('Imbo\Http\Request\Request');
+        $this->response = $this->createMock('Imbo\Http\Response\Response');
+        $this->database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $this->storage = $this->createMock('Imbo\Storage\StorageInterface');
+        $this->event = $this->createMock('Imbo\EventManager\Event');
         $this->event->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
         $this->event->expects($this->any())->method('getResponse')->will($this->returnValue($this->response));
         $this->event->expects($this->any())->method('getDatabase')->will($this->returnValue($this->database));
@@ -71,7 +71,7 @@ class UserTest extends ResourceTests {
      */
     public function testSupportsHttpGet() {
         $date = new DateTime('@1361628679', new DateTimeZone('UTC'));
-        $manager = $this->getMockBuilder('Imbo\EventManager\EventManager')->disableOriginalConstructor()->getMock();
+        $manager = $this->createMock('Imbo\EventManager\EventManager');
         $manager->expects($this->once())->method('trigger')->with('db.user.load');
         $this->event->expects($this->once())->method('getManager')->will($this->returnValue($manager));
 

--- a/tests/phpunit/unit/Storage/DoctrineTest.php
+++ b/tests/phpunit/unit/Storage/DoctrineTest.php
@@ -43,7 +43,7 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
             $this->markTestSkipped('Doctrine is required to run this test');
         }
 
-        $this->connection = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $this->connection = $this->createMock('Doctrine\DBAL\Connection');
         $this->driver = new Doctrine([], $this->connection);
     }
 

--- a/tests/phpunit/unit/Storage/FilesystemTest.php
+++ b/tests/phpunit/unit/Storage/FilesystemTest.php
@@ -92,7 +92,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Storage\Filesystem::store
      */
     public function testStoreToUnwritablePath() {
-        $image = $this->getMock('Imbo\Image\ImageInterface');
+        $image = 'some image data';
         $dir = 'unwritableDirectory';
 
         // Create the virtual directory with no permissions

--- a/tests/phpunit/unit/Storage/GridFSTest.php
+++ b/tests/phpunit/unit/Storage/GridFSTest.php
@@ -60,8 +60,8 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
             $this->markTestSkipped('pecl/mongo >= 1.3.0 is required to run this test');
         }
 
-        $this->grid = $this->getMockBuilder('MongoGridFS')->disableOriginalConstructor()->getMock();
-        $this->mongoClient = $this->getMockBuilder('MongoClient')->disableOriginalConstructor()->getMock();
+        $this->grid = $this->createMock('MongoGridFS');
+        $this->mongoClient = $this->createMock('MongoClient');
         $this->driver = new GridFS([], $this->mongoClient, $this->grid);
     }
 
@@ -81,7 +81,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
     public function testStore() {
         $data = 'some content';
 
-        $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
+        $cursor = $this->createMock('MongoGridFSCursor');
         $cursor->expects($this->once())->method('count')->will($this->returnValue(0));
 
         $this->grid->expects($this->at(0))
@@ -103,7 +103,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Storage\GridFS::imageExists
      */
     public function testDeleteFileThatDoesNotExist() {
-        $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
+        $cursor = $this->createMock('MongoGridFSCursor');
         $cursor->expects($this->once())->method('count')->will($this->returnValue(0));
 
         $this->grid->expects($this->once())->method('find')->will($this->returnValue($cursor));
@@ -116,9 +116,9 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Storage\GridFS::imageExists
      */
     public function testDeleteFile() {
-        $file = $this->getMockBuilder('MongoGridFSFile')->disableOriginalConstructor()->getMock();
+        $file = $this->createMock('MongoGridFSFile');
 
-        $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
+        $cursor = $this->createMock('MongoGridFSCursor');
         $cursor->expects($this->once())->method('count')->will($this->returnValue(1));
         $cursor->expects($this->once())->method('getNext')->will($this->returnValue($file));
 
@@ -135,7 +135,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Storage\GridFS::imageExists
      */
     public function testGetImageThatDoesNotExist() {
-        $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
+        $cursor = $this->createMock('MongoGridFSCursor');
         $cursor->expects($this->once())->method('count')->will($this->returnValue(0));
 
         $this->grid->expects($this->once())->method('find')->will($this->returnValue($cursor));
@@ -150,10 +150,10 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
     public function testGetImage() {
         $data = 'file contents';
 
-        $file = $this->getMockBuilder('MongoGridFSFile')->disableOriginalConstructor()->getMock();
+        $file = $this->createMock('MongoGridFSFile');
         $file->expects($this->once())->method('getBytes')->will($this->returnValue($data));
 
-        $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
+        $cursor = $this->createMock('MongoGridFSCursor');
         $cursor->expects($this->once())->method('count')->will($this->returnValue(1));
         $cursor->expects($this->once())->method('getNext')->will($this->returnValue($file));
 
@@ -169,7 +169,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
      * @covers Imbo\Storage\GridFS::imageExists
      */
     public function testGetLastModifiedWhenImageDoesNotExist() {
-        $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
+        $cursor = $this->createMock('MongoGridFSCursor');
         $cursor->expects($this->once())->method('count')->will($this->returnValue(0));
 
         $this->grid->expects($this->once())->method('find')->will($this->returnValue($cursor));
@@ -184,7 +184,7 @@ class GridFSTest extends \PHPUnit_Framework_TestCase {
     public function testGetLastModified() {
         $file = new TestFile();
 
-        $cursor = $this->getMockBuilder('MongoGridFSCursor')->disableOriginalConstructor()->getMock();
+        $cursor = $this->createMock('MongoGridFSCursor');
         $cursor->expects($this->once())->method('count')->will($this->returnValue(1));
         $cursor->expects($this->once())->method('getNext')->will($this->returnValue($file));
 


### PR DESCRIPTION
This PR upgrades PHPUnit from `^4.8` to `^5.6`. The only thing I needed to fix was to convert `$this->getMock( ... )` to `$this->createMock( ... )`, along with some other minor things.

Fix #447.