### PR TITLE
Change parameter name in image transformations

### DIFF
--- a/docs/usage/image-transformations.rst
+++ b/docs/usage/image-transformations.rst
@@ -339,13 +339,13 @@ The most common ICC profiles can be downloaded directly from `the ICC's page for
 
 **Parameters:**
 
-``name``
+``profile``
     The name of the profile to apply as defined in the configuration file when adding the transformation.
 
 **Examples:**
 
 * ``t[]=icc``
-* ``t[]=icc:name=srgb``
+* ``t[]=icc:profile=srgb``
 
 .. _levels-transformation:
 

--- a/src/Image/Transformation/Clip.php
+++ b/src/Image/Transformation/Clip.php
@@ -27,8 +27,8 @@ class Clip extends Transformation {
     public function transform(array $params) {
         $pathName = null;
 
-        if (!empty($params['name'])) {
-            $pathName = $params['name'];
+        if (!empty($params['path'])) {
+            $pathName = $params['path'];
 
             $metadata = $this->event->getDatabase()->getMetadata(
                 $this->image->getUser(),

--- a/src/Image/Transformation/Icc.php
+++ b/src/Image/Transformation/Icc.php
@@ -20,9 +20,9 @@ use Imbo\Exception\ConfigurationException,
  *
  * The transformation is not enabled by default, but can be added to the list of transformations in
  * your custom configuration. The transformation requires a list of key => .icc-file pairs, and
- * exposes these profiles through the `name` parameter given for the transformation.
+ * exposes these profiles through the `profile` parameter given for the transformation.
  *
- * The `default` key in the array is used if no profile name is given when
+ * The `default` key in the array is used if no profile is given when
  * the transformation is invoked.
  *
  *      'transformations' => [
@@ -47,8 +47,8 @@ class Icc extends Transformation {
      * Class constructor
      *
      * @param array $profiles An associative array where the keys are profile names that can be used
-     *                        with the `name` parameter for the transformation, and the values are
-     *                        paths to the profiles themselves.
+     *                        with the `profile` parameter for the transformation, and the values
+     *                        are paths to the profiles themselves.
      */
     public function __construct($profiles) {
         if (!is_array($profiles)) {
@@ -62,16 +62,16 @@ class Icc extends Transformation {
      * {@inheritdoc}
      */
     public function transform(array $params) {
-        if (empty($params['name']) && empty($this->profiles['default'])) {
-            throw new InvalidArgumentException('No name given for ICC profile to use and no profile assigned to the "default" name.', 400);
-        } else if (!empty($params['name']) && empty($this->profiles[$params['name']])) {
-            throw new InvalidArgumentException('The given ICC profile alias ("' . $params['name'] . '") is unknown to the server.', 400);
+        if (empty($params['profile']) && empty($this->profiles['default'])) {
+            throw new InvalidArgumentException('No profile name given for which ICC profile to use and no profile is assigned to the "default" name.', 400);
+        } else if (!empty($params['profile']) && empty($this->profiles[$params['profile']])) {
+            throw new InvalidArgumentException('The given ICC profile name ("' . $params['profile'] . '") is unknown to the server.', 400);
         }
 
-        $file = empty($params['name']) ? $this->profiles['default'] : $this->profiles[$params['name']];
+        $file = empty($params['profile']) ? $this->profiles['default'] : $this->profiles[$params['profile']];
 
         if (!file_exists($file)) {
-            throw new ConfigurationException('Could not load ICC profile referenced by "' . (!empty($params['name']) ? $params['name'] : 'default') . '": ' . $file, 500);
+            throw new ConfigurationException('Could not load ICC profile referenced by "' . (!empty($params['profile']) ? $params['profile'] : 'default') . '": ' . $file, 500);
         }
 
         $iccProfile = file_get_contents($file);

--- a/tests/phpunit/unit/Image/Transformation/ClipTest.php
+++ b/tests/phpunit/unit/Image/Transformation/ClipTest.php
@@ -83,14 +83,14 @@ class ClipTest extends \PHPUnit_Framework_TestCase {
      *
      */
     public function testExceptionIfMissingNamedPath() {
-        $this->transformation->transform(['name' => 'foo']);
+        $this->transformation->transform(['path' => 'foo']);
     }
 
     /**
      * @covers ::transform
      */
     public function testNoExceptionIfMissingNamedPathButIgnoreSet() {
-        $this->transformation->transform(['name' => 'foo', 'ignoreUnknownPath' => '']);
+        $this->transformation->transform(['path' => 'foo', 'ignoreUnknownPath' => '']);
     }
 
     /**
@@ -98,7 +98,7 @@ class ClipTest extends \PHPUnit_Framework_TestCase {
      */
     public function testTransformationHappensWithMatchingPath() {
         $this->image->expects($this->atLeastOnce())->method('hasBeenTransformed')->with(true);
-        $this->transformation->transform(['name' => 'Panda']);
+        $this->transformation->transform(['path' => 'Panda']);
     }
 
     /**

--- a/tests/phpunit/unit/Image/Transformation/IccTest.php
+++ b/tests/phpunit/unit/Image/Transformation/IccTest.php
@@ -60,7 +60,7 @@ class IccTest extends \PHPUnit_Framework_TestCase {
     /**
      * @covers ::transform
      * @expectedException Imbo\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp #No name given for ICC profile to use and no profile#
+     * @expectedExceptionMessage No profile name given for which ICC profile to use and no profile is assigned to the "default" name.
      * @expectedExceptionCode 400
      *
      */
@@ -72,12 +72,12 @@ class IccTest extends \PHPUnit_Framework_TestCase {
     /**
      * @covers ::transform
      * @expectedException Imbo\Exception\InvalidArgumentException
-     * @expectedExceptionMessageRegExp #The given ICC profile alias.*is unknown#
+     * @expectedExceptionMessage The given ICC profile name ("foo") is unknown to the server.
      * @expectedExceptionCode 400
      */
     public function testExceptionWithInvalidName() {
         $transformation = new Icc([]);
-        $transformation->transform(['name' => 'foo']);
+        $transformation->transform(['profile' => 'foo']);
     }
 
     /**
@@ -91,7 +91,7 @@ class IccTest extends \PHPUnit_Framework_TestCase {
         $transformation->setImage($this->image);
         $this->image->expects($this->atLeastOnce())->method('hasBeenTransformed')->with(true);
 
-        $transformation->transform(['name' => 'foo']);
+        $transformation->transform(['profile' => 'foo']);
     }
 
     /**
@@ -112,6 +112,7 @@ class IccTest extends \PHPUnit_Framework_TestCase {
     /**
      * @covers ::transform
      * @expectedException Imbo\Exception\TransformationException
+     * @expectedExceptionMessage Some error
      * @expectedExceptionCode 400
      */
     public function testThrowsExceptionWhenImagickFailsWithAFatalError() {


### PR DESCRIPTION
Changes the parameter called `name` in `Imbo\Image\Transformation\Clip` and `Imbo\Image\Transformation\Icc` to `path` and `profile` respectively.