### PR TITLE
Make access token algorithm pluggable

### DIFF
--- a/docs/installation/event_listeners.rst
+++ b/docs/installation/event_listeners.rst
@@ -713,3 +713,4 @@ The header appears multiple times in the response, with slightly different value
 
     X-HashTwo: imbo;image;<publicKey>;<imageIdentifier>
     X-HashTwo: imbo;user;<publicKey>
+

--- a/docs/installation/event_listeners.rst
+++ b/docs/installation/event_listeners.rst
@@ -79,9 +79,9 @@ Custom Access Token Generators
 
 You can customize how the access token is generated and which URL parameter that contain the access token. The default implementation uses a SHA256 HMAC generated from the private key and the URL of the request.
 
-To switch to a different access token generator provide a new generator in the ``accessTokenGenerator`` parameter. This generator must implement the AccessTokenInterface interface, available under EventListener\AccessToken\AccessTokenInterface. An abstract class (``AccessTokenGenerator``) is included that you can subclass to quickly implement an alternative signature algorithm.
+To switch to a different access token generator provide a new generator in the ``accessTokenGenerator`` parameter. This generator must implement the ``AccessTokenInterface`` interface, available under ``EventListener\AccessToken\AccessTokenInterface``. An abstract class (``AccessTokenGenerator``) is included that you can subclass to quickly implement an alternative signature algorithm.
 
-To use a different algorithm, provide it as a key in the parameter array when creating the AccessToken event listener:
+To use a different algorithm, provide it as a key in the parameter array when creating the access token event listener:
 
 .. code-block:: php
 

--- a/docs/installation/event_listeners.rst
+++ b/docs/installation/event_listeners.rst
@@ -101,7 +101,7 @@ which would allow the token to be present under either ``foo`` or ``accessToken`
 
 Imbo uses a SHA256 HMAC as the default signature generation algorithm, available under ``EventListener\AccessToken\SHA256``.
 
-If you want to use multiple access token generators, you can use the bundled `MultipleAccessTokensGenerators` generator, which will pick a generator based on the available URL parameters (in sequence, the first match will be used).
+If you want to use multiple access token generators, you can use the bundled ``MultipleAccessTokensGenerators`` generator, which will pick a generator based on the available URL parameters (in sequence, the first match will be used).
 
 .. code-block:: php
 

--- a/docs/installation/event_listeners.rst
+++ b/docs/installation/event_listeners.rst
@@ -72,6 +72,36 @@ This event listener is included in the default configuration file without specif
 
 Disable this event listener with care. Installations with no access token check is open for `DoS <http://en.wikipedia.org/wiki/Denial-of-service_attack>`_ attacks.
 
+.. _custom-access-token-generators:
+
+Custom Access Token Generators
+------------------------------
+
+You can customize how the access token is generated and which URL parameter that contain the access token. The default implementation uses a SHA256 HMAC generated from the private key and the URL of the request.
+
+To switch to a different access token generator provide a new generator in the ``accessTokenGenerator`` parameter. This generator must implement the AccessTokenInterface interface, available under EventListener\AccessToken\AccessTokenInterface. An abstract class (``AccessTokenGenerator``) is included that you can subclass to quickly implement an alternative signature algorithm.
+
+To use a different algorithm, provide it as a key in the parameter array when creating the AccessToken event listener:
+
+.. code-block:: php
+
+    [
+        'accessTokenGenerator' => new AccessToken\SHA256(),
+    ]
+
+You can also provide a list of URL argument names for the access token, if it's not available through the regular ``accessToken`` argument.
+
+.. code-block:: php
+
+    [
+        'accessTokenGenerator' => new AccessToken\SHA256(['argumentKeys' => ['foo', 'accessToken']]),
+    ]
+
+.. which would allow the token to be present under either ``foo`` or ``accessToken`` in the URL arguments.
+
+Imbo uses a SHA256 HMAC as the default signature generation algorithm, available under ``EventListener\AccessToken\SHA256``.
+
+
 .. _authenticate-event-listener:
 
 Authenticate

