### PR TITLE
Fixed event listener key for authentication in docs

### DIFF
--- a/docs/installation/event_listeners.rst
+++ b/docs/installation/event_listeners.rst
@@ -96,7 +96,7 @@ This event listener does not support any parameters and is enabled per default l
         // ...
 
         'eventListeners' => [
-            'authenticate' => 'Imbo\EventListener\Authenticate',
+            'auth' => 'Imbo\EventListener\Authenticate',
         ],
 
         // ...


### PR DESCRIPTION
Hi. I've spent a few hours trying to figure out why I can't turn off an authentication mechanism. I was following the docs and event listener keys which are mentioned there (https://github.com/imbo/imbo/blame/develop/docs/installation/event_listeners.rst#L99). Turning off the access token requirement was easy. Turning off authentication was quite difficult.

```
'eventListeners' => [
    'accessToken' => null,
    'authentication' => new class extends Imbo\EventListener\Authenticate {
        public function authenticate(Imbo\EventManager\EventInterface $event)
        {
            // I couldn't hit a breakpoint in here
            return;
        }
    }
],
```

After digging around I've just realized there's a bug in docs, and the event listener which is used for authentication lives under `auth` (not `authentication`) key. I've created a hotfix so hopefully someone will save some time.

Thanks.