### PR TITLE
Deprecate PDO and the connection instance in Doctrine-based adapters

### DIFF
--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -443,7 +443,7 @@ Examples
 
 Here are some examples on how to use the Doctrine adapter in the configuration file:
 
-1) Use a PDO instance to connect to a SQLite database:
+1) Connect to a SQLite database:
 
 .. code-block:: php
 
@@ -453,14 +453,15 @@ Here are some examples on how to use the Doctrine adapter in the configuration f
 
         'storage' => function() {
             return new Imbo\Storage\Doctrine([
-                'pdo' => new PDO('sqlite:/path/to/database'),
+                'path' => '/path/to/database',
+                'driver' => 'pdo_sqlite',
             ]);
         },
 
         // ...
     ];
 
-2) Connect to a MySQL database using PDO:
+2) Connect to a MySQL database:
 
 .. code-block:: php
 
@@ -480,6 +481,8 @@ Here are some examples on how to use the Doctrine adapter in the configuration f
 
         // ...
     ];
+
+.. warning:: Connecting to a database by specifying a PDO instance in the ``pdo`` element of the configuration array is deprecated as of Imbo v2.3, and will be removed in Imbo v3.
 
 .. _filesystem-storage-adapter:
 

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -236,7 +236,7 @@ Examples
 
 Here are some examples on how to use the Doctrine adapter in the configuration file:
 
-1) Use a `PDO <http://php.net/pdo,>`_ instance to connect to a SQLite database:
+1) Connect to a SQLite database:
 
 .. code-block:: php
 
@@ -246,14 +246,15 @@ Here are some examples on how to use the Doctrine adapter in the configuration f
 
         'database' => function() {
             return new Imbo\Database\Doctrine([
-                'pdo' => new PDO('sqlite:/path/to/database'),
+                'path' => '/path/to/database',
+                'driver' => 'pdo_sqlite',
             ]);
         },
 
         // ...
     ];
 
-2) Connect to a MySQL database using PDO:
+2) Connect to a MySQL database:
 
 .. code-block:: php
 
@@ -273,6 +274,8 @@ Here are some examples on how to use the Doctrine adapter in the configuration f
 
         // ...
     ];
+
+.. warning:: Connecting to a database by specifying a PDO instance in the ``pdo`` element of the configuration array is deprecated as of Imbo v2.3, and will be removed in Imbo v3.
 
 .. _mongodb-database-adapter:
 .. _default-database-adapter:

--- a/docs/installation/event_listeners.rst
+++ b/docs/installation/event_listeners.rst
@@ -420,7 +420,7 @@ The event listener supports for following configuration parameters:
             // ...
         ];
 
-    The Doctrine adapter is an alternative for storing both metadata and variation data. This adapter uses the `Doctrine Database Abstraction Layer <http://www.doctrine-project.org/projects/dbal.html>`_. When using this adapter you need to create the required tables in the RDBMS first, as specified in the :ref:`database-setup` section. Note that you can either pass a PDO instance (as the ``pdo`` parameter) or specify connection details. Example usage:
+    The Doctrine adapter is an alternative for storing both metadata and variation data. This adapter uses the `Doctrine Database Abstraction Layer <http://www.doctrine-project.org/projects/dbal.html>`_. When using this adapter you need to create the required tables in the RDBMS first, as specified in the :ref:`database-setup` section. Example usage:
 
     .. code-block:: php
 
@@ -438,11 +438,8 @@ The event listener supports for following configuration parameters:
                                 'user'      => 'imbo_rw',
                                 'password'  => 'imbo_password',
                                 'host'      => 'localhost',
-                                'driver'    => 'mysql',
-                                'tableName' => 'imagevariations',
-
-                                // OR, pass a PDO instance
-                                'pdo'       => null,
+                                'driver'    => 'pdo_mysql',
+                                'tableName' => 'imagevariations', // Default value, can be omitted
                             ]
                         ],
                         'storage' => [
@@ -455,6 +452,8 @@ The event listener supports for following configuration parameters:
 
             // ...
         ];
