### PR TITLE
Backported the fixes for #491 to the 2.x branch

### DIFF
--- a/library/Imbo/Database/Doctrine.php
+++ b/library/Imbo/Database/Doctrine.php
@@ -363,7 +363,7 @@ class Doctrine implements DatabaseInterface {
             ];
 
             if ($returnMetadata) {
-                $image['metadata'] = $this->getMetadata($user, $row['imageIdentifier']);
+                $image['metadata'] = $this->getMetadata($row['user'], $row['imageIdentifier']);
             }
 
             $images[] = $image;

--- a/tests/phpunit/ImboIntegrationTest/Database/DatabaseTests.php
+++ b/tests/phpunit/ImboIntegrationTest/Database/DatabaseTests.php
@@ -404,22 +404,34 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
     }
 
     public function testGetImagesAndReturnMetadata() {
-        $this->insertImages();
+        $this->insertImages(true);
 
         $query = new Query();
         $query->returnMetadata(true);
 
-        $images = $this->adapter->getImages(['user'], $query, $this->getMock('Imbo\Model\Images'));
+        $images = $this->adapter->getImages(['user', 'user2'], $query, $this->getMock('Imbo\Model\Images'));
+        $this->assertCount(6, $images, 'Incorrect length. Expected 6, got ' . count($images));
 
         foreach ($images as $image) {
             $this->assertArrayHasKey('metadata', $image);
         }
 
+        $this->assertSame('user',  $images[0]['user']);
         $this->assertSame(['key5' => 'value5'], $images[0]['metadata']);
+
+        $this->assertSame('user2', $images[1]['user']);
         $this->assertSame(['key4' => 'value4'], $images[1]['metadata']);
+
+        $this->assertSame('user',  $images[2]['user']);
         $this->assertSame(['key3' => 'value3'], $images[2]['metadata']);
+
+        $this->assertSame('user2', $images[3]['user']);
         $this->assertSame(['key2' => 'value2'], $images[3]['metadata']);
+
+        $this->assertSame('user',  $images[4]['user']);
         $this->assertSame(['key1' => 'value1'], $images[4]['metadata']);
+
+        $this->assertSame('user2', $images[5]['user']);
         $this->assertSame(['key0' => 'value0'], $images[5]['metadata']);
 
     }


### PR DESCRIPTION
We too stumbled upon the bug that was fixed by #491. But since 3.x isn't ready yet, we don't want to update to it, just to fix the issue with loading metadata from multi-user image retrievals.

So I've back ported the fixes, with the hope that a 2.2.1-release could be made.