### PR TITLE
Use more entropy with uniqid to avoid generating duplicate ids

### DIFF
--- a/tests/phpunit/integration/Database/DatabaseTests.php
+++ b/tests/phpunit/integration/Database/DatabaseTests.php
@@ -1548,12 +1548,12 @@ abstract class DatabaseTests extends PHPUnit_Framework_TestCase {
             ],
             'images with different users' => [
                 'images' => [
-                    ['user' => 'user1', 'imageIdentifier' => uniqid()] + $image,
-                    ['user' => 'user3', 'imageIdentifier' => uniqid()] + $image,
-                    ['user' => 'user1', 'imageIdentifier' => uniqid()] + $image,
-                    ['user' => 'user2', 'imageIdentifier' => uniqid()] + $image,
-                    ['user' => 'user2', 'imageIdentifier' => uniqid()] + $image,
-                    ['user' => 'user2', 'imageIdentifier' => uniqid()] + $image,
+                    ['user' => 'user1', 'imageIdentifier' => uniqid('imbo-', true)] + $image,
+                    ['user' => 'user3', 'imageIdentifier' => uniqid('imbo-', true)] + $image,
+                    ['user' => 'user1', 'imageIdentifier' => uniqid('imbo-', true)] + $image,
+                    ['user' => 'user2', 'imageIdentifier' => uniqid('imbo-', true)] + $image,
+                    ['user' => 'user2', 'imageIdentifier' => uniqid('imbo-', true)] + $image,
+                    ['user' => 'user2', 'imageIdentifier' => uniqid('imbo-', true)] + $image,
                 ],
                 'expectedUsers' => ['user1', 'user2', 'user3'],
             ],


### PR DESCRIPTION
This fails if PHP (since the data is validate by a unique-constraint that fails if (user, id) is not unique) using a low resolution timer by default, so the `moreentropy` flag has to be set - at least on Windows.