### PR TITLE
Mark the Doctrine-based storage adapters as deprecated

### DIFF
--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -433,8 +433,10 @@ Examples
         // ...
     ];
 
-Doctrine
-++++++++
+Doctrine (deprecated)
++++++++++++++++++++++
+
+.. warning:: This adapter is deprecated as of Imbo v2.3, and will be removed in Imbo v3.
 
 This adapter uses the `Doctrine Database Abstraction Layer <http://www.doctrine-project.org/projects/dbal.html>`_. The options you pass to the constructor of this adapter is passed to the underlying classes, so have a look at the Doctrine DBAL documentation over at `doctrine-project.org <http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/index.html>`_. When using this adapter you need to create the required tables in the RDBMS first, as specified in the :ref:`database-setup` section.
 
@@ -481,8 +483,6 @@ Here are some examples on how to use the Doctrine adapter in the configuration f
 
         // ...
     ];
-
-.. warning:: Connecting to a database by specifying a PDO instance in the ``pdo`` element of the configuration array is deprecated as of Imbo v2.3, and will be removed in Imbo v3.
 
 .. _filesystem-storage-adapter:
 

--- a/docs/installation/event_listeners.rst
+++ b/docs/installation/event_listeners.rst
@@ -271,7 +271,7 @@ The event listener has two roles, one is to generate the variations when new ima
 
 Imbo ships with MongoDB and Doctrine adapters for storing metadata about these variations. If you want to use a different database, you can implement the ``Imbo\EventListener\ImageVariations\Database\DatabaseInterface`` interface and set the name of the class in the configuration of the event listener.
 
-In the same way, Imbo ships three different adapters for storing the actual image variation data (the downscaled images): GridFS, Doctrine and Filesystem. See examples of their configuration below.
+In the same way, Imbo ships three different adapters for storing the actual image variation data (the downscaled images): GridFS, Doctrine (deprecated) and Filesystem. See examples of their configuration below.
 
 The event listener supports for following configuration parameters:
 
@@ -454,6 +454,7 @@ The event listener supports for following configuration parameters:
         ];
 
     .. warning:: Connecting to a database by specifying a PDO instance in the ``pdo`` element of the configuration array is deprecated as of Imbo v2.3, and will be removed in Imbo v3.
+    .. warning:: The Doctrine-based storage adapter is deprecated as of Imbo v2.3, and will be removed in Imbo v3.
 
     The third option for the storage adapter is the Filesystem adapter. It's fairly straightforward and uses a similar algorithm when generating file names as the :ref:`filesystem-storage-adapter` storage adapter. Example usage:
 

