### PR TITLE
Correct Transpose & Transverse dimensions

### DIFF
--- a/src/Image/Transformation/Transpose.php
+++ b/src/Image/Transformation/Transpose.php
@@ -40,7 +40,10 @@ class Transpose extends Transformation implements ListenerInterface {
     public function transform(EventInterface $event) {
         try {
             $this->imagick->transposeImage();
-            $event->getArgument('image')->hasBeenTransformed(true);
+            $event->getArgument('image')
+                ->setHeight($this->imagick->getImageHeight())
+                ->setWidth($this->imagick->getImageWidth())
+                ->hasBeenTransformed(true);
         } catch (ImagickException $e) {
             throw new TransformationException($e->getMessage(), 400, $e);
         }

--- a/src/Image/Transformation/Transverse.php
+++ b/src/Image/Transformation/Transverse.php
@@ -40,7 +40,10 @@ class Transverse extends Transformation implements ListenerInterface {
     public function transform(EventInterface $event) {
         try {
             $this->imagick->transverseImage();
-            $event->getArgument('image')->hasBeenTransformed(true);
+            $event->getArgument('image')
+                ->setHeight($this->imagick->getImageHeight())
+                ->setWidth($this->imagick->getImageWidth())
+                ->hasBeenTransformed(true);
         } catch (ImagickException $e) {
             throw new TransformationException($e->getMessage(), 400, $e);
         }

--- a/tests/phpunit/integration/Image/Transformation/TransposeTest.php
+++ b/tests/phpunit/integration/Image/Transformation/TransposeTest.php
@@ -33,11 +33,17 @@ class TransposeTest extends TransformationTests {
         $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->createMock('Imbo\EventManager\Event');
-        $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
-
         $imagick = new Imagick();
         $imagick->readImageBlob(file_get_contents(FIXTURES_DIR . '/image.png'));
+
+        $expectedWidth = $imagick->getImageHeight();
+        $expectedHeight = $imagick->getImageWidth();
+
+        $image->expects($this->once())->method('setWidth')->with($expectedWidth)->will($this->returnValue($image));
+        $image->expects($this->once())->method('setHeight')->with($expectedHeight)->will($this->returnValue($image));
+
+        $event = $this->createMock('Imbo\EventManager\Event');
+        $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $this->getTransformation()->setImagick($imagick)->transform($event);
     }

--- a/tests/phpunit/integration/Image/Transformation/TransverseTest.php
+++ b/tests/phpunit/integration/Image/Transformation/TransverseTest.php
@@ -33,11 +33,17 @@ class TransverseTest extends TransformationTests {
         $image = $this->createMock('Imbo\Model\Image');
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
-        $event = $this->createMock('Imbo\EventManager\Event');
-        $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
-
         $imagick = new Imagick();
         $imagick->readImageBlob(file_get_contents(FIXTURES_DIR . '/image.png'));
+
+        $expectedWidth = $imagick->getImageHeight();
+        $expectedHeight = $imagick->getImageWidth();
+
+        $image->expects($this->once())->method('setWidth')->with($expectedWidth)->will($this->returnValue($image));
+        $image->expects($this->once())->method('setHeight')->with($expectedHeight)->will($this->returnValue($image));
+
+        $event = $this->createMock('Imbo\EventManager\Event');
+        $event->expects($this->once())->method('getArgument')->with('image')->will($this->returnValue($image));
 
         $this->getTransformation()->setImagick($imagick)->transform($event);
     }


### PR DESCRIPTION
The transpose and transverse transformations changes the dimensions of an image from x,y to y,x, but the transformations didn't change the dimensions after their change. This caused later transformations to use wrong coordinates for any effects applied to the image.