--- a/docs/installation/event_listeners.rst
+++ b/docs/installation/event_listeners.rst
@@ -97,10 +97,25 @@ You can also provide a list of URL argument names for the access token, if it's 
         'accessTokenGenerator' => new AccessToken\SHA256(['argumentKeys' => ['foo', 'accessToken']]),
     ]
 
-.. which would allow the token to be present under either ``foo`` or ``accessToken`` in the URL arguments.
+which would allow the token to be present under either ``foo`` or ``accessToken`` in the URL arguments.
 
 Imbo uses a SHA256 HMAC as the default signature generation algorithm, available under ``EventListener\AccessToken\SHA256``.
 
+If you want to use multiple access token generators, you can use the bundled `MultipleAccessTokensGenerators` generator, which will pick a generator based on the available URL parameters (in sequence, the first match will be used).
+
+.. code-block:: php
+
+    [
+        'accessTokenGenerator' => new AccessToken\MultipleAccessTokenGenerators([
+            'generators' => [
+                'accessToken' => new AccessToken\SHA256(),
+                'dummy' => new DummyImplementation(),
+                ...
+            ],
+        ]),
+    ]
+
+This will cause the ``SHA256`` implementation to be used if an ``accessToken``  parameter is available, but if only the ``dummy`` parameter is present, the ``DummyImplementation`` generator will be used.
 
 .. _authenticate-event-listener:
 

--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -951,7 +951,7 @@ and Ruby:
     :language: ruby
     :linenos:
 
-If the event listener enforcing the access token check is removed, Imbo will ignore the ``accessToken`` query parameter completely. If you wish to implement your own form of access token you can do this by implementing an event listener of your own (see :ref:`custom-event-listeners` for more information).
+If the event listener enforcing the access token check is removed, Imbo will ignore the ``accessToken`` query parameter completely. If you wish to implement your own form of access token you can do this by either implementing an event listener of your own (see :ref:`custom-event-listeners` for more information), or :ref:`by writing a new access token signature generator for the access token event listener <custom-access-token-generators>`.
 
 Prior to Imbo-1.0.0 there was no rule that the URL had to be completely URL-decoded prior to generating the access token in the clients. Because of this Imbo will also try to re-generate the access token server side by using the URL as-is. This feature has been added to ease the transition to Imbo >= 1.0.0, and will be removed some time in the future.
 

--- a/src/EventListener/AccessToken.php
+++ b/src/EventListener/AccessToken.php
@@ -14,6 +14,7 @@ use Imbo\EventListener\AccessToken\AccessTokenInterface;
 use Imbo\EventManager\EventInterface,
     Imbo\Http\Request\Request,
     Imbo\Exception\RuntimeException,
+    Imbo\Exception\ConfigurationException,
     Imbo\Helpers\Urls,
     Imbo\EventListener\AccessToken\SHA256,
     GuzzleHttp\Psr7;

--- a/src/EventListener/AccessToken/AccessTokenGenerator.php
+++ b/src/EventListener/AccessToken/AccessTokenGenerator.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\EventListener\AccessToken;
+
+/**
+ * Abstract class for Access Token Generation
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package AccessToken
+ */
+abstract class AccessTokenGenerator implements AccessTokenInterface {
+    /**
+     * Parameters for the generator
+     *
+     * @var array
+     */
+    protected $params = [
+        'argumentKey' => 'accessToken',
+    ];
+
+    abstract public function generateSignature($data, $privateKey);
+
+    /**
+     * Class constructor
+     *
+     * @param array $params Parameters for the listener
+     */
+    public function __construct(array $params = null) {
+        if ($params) {
+            $this->params = array_replace_recursive($this->params, $params);
+        }
+    }
+
+    public function getArgumentKey() {
+        return $this->params['argumentKey'];
+    }
+
+    public function setArgumentKey($argumentKey) {
+        $this->params['argumentKey'] = $argumentKey;
+
+        return $this;
+    }
+}