--- a/library/Imbo/EventListener/ImageVariations/Storage/Doctrine.php
+++ b/library/Imbo/EventListener/ImageVariations/Storage/Doctrine.php
@@ -53,24 +53,15 @@ class Doctrine implements StorageInterface {
     public function __construct(array $params, Connection $connection = null) {
         $this->params = $params;
 
-        if (isset($this->params['pdo'])) {
-            trigger_error(
-                sprintf(
-                    'The usage of pdo in the configuration array for %s is deprecated and will be removed in Imbo-3.x',
-                    __CLASS__
-                ),
-                E_USER_DEPRECATED
-            );
-        }
+        trigger_error(
+            sprintf(
+                'The %s adapter is deprectaed and will be removed in Imbo-3.x',
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
 
         if ($connection !== null) {
-            trigger_error(
-                sprintf(
-                    'Specifying a connection instance in %s is deprecated and will be removed in Imbo-3.x',
-                    __CLASS__
-                ),
-                E_USER_DEPRECATED
-            );
             $this->setConnection($connection);
         }
     }

--- a/library/Imbo/EventListener/ImageVariations/Storage/Doctrine.php
+++ b/library/Imbo/EventListener/ImageVariations/Storage/Doctrine.php
@@ -55,7 +55,7 @@ class Doctrine implements StorageInterface {
 
         trigger_error(
             sprintf(
-                'The %s adapter is deprectaed and will be removed in Imbo-3.x',
+                'The %s adapter is deprecated and will be removed in Imbo-3.x',
                 __CLASS__
             ),
             E_USER_DEPRECATED

--- a/library/Imbo/Storage/Doctrine.php
+++ b/library/Imbo/Storage/Doctrine.php
@@ -58,24 +58,15 @@ class Doctrine implements StorageInterface {
     public function __construct(array $params, Connection $connection = null) {
         $this->params = $params;
 
-        if (isset($this->params['pdo'])) {
-            trigger_error(
-                sprintf(
-                    'The usage of pdo in the configuration array for %s is deprecated and will be removed in Imbo-3.x',
-                    __CLASS__
-                ),
-                E_USER_DEPRECATED
-            );
-        }
+        trigger_error(
+            sprintf(
+                'The %s adapter is deprecated and will be removed in Imbo-3.x',
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
 
         if ($connection !== null) {
-            trigger_error(
-                sprintf(
-                    'Specifying a connection instance in %s is deprecated and will be removed in Imbo-3.x',
-                    __CLASS__
-                ),
-                E_USER_DEPRECATED
-            );
             $this->setConnection($connection);
         }
     }

--- a/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboIntegrationTest/EventListener/ImageVariations/Storage/DoctrineTest.php
@@ -31,10 +31,16 @@ class DoctrineTest extends StorageTests {
      * @see ImboIntegrationTest\EventListener\ImageVariations\Storage\StorageTests::getAdapter()
      */
     protected function getAdapter() {
-        return new Doctrine([
+        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
+
+        $adapter = @new Doctrine([
             'path' => $this->dbPath,
             'driver' => 'pdo_sqlite',
         ]);
+
+        \PHPUnit_Framework_Error_Deprecated::$enabled = true;
+
+        return $adapter;
     }
 
     /**

--- a/tests/phpunit/ImboIntegrationTest/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Storage/DoctrineTest.php
@@ -31,10 +31,16 @@ class DoctrineTest extends StorageTests {
      * @see ImboIntegrationTest\Storage\StorageTests::getDriver()
      */
     protected function getDriver() {
-        return new Doctrine([
+        \PHPUnit_Framework_Error_Deprecated::$enabled = false;
+
+        $adapter = @new Doctrine([
             'path' => $this->dbPath,
             'driver' => 'pdo_sqlite',
         ]);
+
+        \PHPUnit_Framework_Error_Deprecated::$enabled = true;
+
+        return $adapter;
     }
 
     public function setUp() {

--- a/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Storage/DoctrineTest.php
@@ -23,7 +23,7 @@ use Doctrine\DBAL\DriverManager;
 class DoctrineTest extends \PHPUnit_Framework_TestCase {
     /**
      * @expectedException PHPUnit_Framework_Error_Deprecated
-     * @expectedExceptionMessage The Imbo\EventListener\ImageVariations\Storage\Doctrine adapter is deprectaed and will be removed in Imbo-3.x
+     * @expectedExceptionMessage The Imbo\EventListener\ImageVariations\Storage\Doctrine adapter is deprecated and will be removed in Imbo-3.x
      */
     public function testAdapterIsDeprecated() {
         new Doctrine([]);

--- a/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboUnitTest/EventListener/ImageVariations/Storage/DoctrineTest.php
@@ -23,17 +23,9 @@ use Doctrine\DBAL\DriverManager;
 class DoctrineTest extends \PHPUnit_Framework_TestCase {
     /**
      * @expectedException PHPUnit_Framework_Error_Deprecated
-     * @expectedExceptionMessage The usage of pdo in the configuration array for Imbo\EventListener\ImageVariations\Storage\Doctrine is deprecated and will be removed in Imbo-3.x
+     * @expectedExceptionMessage The Imbo\EventListener\ImageVariations\Storage\Doctrine adapter is deprectaed and will be removed in Imbo-3.x
      */
-    public function testUsageOfPdoInParametersIsDeprecated() {
-        new Doctrine(['pdo' => new PDO('sqlite::memory:')]);
-    }
-
-    /**
-     * @expectedException PHPUnit_Framework_Error_Deprecated
-     * @expectedExceptionMessage Specifying a connection instance in Imbo\EventListener\ImageVariations\Storage\Doctrine is deprecated and will be removed in Imbo-3.x
-     */
-    public function testUsageOfConnectionInConstructor() {
-        new Doctrine([], DriverManager::getConnection(['pdo' => new PDO('sqlite::memory:')]));
+    public function testAdapterIsDeprecated() {
+        new Doctrine([]);
     }
 }

--- a/tests/phpunit/ImboUnitTest/Storage/DoctrineTest.php
+++ b/tests/phpunit/ImboUnitTest/Storage/DoctrineTest.php
@@ -23,17 +23,9 @@ use Imbo\Storage\Doctrine,
 class DoctrineTest extends \PHPUnit_Framework_TestCase {
     /**
      * @expectedException PHPUnit_Framework_Error_Deprecated
-     * @expectedExceptionMessage The usage of pdo in the configuration array for Imbo\Storage\Doctrine is deprecated and will be removed in Imbo-3.x
+     * @expectedExceptionMessage The Imbo\Storage\Doctrine adapter is deprecated and will be removed in Imbo-3.x
      */
-    public function testUsageOfPdoInParametersIsDeprecated() {
-        new Doctrine(['pdo' => new PDO('sqlite::memory:')]);
-    }
-
-    /**
-     * @expectedException PHPUnit_Framework_Error_Deprecated
-     * @expectedExceptionMessage Specifying a connection instance in Imbo\Storage\Doctrine is deprecated and will be removed in Imbo-3.x
-     */
-    public function testUsageOfConnectionInConstructor() {
-        new Doctrine([], DriverManager::getConnection(['pdo' => new PDO('sqlite::memory:')]));
+    public function testAdapterIsDeprecated() {
+        new Doctrine([]);
     }
 }


### PR DESCRIPTION
This PR will mark the Doctrine-based storage adapters as deprecated as these will be completely removed in Imbo v3.