### PR TITLE
Make Travis-CI builds for Imbo-2.x great again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
   only:
     - develop
     - master
+    - imbo-2.x
 services:
   - mongodb
   - memcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ before_install:
   - sudo add-apt-repository -y ppa:moti-p/cc
   - sudo apt-get update
   - sudo apt-get -y --reinstall install imagemagick
-  - printf "\n" | pecl install mongo-1.6.14
-  - printf "\n" | pecl install memcached-2.2.0
-  - printf "\n" | pecl install imagick-3.4.3
+  - printf "\n" | pecl install mongo-1.6
+  - printf "\n" | pecl install memcached-2.2
+  - printf "\n" | pecl install imagick-3.4
   - pecl list
 before_script:
   - phpenv config-add tests/travis-php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 before_script:
   - phpenv config-add tests/travis-php.ini
   - composer self-update
-  - composer -n --no-ansi install --dev --prefer-source
+  - composer -n install --prefer-source
 script:
   - ./vendor/bin/phpunit --verbose -c tests/phpunit/phpunit.xml.travis
   - ./vendor/bin/behat --strict --profile no-cc --config tests/behat/behat.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ before_install:
   - sudo add-apt-repository -y ppa:moti-p/cc
   - sudo apt-get update
   - sudo apt-get -y --reinstall install imagemagick
-  - printf "\n" | pecl install mongo-1.6
-  - printf "\n" | pecl install memcached-2.2
-  - printf "\n" | pecl install imagick-3.4
+  - printf "\n" | pecl install mongo-1.6.14
+  - printf "\n" | pecl install memcached-2.2.0
+  - printf "\n" | pecl install imagick-3.4.3
   - pecl list
 before_script:
   - phpenv config-add tests/travis-php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_install:
   - printf "\n" | pecl install --force mongo
   - printf "\n" | pecl install --force mongodb
   - printf "\n" | pecl install --force memcached-2.2.0
-  - printf "\n" | pecl install apcu-4.0.10
   - printf "\n" | pecl install imagick-3.4.0RC2
+  - pecl list
 before_script:
   - phpenv config-add tests/travis-php.ini
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ before_install:
   - sudo add-apt-repository -y ppa:moti-p/cc
   - sudo apt-get update
   - sudo apt-get -y --reinstall install imagemagick
-  - printf "\n" | pecl install --force mongo
-  - printf "\n" | pecl install --force mongodb
-  - printf "\n" | pecl install --force memcached-2.2.0
-  - printf "\n" | pecl install imagick-3.4.0RC2
+  - printf "\n" | pecl install mongo-1.6.14
+  - printf "\n" | pecl install memcached-2.2.0
+  - printf "\n" | pecl install imagick-3.4.3
   - pecl list
 before_script:
   - phpenv config-add tests/travis-php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ services:
   - mongodb
   - memcached
 before_install:
+  - pecl list
   - sudo add-apt-repository -y ppa:moti-p/cc
   - sudo apt-get update
   - sudo apt-get -y --reinstall install imagemagick

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: php
 php:
   - 5.6
-  - 7.0
-matrix:
-  allow_failures:
-    - php: 7.0
 notifications:
   irc:
     use_notice: true

--- a/tests/behat/features/image-transformations.feature
+++ b/tests/behat/features/image-transformations.feature
@@ -77,8 +77,8 @@ Feature: Imbo enables dynamic transformations of images
             | strip                                                                                             | 599   | 417    |
             | thumbnail                                                                                         | 50    | 50     |
             | thumbnail:width=40,height=30                                                                      | 40    | 30     |
-            | thumbnail:width=40,height=40,fit=inset                                                            | 40    | 27     |
-            | thumbnail:width=10,height=70,fit=inset                                                            | 10    | 6      |
+            | thumbnail:width=40,height=40,fit=inset                                                            | 40    | 27±1   |
+            | thumbnail:width=10,height=70,fit=inset                                                            | 10    | 6±1    |
             | transpose                                                                                         | 417   | 599    |
             | transverse                                                                                        | 417   | 599    |
             | graythumb:width=40,height=40                                                                      | 40    | 40     |

--- a/tests/phpunit/ImboIntegrationTest/Image/Transformation/ThumbnailTest.php
+++ b/tests/phpunit/ImboIntegrationTest/Image/Transformation/ThumbnailTest.php
@@ -51,7 +51,8 @@ class ThumbnailTest extends TransformationTests {
             'only fit (inset)' => [
                 'params' => ['fit' => 'inset'],
                 'width'  => 50,
-                'height' => 34
+                'height' => 34,
+                'diff'   => 1,
             ],
             'only fit (outbound)' => [
                 'params' => ['fit' => 'outbound'],
@@ -61,7 +62,8 @@ class ThumbnailTest extends TransformationTests {
             'all params (inset)' => [
                 'params' => ['width' => 123, 'height' => 456, 'fit' => 'inset'],
                 'width'  => 123,
-                'height' => 85
+                'height' => 85,
+                'diff'   => 1,
             ],
             'all params (outbound)' => [
                 'params' => ['width' => 123, 'height' => 456, 'fit' => 'outbound'],
@@ -75,10 +77,14 @@ class ThumbnailTest extends TransformationTests {
      * @dataProvider getThumbnailParams
      * @covers Imbo\Image\Transformation\Thumbnail::transform
      */
-    public function testCanTransformImage($params, $width, $height) {
+    public function testCanTransformImage($params, $width, $height, $diff = 0) {
         $image = $this->getMock('Imbo\Model\Image');
-        $image->expects($this->once())->method('setWidth')->with($width)->will($this->returnValue($image));
-        $image->expects($this->once())->method('setHeight')->with($height)->will($this->returnValue($image));
+        $image->expects($this->once())->method('setWidth')->with($this->callback(function($actual) use ($width, $diff) {
+            return ($actual >= ($width - $diff)) && ($actual <= ($width + $diff));
+        }))->will($this->returnValue($image));
+        $image->expects($this->once())->method('setHeight')->with($this->callback(function($actual) use ($height, $diff) {
+            return ($actual >= ($height - $diff)) && ($actual <= ($height + $diff));
+        }))->will($this->returnValue($image));
         $image->expects($this->once())->method('hasBeenTransformed')->with(true)->will($this->returnValue($image));
 
         $event = $this->getMock('Imbo\EventManager\Event');


### PR DESCRIPTION
Currently Travis-CI does not build the `imbo-2.x` branch, which it should. Also, Travis-CI currently fails for `master`, which is now the same as `imbo-2.x`.