--- a/src/EventListener/AccessToken/AccessTokenGenerator.php
+++ b/src/EventListener/AccessToken/AccessTokenGenerator.php
@@ -23,10 +23,13 @@ abstract class AccessTokenGenerator implements AccessTokenInterface {
      * @var array
      */
     protected $params = [
-        'argumentKey' => 'accessToken',
+        'argumentKeys' => ['accessToken'],
     ];
 
-    abstract public function generateSignature($data, $privateKey);
+    /**
+     * {@inheritdoc}
+     */
+    abstract public function generateSignature($argumentKey, $data, $privateKey);
 
     /**
      * Class constructor
@@ -39,12 +42,26 @@ abstract class AccessTokenGenerator implements AccessTokenInterface {
         }
     }
 
-    public function getArgumentKey() {
-        return $this->params['argumentKey'];
+    /**
+     * {@inheritdoc}
+     */
+    public function getArgumentKeys() {
+        return $this->params['argumentKeys'];
     }
 
-    public function setArgumentKey($argumentKey) {
-        $this->params['argumentKey'] = $argumentKey;
+    /**
+     * @param $argumentKey string Add an argument key to be handled by this generator
+     */
+    public function addArgumentKey($argumentKey) {
+        $this->params['argumentKeys'][] = $argumentKey;
+    }
+
+    /**
+     * @param $argumentKeys array<string> Set the argumentKeys that this generator handles
+     * @return $this
+     */
+    public function setArgumentKeys($argumentKeys) {
+        $this->params['argumentKeys'] = $argumentKeys;
 
         return $this;
     }

--- a/src/EventListener/AccessToken/AccessTokenGenerator.php
+++ b/src/EventListener/AccessToken/AccessTokenGenerator.php
@@ -50,15 +50,15 @@ abstract class AccessTokenGenerator implements AccessTokenInterface {
     }
 
     /**
-     * @param $argumentKey string Add an argument key to be handled by this generator
+     * @param string $argumentKey Add an argument key to be handled by this generator
      */
     public function addArgumentKey($argumentKey) {
         $this->params['argumentKeys'][] = $argumentKey;
     }
 
     /**
-     * @param $argumentKeys array<string> Set the argumentKeys that this generator handles
-     * @return $this
+     * @param string[] $argumentKeys Set the argumentKeys that this generator handles
+     * @return self
      */
     public function setArgumentKeys($argumentKeys) {
         $this->params['argumentKeys'] = $argumentKeys;

--- a/src/EventListener/AccessToken/AccessTokenInterface.php
+++ b/src/EventListener/AccessToken/AccessTokenInterface.php
@@ -11,12 +11,22 @@
 namespace Imbo\EventListener\AccessToken;
 
 /**
- * Abstract class for Access Token Generation
+ * Interface for Access Token Generation
  *
  * @author Mats Lindh <mats@lindh.no>
  * @package AccessToken
  */
 interface AccessTokenInterface {
-    public function generateSignature($data, $privateKey);
-    public function getArgumentKey();
+    /**
+     * @param $argumentKey string The URL argument used for key comparison
+     * @param $data string The data to be signed
+     * @param $privateKey string The private key used to sign the data
+     * @return string The generated signature from the parameters given
+     */
+    public function generateSignature($argumentKey, $data, $privateKey);
+
+    /**
+     * @return array<string> The defined argument keys handled by this generator
+     */
+    public function getArgumentKeys();
 }

--- a/src/EventListener/AccessToken/AccessTokenInterface.php
+++ b/src/EventListener/AccessToken/AccessTokenInterface.php
@@ -18,15 +18,15 @@ namespace Imbo\EventListener\AccessToken;
  */
 interface AccessTokenInterface {
     /**
-     * @param $argumentKey string The URL argument used for key comparison
-     * @param $data string The data to be signed
-     * @param $privateKey string The private key used to sign the data
+     * @param string $argumentKey The URL argument used for key comparison
+     * @param string $data The data to be signed
+     * @param string $privateKey The private key used to sign the data
      * @return string The generated signature from the parameters given
      */
     public function generateSignature($argumentKey, $data, $privateKey);
 
     /**
-     * @return array<string> The defined argument keys handled by this generator
+     * @return string[] The defined argument keys handled by this generator
      */
     public function getArgumentKeys();
 }

--- a/src/EventListener/AccessToken/AccessTokenInterface.php
+++ b/src/EventListener/AccessToken/AccessTokenInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\EventListener\AccessToken;
+
+/**
+ * Abstract class for Access Token Generation
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package AccessToken
+ */
+interface AccessTokenInterface {
+    public function generateSignature($data, $privateKey);
+    public function getArgumentKey();
+}

--- a/src/EventListener/AccessToken/MultipleAccessTokenGenerators.php
+++ b/src/EventListener/AccessToken/MultipleAccessTokenGenerators.php
@@ -21,7 +21,7 @@ class MultipleAccessTokenGenerators extends AccessTokenGenerator {
      * @param array $params Parameters to the MultipleAccessTokenGenerators.
      */
     public function __construct(array $params = []) {
-        if (!$params['generators']) {
+        if (!isset($params['generators'])) {
             $params['generators'] = [];
         }
 

--- a/src/EventListener/AccessToken/MultipleAccessTokenGenerators.php
+++ b/src/EventListener/AccessToken/MultipleAccessTokenGenerators.php
@@ -1,0 +1,38 @@
+<?php
+namespace Imbo\EventListener\AccessToken;
+
+use Imbo\EventListener\AccessToken\AccessTokenGenerator,
+    Imbo\EventListener\AccessToken\SHA256;
+
+class MultipleAccessTokenGenerators extends AccessTokenGenerator {
+    /**
+     * The params array for this generator allows you to define a set of access token signature generators to be used
+     * for different url parameters if present. Each will be tried in the sequence defined.
+     *
+     * 'generators' => [
+     *     'accessToken' => new SHA256(),
+     *     'dummy' => new Dummy(),
+     * ]
+     *
+     * .. will first try the SHA256() generator if the 'accessToken' parameter is present in the URL, before trying
+     * the Dummy generator if the first authentication attempt fails. This allows you to introduce new access token
+     * validation schemes while keeping backwards compatible signature algorithms valid.
+     *
+     * @param array $params Parameters to the MultipleAccessTokenGenerators.
+     */
+    public function __construct(array $params = []) {
+        if (!$params['generators']) {
+            $params['generators'] = [];
+        }
+
+        parent::__construct($params);
+    }
+
+    public function generateSignature($argumentKey, $data, $privateKey) {
+        return $this->params['generators'][$argumentKey]->generateSignature($argumentKey, $data, $privateKey);
+    }
+
+    public function getArgumentKeys() {
+        return array_keys($this->params['generators']);
+    }
+}

--- a/src/EventListener/AccessToken/MultipleAccessTokenGenerators.php
+++ b/src/EventListener/AccessToken/MultipleAccessTokenGenerators.php
@@ -3,6 +3,7 @@ namespace Imbo\EventListener\AccessToken;
 
 use Imbo\EventListener\AccessToken\AccessTokenGenerator,
     Imbo\EventListener\AccessToken\SHA256;
+use Imbo\Exception\RuntimeException;
 
 class MultipleAccessTokenGenerators extends AccessTokenGenerator {
     /**
@@ -21,8 +22,14 @@ class MultipleAccessTokenGenerators extends AccessTokenGenerator {
      * @param array $params Parameters to the MultipleAccessTokenGenerators.
      */
     public function __construct(array $params = []) {
-        if (!isset($params['generators'])) {
+        if (!isset($params['generators']) || !is_array($params['generators'])) {
             $params['generators'] = [];
+        } else {
+            foreach ($params['generators'] as $generator) {
+                if (!$generator instanceof AccessTokenInterface) {
+                    throw new RuntimeException('AccessTokenGenerators must implement AccessTokenInterface');
+                }
+            }
         }
 
         parent::__construct($params);

--- a/src/EventListener/AccessToken/SHA256.php
+++ b/src/EventListener/AccessToken/SHA256.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\EventListener\AccessToken;
+
+/**
+ * Implementation of the default SHA256 access token generator
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package AccessToken
+ */
+class SHA256 extends AccessTokenGenerator {
+    public function generateSignature($data, $privateKey) {
+        return hash_hmac('sha256', $data, $privateKey);
+    }
+}

--- a/src/EventListener/AccessToken/SHA256.php
+++ b/src/EventListener/AccessToken/SHA256.php
@@ -11,13 +11,16 @@
 namespace Imbo\EventListener\AccessToken;
 
 /**
- * Implementation of the default SHA256 access token generator
+ * Implementation of the default SHA256 access token generator (HMAC-ed with the private key)
  *
  * @author Mats Lindh <mats@lindh.no>
  * @package AccessToken
  */
 class SHA256 extends AccessTokenGenerator {
-    public function generateSignature($data, $privateKey) {
+    /**
+     * {@inheritdoc}
+     */
+    public function generateSignature($argumentKey, $data, $privateKey) {
         return hash_hmac('sha256', $data, $privateKey);
     }
 }

--- a/tests/phpunit/unit/EventListener/AccessTokenTest.php
+++ b/tests/phpunit/unit/EventListener/AccessTokenTest.php
@@ -323,7 +323,7 @@ class AccessTokenTest extends ListenerTests {
         $privateKey = 'private key';
 
         $listener = new AccessToken([
-            'accessTokenGenerator' => new AccessToken\SHA256(['argumentKey' => 'foo']),
+            'accessTokenGenerator' => new AccessToken\SHA256(['argumentKeys' => ['foo']]),
         ]);
 
 

--- a/tests/phpunit/unit/EventListener/AccessTokenTest.php
+++ b/tests/phpunit/unit/EventListener/AccessTokenTest.php
@@ -185,7 +185,7 @@ class AccessTokenTest extends ListenerTests {
         $listener = new AccessToken($filter);
 
         if (!$whitelisted) {
-            $this->setExpectedException('Imbo\Exception\RuntimeException', 'Missing access token', 400);
+            $this->expectException('Imbo\Exception\RuntimeException', 'Missing access token', 400);
         }
 
         $this->event->expects($this->once())->method('getName')->will($this->returnValue('image.get'));
@@ -262,7 +262,7 @@ class AccessTokenTest extends ListenerTests {
      */
     public function testThrowsExceptionOnIncorrectToken($url, $token, $privateKey, $correct) {
         if (!$correct) {
-            $this->setExpectedException('Imbo\Exception\RuntimeException', 'Incorrect access token', 400);
+            $this->expectException('Imbo\Exception\RuntimeException', 'Incorrect access token', 400);
         }
 
         $this->query->expects($this->once())->method('has')->with('accessToken')->will($this->returnValue(true));
@@ -492,7 +492,7 @@ class AccessTokenTest extends ListenerTests {
      */
     public function testWillRewriteIncomingUrlToConfiguredProtocol($accessToken, $url, $protocol, $correct) {
         if (!$correct) {
-            $this->setExpectedException('Imbo\Exception\RuntimeException', 'Incorrect access token', 400);
+            $this->expectException('Imbo\Exception\RuntimeException', 'Incorrect access token', 400);
         }
 
         $event = $this->getEventMock([

--- a/tests/phpunit/unit/EventListener/AccessTokenTest.php
+++ b/tests/phpunit/unit/EventListener/AccessTokenTest.php
@@ -10,7 +10,8 @@
 
 namespace ImboUnitTest\EventListener;
 
-use Imbo\EventListener\AccessToken;
+use Imbo\EventListener\AccessToken,
+    Imbo\Exception\ConfigurationException;
 
 /**
  * @covers Imbo\EventListener\AccessToken
@@ -333,6 +334,21 @@ class AccessTokenTest extends ListenerTests {
         $this->request->expects($this->atLeastOnce())->method('getUriAsIs')->will($this->returnValue($url));
 
         $this->accessControl->expects($this->once())->method('getPrivateKey')->will($this->returnValue($privateKey));
+        $listener->checkAccessToken($this->event);
+    }
+
+    /**
+     * Test that we can configure the access token argument key
+     *
+     * @expectedException Imbo\Exception\ConfigurationException
+     * @expectedExceptionMessage Invalid accessTokenGenerator
+     * @expectedExceptionCode 500
+     */
+    public function testConfigurationExceptionOnInvalidAccessTokenGenerator() {
+        $listener = new AccessToken([
+            'accessTokenGenerator' => new \StdClass(),
+        ]);
+
         $listener->checkAccessToken($this->event);
     }
 

--- a/tests/phpunit/unit/EventListener/AccessTokenTest.php
+++ b/tests/phpunit/unit/EventListener/AccessTokenTest.php
@@ -315,6 +315,28 @@ class AccessTokenTest extends ListenerTests {
     }
 
     /**
+     * Test that we can configure the access token argument key
+     */
+    public function testAccessTokenArgumentKey() {
+        $url = 'http://imbo/users/christer';
+        $token = '81b52f01115401e5bcd0b65b625258510f8823e0b3189c13d279f84c4eb0ac3a';
+        $privateKey = 'private key';
+
+        $listener = new AccessToken([
+            'accessTokenGenerator' => new AccessToken\SHA256(['argumentKey' => 'foo']),
+        ]);
+
+
+        $this->query->expects($this->once())->method('has')->with('foo')->will($this->returnValue(true));
+        $this->query->expects($this->once())->method('get')->with('foo')->will($this->returnValue($token));
+        $this->request->expects($this->atLeastOnce())->method('getRawUri')->will($this->returnValue(urldecode($url)));
+        $this->request->expects($this->atLeastOnce())->method('getUriAsIs')->will($this->returnValue($url));
+
+        $this->accessControl->expects($this->once())->method('getPrivateKey')->will($this->returnValue($privateKey));
+        $listener->checkAccessToken($this->event);
+    }
+
+    /**
      * Get access tokens with rewritten URLs
      *
      * @return array[]

--- a/tests/phpunit/unit/EventListener/AccessTokenTest.php
+++ b/tests/phpunit/unit/EventListener/AccessTokenTest.php
@@ -327,7 +327,6 @@ class AccessTokenTest extends ListenerTests {
             'accessTokenGenerator' => new AccessToken\SHA256(['argumentKeys' => ['foo']]),
         ]);
 
-
         $this->query->expects($this->once())->method('has')->with('foo')->will($this->returnValue(true));
         $this->query->expects($this->once())->method('get')->with('foo')->will($this->returnValue($token));
         $this->request->expects($this->atLeastOnce())->method('getRawUri')->will($this->returnValue(urldecode($url)));
@@ -408,8 +407,6 @@ class AccessTokenTest extends ListenerTests {
 
         $listener->checkAccessToken($this->event);
     }
-
-
 
     /**
      * Test that we can configure the access token argument key


### PR DESCRIPTION
To allow for alternative access token schemes without having to reimplement most of the Access Token event listener, this change introduces Access Token Generators. The default implementation is ported over to the `AccessToken\SHA256` class, and different generators can either implement the interface directly, or subclass the new AccessTokenGenerator class and implement the `generateSignature` method.