### PR TITLE
Mark Imbo\Image\Identifier\Generator\Md5 as deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-dist: trusty
 php:
   - 5.6
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 php:
   - 5.6
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 php:
   - 5.6
 notifications:
@@ -8,21 +9,15 @@ notifications:
     channels: ["irc.freenode.org#imbo"]
 branches:
   only:
-    - develop
-    - master
     - imbo-2.x
 services:
   - mongodb
   - memcached
 before_install:
   - pecl list
-  - sudo add-apt-repository -y ppa:moti-p/cc
-  - sudo apt-get update
-  - sudo apt-get -y --reinstall install imagemagick
-  - printf "\n" | pecl install mongo-1.6.14
-  - printf "\n" | pecl install memcached-2.2.0
-  - printf "\n" | pecl install imagick-3.4.3
-  - pecl list
+  - php -i
+  - printf "\n" | pecl install --force mongodb
+  - printf "\n" | pecl install imagick
 before_script:
   - phpenv config-add tests/travis-php.ini
   - composer self-update

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -9,6 +9,13 @@ If you did a :ref:`git clone <git-clone>` you could simply do a ``git pull`` to 
 
 From time to time Imbo will introduce new features or fix bugs that might require you to update the contents of the database you choose to use. This chapter will contain all information you need to keep your installation up to date. Each of the following sections include the necessary steps you need to execute when upgrading to the different versions.
 
+Imbo-2.3.0
+----------
+
+The following classes have been deprecated, and will be removed in Imbo-3.0.0:
+
+* ``Imbo\Image\Identifier\Generator\Md5``
+
 Imbo-2.0.0
 ----------
 
@@ -65,7 +72,7 @@ MySQL
     ALTER TABLE storage_images CHANGE `publicKey` `user` varchar(255) COLLATE utf8_danish_ci NOT NULL;
     ALTER TABLE storage_image_variations CHANGE `publicKey` `user` varchar(255) COLLATE utf8_danish_ci NOT NULL;
 
-.. note:: The ``imagevariations`` and ``storage_image_variations`` table might not be present in your database unless you previously upgraded to 1.2.4. In this case, skip the queries affecting those tables and instead follow the instructions specified in the :ref:`database-setup` section.
+.. note:: The ``imagevariations`` and ``storage_image_variations`` tables might not be present in your database unless you previously upgraded to 1.2.4. In this case, skip the queries affecting those tables and instead follow the instructions specified in the :ref:`database-setup` section.
 
 MongoDB
 ~~~~~~~

--- a/library/Imbo/Image/Identifier/Generator/Md5.php
+++ b/library/Imbo/Image/Identifier/Generator/Md5.php
@@ -21,6 +21,13 @@ use Imbo\Model\Image;
  */
 class Md5 implements GeneratorInterface {
     /**
+     * Class constructor
+     */
+    public function __construct() {
+        trigger_error(sprintf('"%s" is deprecated and will be removed in Imbo-3', __CLASS__), E_USER_DEPRECATED);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function generate(Image $image) {

--- a/tests/behat/imbo-configs/image-identifier-md5.php
+++ b/tests/behat/imbo-configs/image-identifier-md5.php
@@ -13,6 +13,6 @@
  */
 return [
     'imageIdentifierGenerator' => function() {
-        return new Imbo\Image\Identifier\Generator\Md5();
+        return @new Imbo\Image\Identifier\Generator\Md5();
     }
 ];

--- a/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/Md5Test.php
+++ b/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/Md5Test.php
@@ -22,7 +22,10 @@ class Md5Test extends \PHPUnit_Framework_TestCase {
         $image = $this->getMock('Imbo\Model\Image');
         $image->expects($this->any())->method('getBlob')->will($this->returnValue('foobar'));
 
-        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
+        $this->setExpectedException(
+            'PHPUnit_Framework_Error_Deprecated',
+            '"Imbo\Image\Identifier\Generator\Md5" is deprecated and will be removed in Imbo-3'
+        );
         $generator = new Md5Generator();
 
         // Make sure it generates the same MD5 every time

--- a/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/Md5Test.php
+++ b/tests/phpunit/ImboUnitTest/Image/Identifier/Generator/Md5Test.php
@@ -22,6 +22,7 @@ class Md5Test extends \PHPUnit_Framework_TestCase {
         $image = $this->getMock('Imbo\Model\Image');
         $image->expects($this->any())->method('getBlob')->will($this->returnValue('foobar'));
 
+        $this->setExpectedException('PHPUnit_Framework_Error_Deprecated');
         $generator = new Md5Generator();
 
         // Make sure it generates the same MD5 every time


### PR DESCRIPTION
Deprecate `Imbo\Image\Identifier\Generator\Md5` from Imbo-2.3.