### PR TITLE
Enable Travis-CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,32 @@
 language: php
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 php:
   - 5.6
   - 7.0
+
 matrix:
   allow_failures:
     - php: 7.0
+
 notifications:
   irc:
     use_notice: true
     skip_join: true
     channels: ["irc.freenode.org#imbo"]
+
 branches:
   only:
     - develop
     - master
     - imbo-3.0
+
 services:
   - mongodb
+
 before_install:
   - sudo add-apt-repository -y ppa:moti-p/cc
   - sudo apt-get update
@@ -24,13 +34,16 @@ before_install:
   - printf "\n" | pecl install --force mongo
   - printf "\n" | pecl install --force mongodb
   - printf "\n" | pecl install imagick-3.4.0RC2
+
 before_script:
   - phpenv config-add tests/travis-php.ini
   - composer self-update
-  - composer -n --no-ansi install --dev --prefer-source
+  - composer install --prefer-dist
+
 script:
   - ./vendor/bin/phpunit --verbose -c tests/phpunit/phpunit.xml.travis
   - ./vendor/bin/behat --strict --profile no-cc --config tests/behat/behat.yml
+
 after_failure:
   - echo "Tests failed - httpd log follows"
   - echo "================================"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   - printf "\n" | pecl install imagick-3.4.0RC2
 
 before_script:
-  - phpenv config-add tests/travis-php.ini
+  - phpenv config-rm xdebug.ini
   - composer self-update
   - composer install --prefer-dist
 

--- a/tests/travis-php.ini
+++ b/tests/travis-php.ini
@@ -1,3 +1,0 @@
-extension=mongo.so
-extension=mongodb.so
-extension=imagick.so


### PR DESCRIPTION
Enable cache on Travis-CI, and prefer dist instead of source to be able to cache packages.