### PR TITLE
Filesystem Adapter: Write to temporary file and do a rename

### DIFF
--- a/src/Storage/Filesystem.php
+++ b/src/Storage/Filesystem.php
@@ -75,12 +75,15 @@ class Filesystem implements StorageInterface {
 
         $imagePath = $imageDir . '/' . $imageIdentifier;
 
-        $bytesWritten = file_put_contents($imagePath, $imageData);
+        // write the file to .tmp, so we can do an atomic rename later to avoid possibly serving partly written files
+        $bytesWritten = file_put_contents($imagePath . '.tmp', $imageData);
 
         // if write failed or 0 bytes were written (0 byte input == fail), or we wrote less than expected
         if (!$bytesWritten || ($bytesWritten < strlen($imageData))) {
             throw new StorageException('Failed writing file (disk full? zero bytes input?) to disk: ' . $imagePath, 507);
         }
+
+        rename($imagePath . '.tmp', $imagePath);
 
         return true;
     }


### PR DESCRIPTION
To avoid a possible issue of serving a partly written file if the Filesystem adapter is used with an existing image (inside a cache adapter in this case), writing the file to a temporary file and then renaming that
file to its actually name would make sure we don't end up serving a partly written file.

The rename() call is atomic, meaning that there is no time where the contents inside the file we be partly available for anything reading the file.