+
+    .. warning:: Connecting to a database by specifying a PDO instance in the ``pdo`` element of the configuration array is deprecated as of Imbo v2.3, and will be removed in Imbo v3.
 
     The third option for the storage adapter is the Filesystem adapter. It's fairly straightforward and uses a similar algorithm when generating file names as the :ref:`filesystem-storage-adapter` storage adapter. Example usage:
 

--- a/library/Imbo/Database/Doctrine.php
+++ b/library/Imbo/Database/Doctrine.php
@@ -27,14 +27,6 @@ use Imbo\Model\Image,
 /**
  * Doctrine 2 database driver
  *
- * Parameters for this driver:
- *
- * - <pre>(string) dbname</pre> Name of the database to connect to
- * - <pre>(string) user</pre> Username to use when connecting
- * - <pre>(string) password</pre> Password to use when connecting
- * - <pre>(string) host</pre> Hostname to use when connecting
- * - <pre>(string) driver</pre> Which driver to use
- *
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Database
  */
@@ -44,13 +36,7 @@ class Doctrine implements DatabaseInterface {
      *
      * @var array
      */
-    private $params = [
-        'dbname'   => null,
-        'user'     => null,
-        'password' => null,
-        'host'     => null,
-        'driver'   => null,
-    ];
+    private $params = [];
 
     /**
      * Default table names for the database
@@ -84,9 +70,26 @@ class Doctrine implements DatabaseInterface {
      * @param Connection $connection Optional connection instance. Primarily used for testing
      */
     public function __construct(array $params, Connection $connection = null) {
-        $this->params = array_merge($this->params, $params);
+        $this->params = $params;
+
+        if (isset($this->params['pdo'])) {
+            trigger_error(
+                sprintf(
+                    'The usage of pdo in the configuration array for %s is deprecated and will be removed in Imbo-3.x',
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
+        }
 
         if ($connection !== null) {
+            trigger_error(
+                sprintf(
+                    'Specifying a connection instance in %s is deprecated and will be removed in Imbo-3.x',
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
             $this->setConnection($connection);
         }
     }

--- a/library/Imbo/Database/Doctrine.php
+++ b/library/Imbo/Database/Doctrine.php
@@ -27,6 +27,8 @@ use Imbo\Model\Image,
 /**
  * Doctrine 2 database driver
  *
+ * Refer to http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest for configuration parameters
+ *
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Database
  */

--- a/library/Imbo/EventListener/ImageVariations/Database/Doctrine.php
+++ b/library/Imbo/EventListener/ImageVariations/Database/Doctrine.php
@@ -18,15 +18,6 @@ use Doctrine\DBAL\Configuration,
 /**
  * Doctrine 2 database driver for the image variations
  *
- * Valid parameters for this driver:
- *
- * - <pre>(string) dbname</pre> Name of the database to connect to
- * - <pre>(string) user</pre> Username to use when connecting
- * - <pre>(string) password</pre> Password to use when connecting
- * - <pre>(string) host</pre> Hostname to use when connecting
- * - <pre>(string) driver</pre> Which driver to use
- * - <pre>(PDO) pdo</pre> PDO adapter to use, as an alternative to specifying the above
- *
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  * @package Database
  */
@@ -37,12 +28,6 @@ class Doctrine implements DatabaseInterface {
      * @var array
      */
     private $params = [
-        'dbname'    => null,
-        'user'      => null,
-        'password'  => null,
-        'host'      => null,
-        'driver'    => null,
-        'pdo'       => null,
         'tableName' => 'imagevariations',
     ];
 
@@ -59,12 +44,27 @@ class Doctrine implements DatabaseInterface {
      * @param array $params Parameters for the driver
      * @param Connection $connection Optional connection instance
      */
-    public function __construct(array $params = null, Connection $connection = null) {
-        if ($params !== null) {
-            $this->params = array_merge($this->params, $params);
+    public function __construct(array $params, Connection $connection = null) {
+        $this->params = array_merge($this->params, $params);
+
+        if (isset($this->params['pdo'])) {
+            trigger_error(
+                sprintf(
+                    'The usage of pdo in the configuration array for %s is deprecated and will be removed in Imbo-3.x',
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
         }
 
         if ($connection !== null) {
+            trigger_error(
+                sprintf(
+                    'Specifying a connection instance in %s is deprecated and will be removed in Imbo-3.x',
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
             $this->setConnection($connection);
         }
     }

--- a/library/Imbo/EventListener/ImageVariations/Database/Doctrine.php
+++ b/library/Imbo/EventListener/ImageVariations/Database/Doctrine.php
@@ -18,6 +18,8 @@ use Doctrine\DBAL\Configuration,
 /**
  * Doctrine 2 database driver for the image variations
  *
+ * Refer to http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest for configuration parameters
+ *
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  * @package Database
  */

--- a/library/Imbo/EventListener/ImageVariations/Storage/Doctrine.php
+++ b/library/Imbo/EventListener/ImageVariations/Storage/Doctrine.php
@@ -17,6 +17,8 @@ use Doctrine\DBAL\Configuration,
 /**
  * Doctrine 2 image variations storage driver
  *
+ * Refer to http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest for configuration parameters
+ *
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  * @package Storage
  */

--- a/library/Imbo/EventListener/ImageVariations/Storage/Doctrine.php
+++ b/library/Imbo/EventListener/ImageVariations/Storage/Doctrine.php
@@ -17,14 +17,6 @@ use Doctrine\DBAL\Configuration,
 /**
  * Doctrine 2 image variations storage driver
  *
- * Parameters for this driver:
- *
- * - <pre>(string) dbname</pre> Name of the database to connect to
- * - <pre>(string) user</pre> Username to use when connecting
- * - <pre>(string) password</pre> Password to use when connecting
- * - <pre>(string) host</pre> Hostname to use when connecting
- * - <pre>(string) driver</pre> Which driver to use
- *
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  * @package Storage
  */
@@ -34,13 +26,7 @@ class Doctrine implements StorageInterface {
      *
      * @var array
      */
-    private $params = [
-        'dbname'   => null,
-        'user'     => null,
-        'password' => null,
-        'host'     => null,
-        'driver'   => null,
-    ];
+    private $params = [];
 
     /**
      * Name of the table used for storing the images
@@ -63,9 +49,26 @@ class Doctrine implements StorageInterface {
      * @param \Doctrine\DBAL\Connection $connection Optional connection instance
      */
     public function __construct(array $params, Connection $connection = null) {
-        $this->params = array_merge($this->params, $params);
+        $this->params = $params;
+
+        if (isset($this->params['pdo'])) {
+            trigger_error(
+                sprintf(
+                    'The usage of pdo in the configuration array for %s is deprecated and will be removed in Imbo-3.x',
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
+        }
 
         if ($connection !== null) {
+            trigger_error(
+                sprintf(
+                    'Specifying a connection instance in %s is deprecated and will be removed in Imbo-3.x',
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
             $this->setConnection($connection);
         }
     }

--- a/library/Imbo/Storage/Doctrine.php
+++ b/library/Imbo/Storage/Doctrine.php
@@ -21,6 +21,8 @@ use Imbo\Exception\StorageException,
 /**
  * Doctrine 2 storage driver
  *
+ * Refer to http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest for configuration parameters
+ *
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Storage
  */

--- a/library/Imbo/Storage/Doctrine.php
+++ b/library/Imbo/Storage/Doctrine.php
@@ -21,14 +21,6 @@ use Imbo\Exception\StorageException,
 /**
  * Doctrine 2 storage driver
  *
- * Parameters for this driver:
- *
- * - <pre>(string) dbname</pre> Name of the database to connect to
- * - <pre>(string) user</pre> Username to use when connecting
- * - <pre>(string) password</pre> Password to use when connecting
- * - <pre>(string) host</pre> Hostname to use when connecting
- * - <pre>(string) driver</pre> Which driver to use
- *
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Storage
  */
@@ -38,13 +30,7 @@ class Doctrine implements StorageInterface {
      *
      * @var array
      */
-    private $params = [
-        'dbname'   => null,
-        'user'     => null,
-        'password' => null,
-        'host'     => null,
-        'driver'   => null,
-    ];
+    private $params = [];
 
     /**
      * Name of the table used for storing the images
@@ -68,9 +54,26 @@ class Doctrine implements StorageInterface {
      *                                              for testing
      */
     public function __construct(array $params, Connection $connection = null) {
-        $this->params = array_merge($this->params, $params);
+        $this->params = $params;
+
+        if (isset($this->params['pdo'])) {
+            trigger_error(
+                sprintf(
+                    'The usage of pdo in the configuration array for %s is deprecated and will be removed in Imbo-3.x',
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
+        }
 
         if ($connection !== null) {
+            trigger_error(
+                sprintf(
+                    'Specifying a connection instance in %s is deprecated and will be removed in Imbo-3.x',
+                    __CLASS__
+                ),
+                E_USER_DEPRECATED
+            );
             $this->setConnection($connection);
         }
     }

--- a/tests/phpunit/ImboIntegrationTest/Database/DoctrineTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Database/DoctrineTest.php
@@ -25,7 +25,7 @@ class DoctrineTest extends DatabaseTests {
      *
      * @var string
      */
-    private $dbPath = '/tmp/imbo-database-doctrine-integration-test.sql';
+    private $dbPath;
 
     /**
      * @see ImboIntegrationTest\Database\DatabaseTests::getAdapter()
@@ -49,6 +49,8 @@ class DoctrineTest extends DatabaseTests {
         if (!class_exists('Doctrine\DBAL\DriverManager')) {
             $this->markTestSkipped('Doctrine is required to run this test');
         }
+
+        $this->dbPath = tempnam(sys_get_temp_dir(), 'imbo-integration-test');
 
         // Create tmp tables
         $pdo = new PDO(sprintf('sqlite:%s', $this->dbPath));
@@ -100,5 +102,13 @@ class DoctrineTest extends DatabaseTests {
         ");
 
         parent::setUp();
+    }
+
+    /**
+     * Remove the database file
+     */
+    public function tearDown() {
+        unlink($this->dbPath);
+        parent::tearDown();
     }
 }

--- a/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Database/DoctrineTest.php
+++ b/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Database/DoctrineTest.php
@@ -21,16 +21,19 @@ use Imbo\EventListener\ImageVariations\Database\Doctrine,
  */
 class DoctrineTest extends DatabaseTests {
     /**
-     * @var PDO
+     * Path to the database file
+     *
+     * @var string
      */
-    private $pdo;
+    private $dbPath = '/tmp/imbo-eventlistener-imagevariations-database-integration-test.sql';
 
     /**
      * @see ImboIntegrationTest\EventListener\ImageVariations\Database\DatabaseTests::getAdapter()
      */
     protected function getAdapter() {
         return new Doctrine([
-            'pdo' => $this->pdo,
+            'path' => $this->dbPath,
+            'driver' => 'pdo_sqlite',
         ]);
     }
 
@@ -52,9 +55,10 @@ class DoctrineTest extends DatabaseTests {
         }
 
         // Create tmp tables
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->query('
-            CREATE TABLE IF NOT EXISTS imagevariations (
+        $pdo = new PDO(sprintf('sqlite:%s', $this->dbPath));
+        $pdo->query("DROP TABLE IF EXISTS imagevariations");
+        $pdo->query('
+            CREATE TABLE imagevariations (
                 user TEXT NOT NULL,
                 imageIdentifier TEXT NOT NULL,
                 width INTEGER NOT NULL,
@@ -65,17 +69,5 @@ class DoctrineTest extends DatabaseTests {
         ');
 
         parent::setUp();
-    }
-
-    /**
-     * Clean up after each run
-     */
-    public function tearDown() {
-        if ($this->pdo) {
-            $this->pdo->query('DROP TABLE IF EXISTS imagevariations');
-            $this->pdo = null;
-        }
-
-        parent::tearDown();
     }
 }

--- a/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Database/DoctrineTest.php
+++ b/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Database/DoctrineTest.php
@@ -25,7 +25,7 @@ class DoctrineTest extends DatabaseTests {
      *
      * @var string
      */
-    private $dbPath = '/tmp/imbo-eventlistener-imagevariations-database-integration-test.sql';
+    private $dbPath;
 
     /**
      * @see ImboIntegrationTest\EventListener\ImageVariations\Database\DatabaseTests::getAdapter()
@@ -54,6 +54,8 @@ class DoctrineTest extends DatabaseTests {
             $this->markTestSkipped('Doctrine is required to run this test');
         }
 
+        $this->dbPath = tempnam(sys_get_temp_dir(), 'imbo-integration-test');
+
         // Create tmp tables
         $pdo = new PDO(sprintf('sqlite:%s', $this->dbPath));
         $pdo->query("DROP TABLE IF EXISTS imagevariations");
@@ -69,5 +71,13 @@ class DoctrineTest extends DatabaseTests {
         ');
 
         parent::setUp();
+    }
+
+    /**
+     * Remove the database file
+     */
+    public function tearDown() {
+        unlink($this->dbPath);
+        parent::tearDown();
     }
 }

--- a/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Storage/DoctrineTest.php
@@ -25,7 +25,7 @@ class DoctrineTest extends StorageTests {
      *
      * @var string
      */
-    private $dbPath = '/tmp/imbo-eventlistener-imagevariations-storage-doctrine-integration-test.sql';
+    private $dbPath;
 
     /**
      * @see ImboIntegrationTest\EventListener\ImageVariations\Storage\StorageTests::getAdapter()
@@ -53,6 +53,8 @@ class DoctrineTest extends StorageTests {
             $this->markTestSkipped('Doctrine is required to run this test');
         }
 
+        $this->dbPath = tempnam(sys_get_temp_dir(), 'imbo-integration-test');
+
         // Create tmp tables
         $pdo = new PDO(sprintf('sqlite:%s', $this->dbPath));
         $pdo->query("DROP TABLE IF EXISTS storage_image_variations");
@@ -67,5 +69,13 @@ class DoctrineTest extends StorageTests {
         ');
 
         parent::setUp();
+    }
+
+    /**
+     * Remove the database file
+     */
+    public function tearDown() {
+        unlink($this->dbPath);
+        parent::tearDown();
     }
 }

--- a/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Storage/DoctrineTest.php
@@ -21,16 +21,19 @@ use Imbo\EventListener\ImageVariations\Storage\Doctrine,
  */
 class DoctrineTest extends StorageTests {
     /**
-     * @var PDO
+     * Path to the database file
+     *
+     * @var string
      */
-    private $pdo;
+    private $dbPath = '/tmp/imbo-eventlistener-imagevariations-storage-doctrine-integration-test.sql';
 
     /**
      * @see ImboIntegrationTest\EventListener\ImageVariations\Storage\StorageTests::getAdapter()
      */
     protected function getAdapter() {
         return new Doctrine([
-            'pdo' => $this->pdo,
+            'path' => $this->dbPath,
+            'driver' => 'pdo_sqlite',
         ]);
     }
 
@@ -51,8 +54,9 @@ class DoctrineTest extends StorageTests {
         }
 
         // Create tmp tables
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->query('
+        $pdo = new PDO(sprintf('sqlite:%s', $this->dbPath));
+        $pdo->query("DROP TABLE IF EXISTS storage_image_variations");
+        $pdo->query('
             CREATE TABLE storage_image_variations (
                 user TEXT NOT NULL,
                 imageIdentifier TEXT NOT NULL,
@@ -63,14 +67,5 @@ class DoctrineTest extends StorageTests {
         ');
 
         parent::setUp();
-    }
-
-    /**
-     * Reset PDO instance after each test
-     */
-    public function tearDown() {
-        $this->pdo = null;
-
-        parent::tearDown();
     }
 }

--- a/tests/phpunit/ImboIntegrationTest/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Storage/DoctrineTest.php
@@ -25,8 +25,7 @@ class DoctrineTest extends StorageTests {
      *
      * @var string
      */
-    private $dbPath = '/tmp/imbo-storage-doctrine-integration-test.sql';
-
+    private $dbPath;
 
     /**
      * @see ImboIntegrationTest\Storage\StorageTests::getDriver()
@@ -51,6 +50,8 @@ class DoctrineTest extends StorageTests {
             $this->markTestSkipped('Doctrine is required to run this test');
         }
 
+        $this->dbPath = tempnam(sys_get_temp_dir(), 'imbo-integration-test');
+
         // Create tmp tables
         $pdo = new PDO(sprintf('sqlite:%s', $this->dbPath));
         $pdo->query("DROP TABLE IF EXISTS storage_images");
@@ -65,5 +66,13 @@ class DoctrineTest extends StorageTests {
         ");
 
         parent::setUp();
+    }
+
+    /**
+     * Remove the database file
+     */
+    public function tearDown() {
+        unlink($this->dbPath);
+        parent::tearDown();
     }
 }

--- a/tests/phpunit/ImboIntegrationTest/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Storage/DoctrineTest.php
@@ -21,16 +21,20 @@ use Imbo\Storage\Doctrine,
  */
 class DoctrineTest extends StorageTests {
     /**
-     * @var PDO
+     * Path to the database file
+     *
+     * @var string
      */
-    private $pdo;
+    private $dbPath = '/tmp/imbo-storage-doctrine-integration-test.sql';
+
 
     /**
      * @see ImboIntegrationTest\Storage\StorageTests::getDriver()
      */
     protected function getDriver() {
         return new Doctrine([
-            'pdo' => $this->pdo,
+            'path' => $this->dbPath,
+            'driver' => 'pdo_sqlite',
         ]);
     }
 
@@ -48,8 +52,9 @@ class DoctrineTest extends StorageTests {
         }
 
         // Create tmp tables
-        $this->pdo = new PDO('sqlite::memory:');
-        $this->pdo->query("
+        $pdo = new PDO(sprintf('sqlite:%s', $this->dbPath));
+        $pdo->query("DROP TABLE IF EXISTS storage_images");
+        $pdo->query("
             CREATE TABLE storage_images (
                 user TEXT NOT NULL,
                 imageIdentifier TEXT NOT NULL,
@@ -60,11 +65,5 @@ class DoctrineTest extends StorageTests {
         ");
 
         parent::setUp();
-    }
-
-    public function tearDown() {
-        $this->pdo = null;
-
-        parent::tearDown();
     }
 }

--- a/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Database/DoctrineTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Database/DoctrineTest.php
@@ -11,6 +11,8 @@
 namespace ImboUnitTest\EventListener\ImageVariations\Database;
 
 use Imbo\EventListener\ImageVariations\Database\Doctrine;
+use Doctrine\DBAL\DriverManager;
+use PDO;
 
 /**
  * @covers Imbo\EventListener\ImageVariations\Database\Doctrine
@@ -20,15 +22,18 @@ use Imbo\EventListener\ImageVariations\Database\Doctrine;
  */
 class DoctrineTest extends \PHPUnit_Framework_TestCase {
     /**
-     * @covers Imbo\EventListener\ImageVariations\Database\Doctrine::__construct
-     * @covers Imbo\EventListener\ImageVariations\Database\Doctrine::setConnection
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     * @expectedExceptionMessage The usage of pdo in the configuration array for Imbo\EventListener\ImageVariations\Database\Doctrine is deprecated and will be removed in Imbo-3.x
      */
-    public function testCanSetConnection() {
-        $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('insert')->will($this->returnValue(false));
+    public function testUsageOfPdoInParametersIsDeprecated() {
+        new Doctrine(['pdo' => new PDO('sqlite::memory:')]);
+    }
 
-        $adapter = new Doctrine([], $connection);
-
-        $this->assertFalse($adapter->storeImageVariationMetadata('key', 'img', 1337, 1942));
+    /**
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     * @expectedExceptionMessage Specifying a connection instance in Imbo\EventListener\ImageVariations\Database\Doctrine is deprecated and will be removed in Imbo-3.x
+     */
+    public function testUsageOfConnectionInConstructor() {
+        new Doctrine([], DriverManager::getConnection(['pdo' => new PDO('sqlite::memory:')]));
     }
 }

--- a/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Storage/DoctrineTest.php
@@ -11,6 +11,8 @@
 namespace ImboUnitTest\EventListener\ImageVariations\Storage;
 
 use Imbo\EventListener\ImageVariations\Storage\Doctrine;
+use PDO;
+use Doctrine\DBAL\DriverManager;
 
 /**
  * @covers Imbo\EventListener\ImageVariations\Storage\Doctrine
@@ -20,14 +22,18 @@ use Imbo\EventListener\ImageVariations\Storage\Doctrine;
  */
 class DoctrineTest extends \PHPUnit_Framework_TestCase {
     /**
-     * @covers Imbo\EventListener\ImageVariations\Storage\Doctrine::__construct
-     * @covers Imbo\EventListener\ImageVariations\Storage\Doctrine::setConnection
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     * @expectedExceptionMessage The usage of pdo in the configuration array for Imbo\EventListener\ImageVariations\Storage\Doctrine is deprecated and will be removed in Imbo-3.x
      */
-    public function testCanSetConnection() {
-        $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
-        $connection->expects($this->once())->method('insert')->will($this->returnValue(false));
+    public function testUsageOfPdoInParametersIsDeprecated() {
+        new Doctrine(['pdo' => new PDO('sqlite::memory:')]);
+    }
 
-        $adapter = new Doctrine([], $connection);
-        $this->assertFalse($adapter->storeImageVariation('key', 'img', 'blob', 1942));
+    /**
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     * @expectedExceptionMessage Specifying a connection instance in Imbo\EventListener\ImageVariations\Storage\Doctrine is deprecated and will be removed in Imbo-3.x
+     */
+    public function testUsageOfConnectionInConstructor() {
+        new Doctrine([], DriverManager::getConnection(['pdo' => new PDO('sqlite::memory:')]));
     }
 }

--- a/tests/phpunit/ImboUnitTest/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboUnitTest/Storage/DoctrineTest.php
@@ -11,7 +11,8 @@
 namespace ImboUnitTest\Storage;
 
 use Imbo\Storage\Doctrine,
-    Doctrine\DBAL\Connection;
+    Doctrine\DBAL\DriverManager,
+    PDO;
 
 /**
  * @covers Imbo\Storage\Doctrine
@@ -21,80 +22,18 @@ use Imbo\Storage\Doctrine,
  */
 class DoctrineTest extends \PHPUnit_Framework_TestCase {
     /**
-     * @var Doctrine
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     * @expectedExceptionMessage The usage of pdo in the configuration array for Imbo\Storage\Doctrine is deprecated and will be removed in Imbo-3.x
      */
-    private $driver;
-
-    /**
-     * @var Connection
-     */
-    private $connection;
-
-    /**
-     * @var string
-     */
-    private $user = 'key';
-
-    /**
-     * Set up the driver
-     */
-    public function setUp() {
-        if (!class_exists('Doctrine\DBAL\Connection')) {
-            $this->markTestSkipped('Doctrine is required to run this test');
-        }
-
-        $this->connection = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
-        $this->driver = new Doctrine([], $this->connection);
+    public function testUsageOfPdoInParametersIsDeprecated() {
+        new Doctrine(['pdo' => new PDO('sqlite::memory:')]);
     }
 
     /**
-     * Tear down the driver
+     * @expectedException PHPUnit_Framework_Error_Deprecated
+     * @expectedExceptionMessage Specifying a connection instance in Imbo\Storage\Doctrine is deprecated and will be removed in Imbo-3.x
      */
-    public function tearDown() {
-        $this->connection = null;
-        $this->driver = null;
-    }
-
-    /**
-     * @covers Imbo\Storage\Doctrine::store
-     * @expectedException Imbo\Exception\StorageException
-     * @expectedExceptionCode 500
-     */
-    public function testStoreExceptionOnInsertFailure() {
-        $this->connection->expects($this->once())->method('insert')->will($this->returnValue(0));
-
-        $driverMock = $this->getMockBuilder('Imbo\Storage\Doctrine')
-            ->setConstructorArgs(array([], $this->connection))
-            ->setMethods(array('imageExists'))
-            ->getMock();
-
-        $driverMock->expects($this->once())->method('imageExists')->will($this->returnValue(false));
-        $driverMock->store($this->user, 'image_identifier_not_used', 'image_data_not_used');
-    }
-
-    /**
-     * @covers Imbo\Storage\Doctrine::getStatus
-     */
-    public function testGetStatusWhenDatabaseIsAlreadyConnected() {
-        $this->connection->expects($this->once())->method('isConnected')->will($this->returnValue(true));
-        $this->assertTrue($this->driver->getStatus());
-    }
-
-    /**
-     * @covers Imbo\Storage\Doctrine::getStatus
-     */
-    public function testGetStatusWhenDatabaseIsNotConnectedAndCanConnect() {
-        $this->connection->expects($this->once())->method('isConnected')->will($this->returnValue(false));
-        $this->connection->expects($this->once())->method('connect')->will($this->returnValue(true));
-        $this->assertTrue($this->driver->getStatus());
-    }
-
-    /**
-     * @covers Imbo\Storage\Doctrine::getStatus
-     */
-    public function testGetStatusWhenDatabaseIsNotConnectedAndCanNotConnect() {
-        $this->connection->expects($this->once())->method('isConnected')->will($this->returnValue(false));
-        $this->connection->expects($this->once())->method('connect')->will($this->returnValue(false));
-        $this->assertFalse($this->driver->getStatus());
+    public function testUsageOfConnectionInConstructor() {
+        new Doctrine([], DriverManager::getConnection(['pdo' => new PDO('sqlite::memory:')]));
     }
 }


### PR DESCRIPTION
This will deprecated the use of PDO directly, and the use of the connection instance in Doctrine-based adapters.

Before the pull request can be merged the following tasks must be finished:

- [x] Fix `Imbo\Database\Doctrine` (675a64b3f73439d3e4406ae3a7722de51da02b7c)
- [x] Fix `Imbo\Storage\Doctrine` (435248aa0358929da30c28572d9b0106c23bd5ab)
- [x] Fix `Imbo\EventListener\ImageVariations\Storage\Doctrine` (3d5483b85c1f50a7946cffb77f5a79d0dc06922e)
- [x] Fix `Imbo\EventListener\ImageVariations\Database\Doctrine` (99cdf558d456ddc4db12269ed579dcab5b3f0708)
- [x] Update docs

Resolves #534.