### PR TITLE
Doctrine adapter should sets the updated date when modifying metadata

### DIFF
--- a/library/Imbo/Database/Doctrine.php
+++ b/library/Imbo/Database/Doctrine.php
@@ -186,13 +186,11 @@ class Doctrine implements DatabaseInterface {
             ]);
         }
 
-        $update = $connection->createQueryBuilder();
-        $update->update($this->tableNames['imageinfo'])
-              ->set('updated', time())
-              ->where('id = :id')
-              ->setParameters([
-                  ':id' => $imageId,
-              ])->execute();
+        $connection->update($this->tableNames['imageinfo'], [
+            'updated' => time(),
+        ], [
+            'id' => $imageId
+        ]);
 
         return true;
     }

--- a/library/Imbo/Database/Doctrine.php
+++ b/library/Imbo/Database/Doctrine.php
@@ -186,6 +186,14 @@ class Doctrine implements DatabaseInterface {
             ]);
         }
 
+        $update = $connection->createQueryBuilder();
+        $update->update($this->tableNames['imageinfo'])
+              ->set('updated', time())
+              ->where('id = :id')
+              ->setParameters([
+                  ':id' => $imageId,
+              ])->execute();
+
         return true;
     }
 

--- a/tests/phpunit/ImboIntegrationTest/Database/DatabaseTests.php
+++ b/tests/phpunit/ImboIntegrationTest/Database/DatabaseTests.php
@@ -197,11 +197,23 @@ abstract class DatabaseTests extends \PHPUnit_Framework_TestCase {
         $user = 'user';
         $imageIdentifier = 'id';
 
-        $this->assertTrue($this->adapter->insertImage($user, $imageIdentifier, $this->getImage()));
+        $original = $this->getImage();
+        $added = time() - 10;
+        $original->setAddedDate(new DateTime('@' . $added, new DateTimeZone('UTC')));
+        $original->setUpdatedDate(new DateTime('@' . $added, new DateTimeZone('UTC')));
+        $this->assertTrue($this->adapter->insertImage($user, $imageIdentifier, $original));
+
         $this->assertTrue($this->adapter->updateMetadata($user, $imageIdentifier, ['foo' => 'bar']));
         $this->assertSame(['foo' => 'bar'], $this->adapter->getMetadata($user, $imageIdentifier));
+
         $this->assertTrue($this->adapter->updateMetadata($user, $imageIdentifier, ['foo' => 'foo', 'bar' => 'foo']));
         $this->assertSame(['foo' => 'foo', 'bar' => 'foo'], $this->adapter->getMetadata($user, $imageIdentifier));
+
+        $image = new Image();
+        $this->assertTrue($this->adapter->load($user, $imageIdentifier, $image));
+
+        $this->assertEquals($added, $image->getAddedDate()->getTimestamp(), 'Added timestamp should not be modified');
+        $this->assertEquals(time(), $image->getUpdatedDate()->getTimestamp(), 'Updated timestamp should have updated', 1);
     }
 
     public function testMetadataWithNestedArraysIsRepresetedCorrectly() {


### PR DESCRIPTION
This should fix the issue described in #530 for the 2.x branch.

I'll restart the discussion in #530 for the best way to fix it for the 3.x branch, since the strategy that was discussed then was to move the logic to a separate new method on the interface.