### PR TITLE
Prepend __DIR__ when including default config.

### DIFF
--- a/src/CliCommand/CliCommand.php
+++ b/src/CliCommand/CliCommand.php
@@ -33,7 +33,7 @@ abstract class CliCommand extends Command {
      */
     public function getConfig() {
         if ($this->config === null) {
-            $this->config = require 'config/config.default.php';
+            $this->config = require __DIR__ . '/../../config/config.default.php';
         }
 
         return $this->config;


### PR DESCRIPTION
This works both for cloned, exported and composer installed imbos, and makes sure we're able to get the default configuration (in particular in tests).

Without this fix `ImboUnitTest\CliCommand\CliCommandTest::testFetchesTheDefaultConfigurationIfNoneHasBeenSet` is borked under Windows at least.