### PR TITLE
Add clip path transformation

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -203,6 +203,7 @@ $defaultConfig = [
         'blur' => 'Imbo\Image\Transformation\Blur',
         'border' => 'Imbo\Image\Transformation\Border',
         'canvas' => 'Imbo\Image\Transformation\Canvas',
+        'clip' => 'Imbo\Image\Transformation\Clip',
         'compress' => 'Imbo\Image\Transformation\Compress',
         'contrast' => 'Imbo\Image\Transformation\Contrast',
         'convert' => 'Imbo\Image\Transformation\Convert',

--- a/src/Image/Transformation/Clip.php
+++ b/src/Image/Transformation/Clip.php
@@ -10,11 +10,12 @@
 
 namespace Imbo\Image\Transformation;
 
-use Imbo\Exception\TransformationException,
+use Imbo\Exception\InvalidArgumentException,
+    Imbo\Exception\TransformationException,
     ImagickException;
 
 /**
- * Clip transformation
+ * Clip transformation for making an image transparent outside of a clipping mask
  *
  * @author Mats Lindh <mats@lindh.no>
  * @package Image\Transformations
@@ -28,7 +29,22 @@ class Clip extends Transformation {
 
         if (!empty($params['name'])) {
             $pathName = $params['name'];
+
+            $metadata = $this->event->getDatabase()->getMetadata(
+                $this->image->getUser(),
+                $this->image->getImageIdentifier()
+            );
+
+            if (empty($metadata['paths']) || !is_array($metadata['paths']) || !in_array($pathName, $metadata['paths'])) {
+                if (isset($params['ignoreUnknownPath'])) {
+                    return;
+                }
+
+                throw new InvalidArgumentException('Selected clipping path "' . $pathName . '" was not found in the image. Add the ignoreUnknownPath argument if you want to ignore this error.', 400);
+            }
         }
+
+        $currentAlphaChannelMode = $this->imagick->getImageAlphaChannel();
 
         try {
             $this->imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
@@ -44,8 +60,10 @@ class Clip extends Transformation {
 
             $this->imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
         } catch (ImagickException $e) {
-            // NoClipPathDefined - the image doesn't have a clip path, but this isn't an fatal error.
+            // NoClipPathDefined - the image doesn't have a clipping path, but this isn't a fatal error.
             if ($e->getCode() == 410) {
+                // but we need to reset the alpha channel mode in case someone else is doing something with it
+                $this->imagick->setImageAlphaChannel($currentAlphaChannelMode);
                 return;
             }
 

--- a/src/Image/Transformation/Clip.php
+++ b/src/Image/Transformation/Clip.php
@@ -73,7 +73,6 @@ class Clip extends Transformation {
             throw new TransformationException($e->getMessage(), 400, $e);
         }
 
-
         $this->image->hasBeenTransformed(true);
     }
 }

--- a/src/Image/Transformation/Clip.php
+++ b/src/Image/Transformation/Clip.php
@@ -63,7 +63,10 @@ class Clip extends Transformation {
             // NoClipPathDefined - the image doesn't have a clipping path, but this isn't a fatal error.
             if ($e->getCode() == 410) {
                 // but we need to reset the alpha channel mode in case someone else is doing something with it
-                $this->imagick->setImageAlphaChannel($currentAlphaChannelMode);
+                if ($currentAlphaChannelMode) {
+                    $this->imagick->setImageAlphaChannel($currentAlphaChannelMode);
+                }
+
                 return;
             }
 

--- a/src/Image/Transformation/Clip.php
+++ b/src/Image/Transformation/Clip.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace Imbo\Image\Transformation;
+
+use Imbo\Exception\TransformationException,
+    ImagickException;
+
+/**
+ * Clip transformation
+ *
+ * @author Mats Lindh <mats@lindh.no>
+ * @package Image\Transformations
+ */
+class Clip extends Transformation {
+    /**
+     * {@inheritdoc}
+     */
+    public function transform(array $params) {
+        try {
+            $this->imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
+            $this->imagick->clipImage();
+            $this->imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
+        } catch (ImagickException $e) {
+            throw new TransformationException($e->getMessage(), 400, $e);
+        }
+
+
+        $this->image->hasBeenTransformed(true);
+    }
+}

--- a/src/Image/Transformation/Clip.php
+++ b/src/Image/Transformation/Clip.php
@@ -29,6 +29,11 @@ class Clip extends Transformation {
             $this->imagick->clipImage();
             $this->imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
         } catch (ImagickException $e) {
+            // NoClipPathDefined - the image doesn't have a clip path, but this isn't an fatal error.
+            if ($e->getCode() == 410) {
+                return;
+            }
+
             throw new TransformationException($e->getMessage(), 400, $e);
         }
 

--- a/src/Image/Transformation/Clip.php
+++ b/src/Image/Transformation/Clip.php
@@ -24,9 +24,24 @@ class Clip extends Transformation {
      * {@inheritdoc}
      */
     public function transform(array $params) {
+        $pathName = null;
+
+        if (!empty($params['name'])) {
+            $pathName = $params['name'];
+        }
+
         try {
             $this->imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_TRANSPARENT);
-            $this->imagick->clipImage();
+
+            // since the implementation of clipImage in ImageMagick is
+            //     return(ClipImagePath(image,"#1",MagickTrue,exception));
+            // .. this should be the same by setting inside=true.
+            if ($pathName) {
+                $this->imagick->clipImagePath($pathName, true);
+            } else {
+                $this->imagick->clipImage();
+            }
+
             $this->imagick->setImageAlphaChannel(\Imagick::ALPHACHANNEL_OPAQUE);
         } catch (ImagickException $e) {
             // NoClipPathDefined - the image doesn't have a clip path, but this isn't an fatal error.

--- a/tests/behat/features/image-transformations.feature
+++ b/tests/behat/features/image-transformations.feature
@@ -32,6 +32,7 @@ Feature: Imbo enables dynamic transformations of images
             | border:mode=inline,width=4,height=5          | 599   | 417    |
             | canvas                                       | 599   | 417    |
             | canvas:width=700,height=600                  | 700   | 600    |
+            | clip                                         | 599   | 417    |
             | contrast                                     | 599   | 417    |
             | contrast:sharpen:-1                          | 599   | 417    |
             | contrast:sharpen:1                           | 599   | 417    |

--- a/tests/phpunit/unit/Image/Transformation/ClipTest.php
+++ b/tests/phpunit/unit/Image/Transformation/ClipTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * This file is part of the Imbo package
+ *
+ * (c) Christer Edvartsen <cogo@starzinger.net>
+ *
+ * For the full copyright and license information, please view the LICENSE file that was
+ * distributed with this source code.
+ */
+
+namespace ImboUnitTest\Image\Transformation;
+
+use Imbo\Exception\InvalidArgumentException,
+    Imbo\Image\Transformation\Clip,
+    Imbo\Model\Image;
+
+/**
+ * @covers Clip
+ * @group unit
+ * @group transformations
+ */
+class ClipTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * @var Clip
+     */
+    private $transformation;
+
+    /**
+     * @var Image
+     */
+    private $image;
+
+    /**
+     * Imagick instance for testing
+     *
+     * @var \Imagick
+     */
+    private $imagick;
+
+    /**
+     * Set up the transformation instance
+     */
+    public function setUp() {
+        $this->transformation = new Clip();
+
+        $user = 'user';
+        $imageIdentifier = 'imageIdentifier';
+        $blob = file_get_contents(FIXTURES_DIR . '/jpeg-with-multiple-paths.jpg');
+
+        $this->image = $this->createMock('Imbo\Model\Image');
+        $this->image->expects($this->any())->method('getImageIdentifier')->will($this->returnValue($imageIdentifier));
+        $this->image->expects($this->any())->method('getUser')->will($this->returnValue($user));
+
+        $database = $this->createMock('Imbo\Database\DatabaseInterface');
+        $database->expects($this->any())->method('getMetadata')->with($user, $imageIdentifier)->will($this->returnValue([
+            'paths' => ['House', 'Panda'],
+        ]));
+
+        $event = $this->createMock('Imbo\EventManager\Event');
+        $event->expects($this->any())->method('getDatabase')->will($this->returnValue($database));
+
+        $this->transformation->setEvent($event);
+        $this->transformation->setImage($this->image);
+
+        $this->imagick = new \Imagick();
+        $this->imagick->readImageBlob($blob);
+        $this->transformation->setImagick($this->imagick);
+    }
+
+    /**
+     * Tear down the transformation instance
+     */
+    public function tearDown() {
+        $this->transformation = null;
+    }
+
+    /**
+     * @covers Clip::transform
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessageRegExp #clipping path .* not found#
+     */
+    public function testExceptionIfMissingNamedPath() {
+        $this->transformation->transform(['name' => 'foo']);
+    }
+
+    /**
+     * @covers Clip::transform
+     */
+    public function testNoExceptionIfMissingNamedPathButIgnoreSet() {
+        $this->transformation->transform(['name' => 'foo', 'ignoreUnknownPath' => '']);
+    }
+
+    /**
+     * @covers Clip::transform
+     */
+    public function testTransformationHappensWithMatchingPath() {
+        $this->image->expects($this->atLeastOnce())->method('hasBeenTransformed')->with(true);
+        $this->transformation->transform(['name' => 'Panda']);
+    }
+
+    /**
+     * @covers Clip::transform
+     */
+    public function testTransformationHappensWithoutExplicitPath() {
+        $this->image->expects($this->atLeastOnce())->method('hasBeenTransformed')->with(true);
+        $this->transformation->transform([]);
+    }
+
+    /**
+     * @covers Clip::transform
+     */
+    public function testTransformationDoesntHappenWhenNoPathIsPresent() {
+        $this->imagick->readImageBlob(file_get_contents(FIXTURES_DIR . '/image.jpg'));
+        $this->image->expects($this->never())->method('hasBeenTransformed');
+
+        $this->transformation->transform([]);
+    }
+
+}

--- a/tests/phpunit/unit/Image/Transformation/ClipTest.php
+++ b/tests/phpunit/unit/Image/Transformation/ClipTest.php
@@ -163,7 +163,7 @@ class ClipTest extends \PHPUnit_Framework_TestCase {
         $imagick
             ->expects($this->once())
             ->method('setImageAlphaChannel')
-            ->withConsecutive([Imagick::ALPHACHANNEL_TRANSPARENT]);
+            ->with(Imagick::ALPHACHANNEL_TRANSPARENT);
 
         $imagick
             ->expects($this->once())


### PR DESCRIPTION
Adds a transformation to use an embedded clipping path from an image's metadata to define transparent areas in a file format that does not support transparency (i.e. as metadata in a JPEG).

Since Imagick throws an exception if no clipping path is found, the exception is caught and the error code checked, before just continuing if there is no path defined (and not setting `hasBeenTransformed`, since the image hasn't been touched).