### PR TITLE
Throw exception with 503 if backend returns false

### DIFF
--- a/src/EventListener/StorageOperations.php
+++ b/src/EventListener/StorageOperations.php
@@ -54,6 +54,15 @@ class StorageOperations implements ListenerInterface {
         $imageIdentifier = $request->getImageIdentifier();
 
         $imageData = $storage->getImage($user, $imageIdentifier);
+
+        // Since the image is actually valid, this means that the backend
+        // were unable to read the image for some reason. Might be NFS
+        // that's down, web-backed storage being unavailable or something
+        // similar.
+        if ($imageData === false) {
+            throw new StorageException('Failed reading file from storage backend for user ' . $user . ', id: ' . $imageIdentifier, 503);
+        }
+
         $lastModified = $storage->getLastModified($user, $imageIdentifier);
 
         $response->setLastModified($lastModified)

--- a/tests/phpunit/unit/EventListener/StorageOperationsTest.php
+++ b/tests/phpunit/unit/EventListener/StorageOperationsTest.php
@@ -95,6 +95,17 @@ class StorageOperationsTest extends ListenerTests {
     }
 
     /**
+     * @expectedException Imbo\Exception\StorageException
+     * @expectedExceptionCode 503
+     * @expectedExceptionMessage Failed reading file from storage backend
+     * @covers Imbo\EventListener\StorageOperations::loadImage
+     */
+    public function testExceptionIfLoadImageFails() {
+        $this->storage->expects($this->once())->method('getImage')->with($this->user, $this->imageIdentifier)->will($this->returnValue(false));
+        $this->listener->loadImage($this->event);
+    }
+
+    /**
      * @covers Imbo\EventListener\StorageOperations::insertImage
      */
     public function testCanInsertImage() {


### PR DESCRIPTION
If a storage backend returns false (i.e. it was unable to read the image for some reason), we should throw an exception with a 503 error code to avoid upstream caches keeping the response around.

Should fix #591.