### PR TITLE
Add ConfigurationException for missing required parameters

### DIFF
--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -11,7 +11,8 @@
 namespace Imbo\Exception;
 
 /**
- * Database exception
+ * Configuration exception - thrown if the configuration provided to a module is invalid or missing.
+ *
  *
  * @author Mats Lindh <mats@lindh.no>
  * @package Exceptions

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Exception;
+
+/**
+ * Database exception
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package Exceptions
+ */
+class ConfigurationException extends RuntimeException {}

--- a/src/Helpers/Parameters.php
+++ b/src/Helpers/Parameters.php
@@ -1,0 +1,31 @@
+<?php
+/**
+* This file is part of the Imbo package
+*
+* (c) Christer Edvartsen <cogo@starzinger.net>
+*
+* For the full copyright and license information, please view the LICENSE file that was
+* distributed with this source code.
+*/
+
+namespace Imbo\Helpers;
+
+/**
+* Helper class for useful functions for building/manipulating URLs
+*
+* @author Mats Lindh <mats@lindh.no>
+* @package Core\Helpers
+*/
+class Parameters {
+    public static function getEmptyOrMissingParamFields($fields, $params) {
+        $missing = [];
+
+        foreach ($fields as $field) {
+            if (empty($params[$field])) {
+                $missing[] = $field;
+            }
+        }
+
+        return $missing;
+    }
+}

