### PR TITLE
Add a cassandra DB adapter

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,11 @@
     <var name="BACKBLAZE_B2_APPLICATION_KEY" value="" />
     <var name="BACKBLAZE_B2_BUCKET" value="" />
     <var name="BACKBLAZE_B2_BUCKET_ID" value="" />
+
+    <!-- Cassandra tests - defaults to 127.0.0.1:9042
+      <var name="CASSANDRA_HOST" value="" />
+      <var name="CASSANDRA_PORT" value="" />
+    -->
   </php>
 
   <filter>

--- a/src/Database/Cassandra.php
+++ b/src/Database/Cassandra.php
@@ -1,0 +1,329 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Database;
+
+use Imbo\Model\Image,
+    Imbo\Model\Images,
+    Imbo\Resource\Images\Query,
+    Cassandra as CassandraLib,
+    Cassandra\Session,
+    Cassandra\ExecutionOptions,
+    Cassandra\SimpleStatement,
+
+    Imbo\Exception\DatabaseException,
+    Imbo\Exception\InvalidArgumentException,
+    Imbo\Exception,
+    DateTime,
+    DateTimeZone;
+
+/**
+ * Cassandra database driver
+ *
+ * Parameters for this driver:
+ *
+ * - <pre>(string> keyspace</pre> Name of keyspace to use (default: imbo)
+ * - <pre>(string) hosts</pre> Array of ips/hosts of cassandra notes to bootstrap from (default: [localhost])
+ * - <pre>(string) persistent</pre> Whether the session should be persistent across requests (default: true)
+ * - <pre>(Cassandra\Session) cluster</pre> Existing Cassandra session (from Cassandra::cluster()->build() with custom parameters)
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package Database
+ */
+class Cassandra implements DatabaseInterface {
+    public function __construct($params = []) {
+        $session = null;
+
+        if (!empty($params['session']) && $params['session'] instanceof Session) {
+            $session = $params['session'];
+        } else {
+            $cluster = CassandraLib::cluster();
+
+            if (!empty($params['hosts'])) {
+                if (is_array($params['hosts'])) {
+                    $cluster = call_user_func_array([$cluster, 'withContactPoints'], $params['hosts']);
+                } else {
+                    $cluster = $cluster->withContactPoints($params['hosts']);
+                }
+            }
+
+            if (!empty($params['persistent'])) {
+                $cluster = $cluster->withPersistentSessions((bool) $params['persistent']);
+            }
+
+            $session = $cluster->build()->connect(!empty($params['keyspace']) ? $params['keyspace'] : 'imbo');
+        }
+
+        $this->session = $session;
+    }
+
+    protected function execute($statement, $args) {
+        $options = new ExecutionOptions(['arguments' => $args]);
+        return $this->session->execute($statement, $options);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function insertImage($user, $imageIdentifier, Image $image) {
+        $now = time();
+
+        if ($added = $image->getAddedDate()) {
+            $added = $added->getTimestamp();
+        }
+
+        if ($updated = $image->getUpdatedDate()) {
+            $updated = $updated->getTimestamp();
+        }
+
+        $statement = $this->session->prepare("
+            INSERT INTO
+                imageinfo 
+            (
+                user,
+                imageIdentifier,
+                size,
+                extension,
+                mime,
+                added,
+                updated,
+                width,
+                height,
+                checksum,
+                originalChecksum            
+            )
+            VALUES
+            (
+                :user, :imageIdentifier, :size, :extension, :mime, :added, :updated, :width, :height, :checksum, :originalChecksum
+            )
+        ");
+
+        $args = [
+            'size'             => $image->getFilesize(),
+            'user'             => $user,
+            'imageIdentifier'  => $imageIdentifier,
+            'extension'        => $image->getExtension(),
+            'mime'             => $image->getMimeType(),
+            'added'            => $added ?: $now,
+            'updated'          => $updated ?: $now,
+            'width'            => $image->getWidth(),
+            'height'           => $image->getHeight(),
+            'checksum'         => $image->getChecksum(),
+            'originalChecksum' => $image->getOriginalChecksum(),
+        ];
+
+        return (boolean) $this->execute($statement, $args);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteImage($user, $imageIdentifier) {
+        // getImageProperties will usually throw the same exception
+        if (!$row = $this->getImageProperties($user, $imageIdentifier)) {
+            throw new DatabaseException("Image not found", 404);
+        }
+
+        $statement = $this->session->prepare("
+            DELETE FROM 
+                imageinfo
+            WHERE
+                user = :user AND 
+                imageIdentifier = :imageIdentifier
+        ");
+
+        $args = [
+            'user' => $user,
+            'imageIdentifier' => $imageIdentifier,
+        ];
+
+        return (boolean) $this->execute($statement, $args);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateMetadata($user, $imageIdentifier, array $metadata) {
+        // TODO: Implement updateMetadata() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMetadata($user, $imageIdentifier) {
+        // TODO: Implement getMetadata() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteMetadata($user, $imageIdentifier) {
+        // TODO: Implement deleteMetadata() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getImages(array $users, Query $query, Images $model) {
+        // TODO: Implement getImages() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function load($user, $imageIdentifier, Image $image) {
+        $row = $this->getImageProperties($user, $imageIdentifier);
+
+        $image->setWidth($row['width'])
+            ->setHeight($row['height'])
+            ->setFilesize($row['size'])
+            ->setMimeType($row['mime'])
+            ->setExtension($row['extension'])
+            ->setAddedDate(new DateTime('@' . $row['added'], new DateTimeZone('UTC')))
+            ->setUpdatedDate(new DateTime('@' . $row['updated'], new DateTimeZone('UTC')));
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getImageProperties($user, $imageIdentifier) {
+        $statement = $this->session->prepare("
+            SELECT
+                *
+            FROM
+                imageinfo
+            WHERE
+                user = :user AND 
+                imageIdentifier = :imageIdentifier
+        ");
+
+        $args = [
+            'user' => $user,
+            'imageIdentifier' => $imageIdentifier,
+        ];
+
+        $rows = $this->execute($statement, $args);
+
+        // count() gives int(1), even if there was no actual rows returned?
+        if (empty($rows[0])) {
+            throw new DatabaseException("Image not found", 404);
+        }
+
+        return $rows[0];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLastModified(array $users, $imageIdentifier = null) {
+        $args = [];
+        $usersCQL = [];
+
+        foreach ($users as $user) {
+            $args[] = $user;
+            $usersCQL[] = 'user = ?';
+        }
+
+        $where = '(' . join('OR', $usersCQL) . ')';
+
+        if ($imageIdentifier) {
+            $where .= ' AND imageIdentifier = ?';
+            $args[] = $imageIdentifier;
+
+            $statement = new SimpleStatement("SELECT updated FROM imageinfo WHERE " . $where);
+            $rows = $this->execute($statement, $args);
+
+            // see note in getImageProperties
+            if (empty($rows[0])) {
+                throw new DatabaseException("Image not found", 404);
+            }
+
+            $row = $rows[0];
+            return new DateTime('@' . $row['updated'], new DateTimeZone('UTC'));
+        } else {
+            // We'll need to introduce a separate table for this..
+            throw new DatabaseException("Multi-user getLastModified without imageIdentifier not implemented yet");
+            $statement = new SimpleStatement("SELECT updated FROM usermeta WHERE " . $where);
+            $rows = $this->execute($statement, $args);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getNumImages($user = null) {
+        // TODO: Implement getNumImages() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getNumBytes($user = null) {
+        // TODO: Implement getNumBytes() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getNumUsers() {
+        // TODO: Implement getNumUsers() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatus() {
+        // TODO: Implement getStatus() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getImageMimeType($user, $imageIdentifier) {
+        // TODO: Implement getImageMimeType() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function imageExists($user, $imageIdentifier) {
+        // TODO: Implement imageExists() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function insertShortUrl($shortUrlId, $user, $imageIdentifier, $extension = null, array $query = []) {
+        // TODO: Implement insertShortUrl() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getShortUrlId($user, $imageIdentifier, $extension = null, array $query = []) {
+        // TODO: Implement getShortUrlId() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getShortUrlParams($shortUrlId) {
+        // TODO: Implement getShortUrlParams() method.
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteShortUrls($user, $imageIdentifier, $shortUrlId = null) {
+        // TODO: Implement deleteShortUrls() method.
+    }
+}

--- a/tests/phpunit/integration/Database/CassandraTest.php
+++ b/tests/phpunit/integration/Database/CassandraTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboIntegrationTest\Database;
+
+use Cassandra as CassandraLib,
+    Cassandra\SimpleStatement,
+    Imbo\Database\Cassandra,
+    Imbo\Exception\DatabaseException,
+    Imbo\Resource\Images\Query;
+
+/**
+ * @covers Imbo\Database\Cassandra
+ * @group integration
+ * @group database
+ * @group doctrine
+ */
+class CassandraTest extends DatabaseTests {
+    private $cassandra;
+
+    /**
+     * @see ImboIntegrationTest\Database\DatabaseTests::getAdapter()
+     */
+    protected function getAdapter() {
+        return new Cassandra([
+            'session' => $this->cassandra,
+        ]);
+    }
+
+
+    public function setUp() {
+        if (!extension_loaded('Cassandra')) {
+            $this->markTestSkipped('Cassandra\'s php-driver is required to run this test');
+        }
+
+        $host = !empty($GLOBALS['CASSANDRA_HOST']) ? $GLOBALS['CASSANDRA_HOST'] : '127.0.0.1';
+        $port = !empty($GLOBALS['CASSANDRA_PORT']) ? $GLOBALS['CASSANDRA_PORT'] : 9042;
+
+        // Create tmp tables
+        $server = CassandraLib::cluster()->withContactPoints($host)->withPort($port)->build();
+        $this->cassandra = $server->connect();
+        $this->cassandra->execute(new SimpleStatement("CREATE KEYSPACE IF NOT EXISTS imbo_integration_tests WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"));
+        $this->cassandra = $server->connect('imbo_integration_tests');
+
+        $this->cassandra->execute(new SimpleStatement("
+            CREATE TABLE IF NOT EXISTS imageinfo (
+                user TEXT,
+                imageIdentifier TEXT,
+                size INT,
+                extension TEXT,
+                mime TEXT,
+                added INT,
+                updated INT,
+                width INT,
+                height INT,
+                checksum TEXT,
+                originalChecksum TEXT,
+                metadata map<text, text>,
+                PRIMARY KEY (user, imageIdentifier)
+            ) 
+        "));
+
+        $this->cassandra->execute(new SimpleStatement("
+            CREATE TABLE IF NOT EXISTS shorturl_user (
+                user TEXT,
+                imageIdentifier TEXT,
+                shortUrlId TEXT,
+                PRIMARY KEY ((user, imageIdentifier), shortUrlId)
+            )
+        "));
+
+        $this->cassandra->execute(new SimpleStatement("
+            CREATE TABLE IF NOT EXISTS shorturl (
+                shortUrlId TEXT,
+                extension TEXT,
+                query TEXT,
+                imageIdentifier TEXT,
+                user TEXT,
+                PRIMARY KEY (shortUrlId, extension, query)
+            )
+        "));
+
+        $this->cassandra->execute(new SimpleStatement("
+            CREATE TABLE IF NOT EXISTS usermeta (
+                user TEXT,
+                last_updated TIMESTAMP,
+                PRIMARY KEY (user)                   
+            )
+        "));
+
+        parent::setUp();
+    }
+
+    public function tearDown() {
+        if ($this->cassandra instanceof CassandraLib\Session) {
+            /*$this->cassandra->execute(new SimpleStatement("DROP TABLE IF EXISTS imageinfo"));
+            $this->cassandra->execute(new SimpleStatement("DROP TABLE IF EXISTS shorturl"));
+            $this->cassandra->execute(new SimpleStatement("DROP TABLE IF EXISTS shorturl_user"));
+            $this->cassandra->execute(new SimpleStatement("DROP TABLE IF EXISTS usermeta"));
+            /* */
+
+            $this->cassandra->execute(new SimpleStatement("TRUNCATE TABLE imageinfo"));
+            $this->cassandra->execute(new SimpleStatement("TRUNCATE TABLE shorturl"));
+            $this->cassandra->execute(new SimpleStatement("TRUNCATE TABLE usermeta"));
+            /* */
+        }
+
+        $this->cassandra = null;
+        parent::tearDown();
+    }
+
+    public function testMetadataWithNestedArraysIsRepresetedCorrectly() {
+        $this->markTestSkipped('Cassandra adapter does not retain native types');
+    }
+
+    public function testMetadataWithNestedArraysIsRepresetedCorrectlyWhenFetchingMultipleImages() {
+        $this->markTestSkipped('Cassandra adapter does not retain native types');
+    }
+
+    public function testGetImagesWithNoQuery() {
+        $this->markTestSkipped('Cassandra adapter does not support images querying');
+    }
+
+    public function testGetImagesWithStartAndEndTimestamps() {
+        $this->markTestSkipped('Cassandra adapter does not support querying by start and end times.');
+    }
+
+    public function testGetImagesAndReturnMetadata() {
+        $this->markTestSkipped('Cassandra adapter does not support images querying');
+    }
+
+    public function testGetImagesWithPageAndLimit($page = null, $limit = null, array $imageIdentifiers = []) {
+        $this->markTestSkipped('Cassandra adapter does not support images querying');
+    }
+
+    public function testGetImagesReturnsImagesOnlyForSpecifiedUsers() {
+        $this->markTestSkipped('Cassandra adapter does not support images querying');
+    }
+
+    public function testGetImagesReturnsImagesWithDateTimeInstances() {
+        $this->markTestSkipped('Cassandra adapter does not support images querying');
+    }
+
+    public function testCanFilterOnImageIdentifiers() {
+        $this->markTestSkipped('Cassandra adapter does not support images querying');
+    }
+
+    public function testCanFilterOnChecksums() {
+        $this->markTestSkipped('Cassandra adapter does not support images querying');
+    }
+
+    /**
+     * @dataProvider getSortData
+     */
+    public function testCanSortImages(array $sort = null, $field, array $values) {
+        $this->markTestSkipped('Cassandra adapter does not support images querying');
+    }
+}

--- a/tests/phpunit/integration/Database/DatabaseTests.php
+++ b/tests/phpunit/integration/Database/DatabaseTests.php
@@ -216,8 +216,15 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($this->adapter->insertImage($user, $imageIdentifier, $this->getImage()));
         $this->assertTrue($this->adapter->updateMetadata($user, $imageIdentifier, ['foo' => 'bar']));
         $this->assertSame(['foo' => 'bar'], $this->adapter->getMetadata($user, $imageIdentifier));
-        $this->assertTrue($this->adapter->updateMetadata($user, $imageIdentifier, ['foo' => 'foo', 'bar' => 'foo']));
-        $this->assertSame(['foo' => 'foo', 'bar' => 'foo'], $this->adapter->getMetadata($user, $imageIdentifier));
+
+        $store = ['foo' => 'foo', 'bar' => 'foo'];
+        ksort($store);
+        $this->assertTrue($this->adapter->updateMetadata($user, $imageIdentifier, $store));
+
+        $fetch = $this->adapter->getMetadata($user, $imageIdentifier);
+        ksort($fetch);
+
+        $this->assertSame($store, $fetch);
     }
 
     public function testMetadataWithNestedArraysIsRepresetedCorrectly() {

--- a/tests/phpunit/integration/Database/DatabaseTests.php
+++ b/tests/phpunit/integration/Database/DatabaseTests.php
@@ -132,7 +132,6 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
      */
     public function testDeleteImageThatDoesNotExist() {
         $this->adapter->deleteImage('user', 'id');
-        $this->adapter->deleteImage('user', 'id');
     }
 
     /**

--- a/tests/phpunit/integration/Database/DatabaseTests.php
+++ b/tests/phpunit/integration/Database/DatabaseTests.php
@@ -341,7 +341,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
      *               the first image was added, and the second is the timestamp of when the last
      *               image was added
      */
-    private function insertImages($alternateUser = false) {
+    protected function insertImages($alternateUser = false) {
         $now = time();
         $start = $now;
         $images = [];

--- a/tests/phpunit/integration/Database/DatabaseTests.php
+++ b/tests/phpunit/integration/Database/DatabaseTests.php
@@ -132,6 +132,7 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
      */
     public function testDeleteImageThatDoesNotExist() {
         $this->adapter->deleteImage('user', 'id');
+        $this->adapter->deleteImage('user', 'id');
     }
 
     /**


### PR DESCRIPTION
This Database adapter supports querying Cassandra for images and metadata.

Table definitions will be added as part of the documentation, as well as enabling Cassandra on Travis.

Because of how Cassandra stores its data, the getImages() method has not been implemented as general filtering and field sorting isn't something Cassandra does a good job with. The adapter will be assumed to be used with a separate adapter / search plugin for finding images, instead of using the Cassandra adapter directly.

Since creating of tables are an expensive operation on Cassandra, running the tests when destroying and recreating the tables between each takes a very, very long time, I currently only do a TRUNCATE operation between tests (see the commented out code in CassandraTest).