--- a/src/Helpers/Parameters.php
+++ b/src/Helpers/Parameters.php
@@ -17,6 +17,11 @@ namespace Imbo\Helpers;
 * @package Core\Helpers
 */
 class Parameters {
+    /**
+     * @param $fields array List of fields to ensure is present in $params
+     * @param $params array Associative array with field => value pairs to check for fields being present
+     * @return array
+     */
     public static function getEmptyOrMissingParamFields($fields, $params) {
         $missing = [];
 

--- a/src/Storage/B2.php
+++ b/src/Storage/B2.php
@@ -79,7 +79,7 @@ class B2 implements StorageInterface {
                 $this->params
             );
 
-            if ($missingFields && !$client) {
+            if ($missingFields) {
                 throw new ConfigurationException(
                     'Missing required configuration parameters in ' . __CLASS__ . ': ' .
                     join(', ', $missingFields)

--- a/src/Storage/B2.php
+++ b/src/Storage/B2.php
@@ -73,18 +73,18 @@ class B2 implements StorageInterface {
 
         if ($client !== null) {
             $this->client = $client;
-        }
-
-        $missingFields = Parameters::getEmptyOrMissingParamFields(
-            ['accountId', 'applicationKey', 'bucketId', 'bucket'],
-            $this->params
-        );
-
-        if ($missingFields) {
-            throw new ConfigurationException(
-                'Missing required configuration parameters in ' . __CLASS__ . ': ' .
-                join(', ', $missingFields)
+        } else {
+            $missingFields = Parameters::getEmptyOrMissingParamFields(
+                ['accountId', 'applicationKey', 'bucketId', 'bucket'],
+                $this->params
             );
+
+            if ($missingFields && !$client) {
+                throw new ConfigurationException(
+                    'Missing required configuration parameters in ' . __CLASS__ . ': ' .
+                    join(', ', $missingFields)
+                );
+            }
         }
     }
 

--- a/src/Storage/B2.php
+++ b/src/Storage/B2.php
@@ -10,12 +10,14 @@
 
 namespace Imbo\Storage;
 
+use Imbo\Exception\ConfigurationException;
 use Imbo\Exception\StorageException,
     Imbo\Exception\InvalidArgumentException,
     ChrisWhite\B2\Client,
     ChrisWhite\B2\Exceptions\NotFoundException,
     DateTime,
-    DateTimeZone;
+    DateTimeZone,
+    Imbo\Helpers\Parameters;
 
 /**
  * Backblaze B2 Cloud Storage adapter
@@ -71,6 +73,18 @@ class B2 implements StorageInterface {
 
         if ($client !== null) {
             $this->client = $client;
+        }
+
+        $missingFields = Parameters::getEmptyOrMissingParamFields(
+            ['accountId', 'applicationKey', 'bucketId', 'bucket'],
+            $this->params
+        );
+
+        if ($missingFields) {
+            throw new ConfigurationException(
+                'Missing required configuration parameters in ' . __CLASS__ . ': ' .
+                join(', ', $missingFields)
+            );
         }
     }
 
@@ -175,10 +189,6 @@ class B2 implements StorageInterface {
     protected function getClient() {
         if ($this->client === null) {
             $this->client = new Client($this->getParam('accountId'), $this->getParam('applicationKey'));
-        }
-
-        if (!$this->getParam('bucketId') || !$this->getParam('bucket')) {
-            throw new InvalidArgumentException('B2: Missing required bucket parameters. Both bucket and bucketId must be provided.', 500);
         }
 
         return $this->client;

--- a/src/Storage/Filesystem.php
+++ b/src/Storage/Filesystem.php
@@ -44,6 +44,12 @@ class Filesystem implements StorageInterface {
      */
     public function __construct(array $params) {
         $this->params = array_merge($this->params, $params);
+
+        if (empty($this->params['dataDir'])) {
+            throw new Exception\ConfigurationException(
+                'Missing required parameter dataDir in the Filesystem storage driver.'
+            );
+        }
     }
 
     /**

--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -11,6 +11,8 @@
 namespace Imbo\Storage;
 
 use Imbo\Exception\StorageException,
+    Imbo\Helpers\Parameters,
+    Imbo\Exception\ConfigurationException,
     Aws\S3\S3Client,
     Aws\S3\Exception\S3Exception,
     DateTime,
@@ -73,6 +75,18 @@ class S3 implements StorageInterface {
 
         if ($client !== null) {
             $this->client = $client;
+        } else {
+            $missingFields = Parameters::getEmptyOrMissingParamFields(
+                ['key', 'secret', 'bucket', 'region'],
+                $this->params
+            );
+
+            if ($missingFields && !$client) {
+                throw new ConfigurationException(
+                    'Missing required configuration parameters in ' . __CLASS__ . ': ' .
+                    join(', ', $missingFields)
+                );
+            }
         }
     }
 

--- a/src/Storage/S3.php
+++ b/src/Storage/S3.php
@@ -81,7 +81,7 @@ class S3 implements StorageInterface {
                 $this->params
             );
 
-            if ($missingFields && !$client) {
+            if ($missingFields) {
                 throw new ConfigurationException(
                     'Missing required configuration parameters in ' . __CLASS__ . ': ' .
                     join(', ', $missingFields)

--- a/tests/phpunit/unit/Storage/B2Test.php
+++ b/tests/phpunit/unit/Storage/B2Test.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboUnitTest\Storage;
+
+use Imbo\Exception\ConfigurationException,
+    Imbo\Storage\B2;
+
+/**
+ * @covers Imbo\Storage\B2
+ * @group unit
+ * @group storage
+ */
+class B2Test extends \PHPUnit_Framework_TestCase {
+    /**
+     * Test that we don't get an exception with required parameters present
+     */
+    public function testConstructorWithAllRequiredParameters() {
+        $b2 = new B2([
+            'accountId' => 'foo',
+            'applicationKey' => 'bar',
+            'bucketId' => 'spam',
+            'bucket' => 'eggs'
+        ]);
+
+        $this->assertNotNull($b2);
+    }
+
+    /**
+     * Test that we _do_ get an exception with required parameters present
+     *
+     * @expectedException Imbo\Exception\ConfigurationException
+     */
+    public function testConstructorMissingRequiredParameters() {
+        $b2 = new B2([
+            'accountId' => '',
+            'applicationKey' => 'bar',
+            'bucketId' => '',
+            'bucket' => 'eggs'
+        ]);
+    }
+
+    /**
+     * Test that we _do_ get exceptions for each single missing parameter
+     */
+    public function testConstructorEachMissingRequiredParameters() {
+        $params = [
+            'accountId' => 'foo',
+            'applicationKey' => 'bar',
+            'bucketId' => 'spam',
+            'bucket' => 'eggs'
+        ];
+
+        foreach ($params as $param => $dummy) {
+            $local = $params;
+            unset($local[$param]);
+            $exception = false;
+
+            try {
+                new B2($local);
+            } catch (ConfigurationException $e) {
+                $exception = true;
+            } finally {
+                $this->assertTrue($exception);
+            }
+        }
+    }
+
+
+}

--- a/tests/phpunit/unit/Storage/B2Test.php
+++ b/tests/phpunit/unit/Storage/B2Test.php
@@ -37,6 +37,7 @@ class B2Test extends \PHPUnit_Framework_TestCase {
      * Test that we _do_ get an exception with required parameters present
      *
      * @expectedException Imbo\Exception\ConfigurationException
+     * @expectedExceptionMessageRegExp /: accountId, bucketId/
      */
     public function testConstructorMissingRequiredParameters() {
         $b2 = new B2([
@@ -67,6 +68,9 @@ class B2Test extends \PHPUnit_Framework_TestCase {
                 new B2($local);
             } catch (ConfigurationException $e) {
                 $exception = true;
+
+                // test that the exception message ends with the field missing
+                $this->assertStringEndsWith(': ' . $param, $e->getMessage());
             } finally {
                 $this->assertTrue($exception);
             }

--- a/tests/phpunit/unit/Storage/FilesystemTest.php
+++ b/tests/phpunit/unit/Storage/FilesystemTest.php
@@ -260,6 +260,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @expectedException Imbo\Exception\ConfigurationException
+     * @expectedExceptionMessageRegExp /Missing required parameter dataDir/
      */
     public function testMissingDataDir() {
         new Filesystem([]);

--- a/tests/phpunit/unit/Storage/FilesystemTest.php
+++ b/tests/phpunit/unit/Storage/FilesystemTest.php
@@ -12,7 +12,8 @@ namespace ImboUnitTest\Storage;
 
 use Imbo\Storage\Filesystem,
     org\bovigo\vfs\vfsStream,
-    org\bovigo\vfs\vfsStreamWrapper;
+    org\bovigo\vfs\vfsStreamWrapper,
+    Imbo\Exception\ConfigurationException;
 
 /**
  * @covers Imbo\Storage\Filesystem
@@ -255,5 +256,12 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase {
 
         $driver = new Filesystem(['dataDir' => vfsStream::url('dir')]);
         $this->assertTrue($driver->getStatus());
+    }
+
+    /**
+     * @expectedException Imbo\Exception\ConfigurationException
+     */
+    public function testMissingDataDir() {
+        new Filesystem([]);
     }
 }

--- a/tests/phpunit/unit/Storage/S3Test.php
+++ b/tests/phpunit/unit/Storage/S3Test.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboUnitTest\Storage;
+
+use Imbo\Exception\ConfigurationException,
+    Imbo\Storage\S3;
+
+/**
+ * @covers Imbo\Storage\S3
+ * @group unit
+ * @group storage
+ */
+class S3Test extends \PHPUnit_Framework_TestCase {
+    /**
+     * Test that we don't get an exception with required parameters present
+     */
+    public function testConstructorWithAllRequiredParameters() {
+        $s3 = new S3([
+            'key' => 'foo',
+            'secret' => 'bar',
+            'bucket' => 'spam',
+            'region' => 'eggs',
+        ]);
+
+        $this->assertNotNull($s3);
+    }
+
+    /**
+     * Test that we _do_ get an exception with required parameters present
+     *
+     * @expectedException Imbo\Exception\ConfigurationException
+     */
+    public function testConstructorMissingRequiredParameters() {
+        new S3([
+            'key' => '',
+            'secret' => 'bar',
+            'bucket' => '',
+            'region' => 'eggs',
+        ]);
+    }
+
+    /**
+     * Test that we _do_ get exceptions for each single missing parameter
+     */
+    public function testConstructorEachMissingRequiredParameters() {
+        $params = [
+            'key' => 'foo',
+            'secret' => 'bar',
+            'bucket' => 'spam',
+            'region' => 'eggs',
+        ];
+
+        foreach ($params as $param => $dummy) {
+            $local = $params;
+            unset($local[$param]);
+            $exception = false;
+
+            try {
+                new S3($local);
+            } catch (ConfigurationException $e) {
+                $exception = true;
+            } finally {
+                $this->assertTrue($exception);
+            }
+        }
+    }
+
+
+}

--- a/tests/phpunit/unit/Storage/S3Test.php
+++ b/tests/phpunit/unit/Storage/S3Test.php
@@ -37,6 +37,7 @@ class S3Test extends \PHPUnit_Framework_TestCase {
      * Test that we _do_ get an exception with required parameters present
      *
      * @expectedException Imbo\Exception\ConfigurationException
+     * @expectedExceptionMessageRegExp /: key, bucket/
      */
     public function testConstructorMissingRequiredParameters() {
         new S3([
@@ -67,6 +68,9 @@ class S3Test extends \PHPUnit_Framework_TestCase {
                 new S3($local);
             } catch (ConfigurationException $e) {
                 $exception = true;
+
+                // test that the exception message ends with the field missing
+                $this->assertStringEndsWith(': ' . $param, $e->getMessage());
             } finally {
                 $this->assertTrue($exception);
             }

--- a/tests/phpunit/unit/Storage/S3Test.php
+++ b/tests/phpunit/unit/Storage/S3Test.php
@@ -76,6 +76,4 @@ class S3Test extends \PHPUnit_Framework_TestCase {
             }
         }
     }
-
-
 }


### PR DESCRIPTION
This PR implements #499, with an addition for the Filesystem driver as well.

After this patch the S3, B2 and Filesystem storage drivers will throw ConfigurationExceptions if required parameters are missing, instead of erroring out (if at all) later when the actual methods are called.

A static helper method is introduced to determine which required fields are missing.