### PR TITLE
Added methods to update last-modified timestamp to DB interface

### DIFF
--- a/src/Database/DatabaseInterface.php
+++ b/src/Database/DatabaseInterface.php
@@ -132,6 +132,28 @@ interface DatabaseInterface {
     function getLastModified(array $users, $imageIdentifier = null);
 
     /**
+     * Update the last modified timestamp for a given image to now.
+     *
+     * @param string $user The user the image belongs to
+     * @param string $imageIdentifier The image identifier
+     * @return DateTime The date the timestamp was updated to
+     */
+    function setLastModifiedNow($user, $imageIdentifier);
+
+    /**
+     * Update the last modified timestamp for a given image
+     *
+     * Will find and modify the last modified timestamp for an image belonging
+     * to a certain user to the given timestamp.
+     *
+     * @param string $user The user the image belongs to
+     * @param string $imageIdentifier The image identifier
+     * @param DateTime $time The timestamp to set last modified to
+     * @return DateTime The date the timestamp was updated to
+     */
+    function setLastModifiedTime($user, $imageIdentifier, DateTime $time);
+
+    /**
      * Fetch the number of images, optionally filtered by a given user
      *
      * @param string $user The user which the images belongs to (pass null to count for all users)

--- a/src/Database/Doctrine.php
+++ b/src/Database/Doctrine.php
@@ -452,6 +452,35 @@ class Doctrine implements DatabaseInterface {
     /**
      * {@inheritdoc}
      */
+    public function setLastModifiedNow($user, $imageIdentifier) {
+        return $this->setLastModifiedTime($user, $imageIdentifier, new DateTime('@' . time(), new DateTimeZone('UTC')));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLastModifiedTime($user, $imageIdentifier, DateTime $time) {
+        // Fetch the current connection
+        $connection = $this->getConnection();
+
+        if (!$imageId = $this->getImageId($user, $imageIdentifier)) {
+            throw new DatabaseException('Image not found', 404);
+        }
+
+        $update = $connection->createQueryBuilder();
+        $update->update($this->tableNames['imageinfo'])
+               ->set('updated', $time->getTimestamp())
+               ->where('id = :id')
+               ->setParameters([
+                   ':id' => $imageId,
+               ])->execute();
+
+        return $time;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getNumImages($user = null) {
         $query = $this->getConnection()->createQueryBuilder();
         $query->select('COUNT(i.id)')

--- a/src/Database/MongoDB.php
+++ b/src/Database/MongoDB.php
@@ -209,7 +209,7 @@ class MongoDB implements DatabaseInterface {
 
             $this->getImageCollection()->updateOne(
                 ['user' => $user, 'imageIdentifier' => $imageIdentifier],
-                ['$set' => ['updated' => time(), 'metadata' => $updatedMetadata]]
+                ['$set' => ['metadata' => $updatedMetadata]]
             );
         } catch (MongoException $e) {
             throw new DatabaseException('Unable to update meta data', 500, $e);
@@ -433,6 +433,34 @@ class MongoDB implements DatabaseInterface {
         }
 
         return new DateTime('@' . $data['updated'], new DateTimeZone('UTC'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLastModifiedNow($user, $imageIdentifier) {
+        return $this->setLastModifiedTime($user, $imageIdentifier, new DateTime('@' . time(), new DateTimeZone('UTC')));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLastModifiedTime($user, $imageIdentifier, DateTime $time) {
+        $data = $this->getImageCollection()->findOne([
+            'user' => $user,
+            'imageIdentifier' => $imageIdentifier,
+        ]);
+
+        if ($data === null) {
+            throw new DatabaseException('Image not found', 404);
+        }
+
+        $this->getImageCollection()->updateOne(
+            ['user' => $user, 'imageIdentifier' => $imageIdentifier],
+            ['$set' => ['updated' => $time->getTimestamp()]]
+        );
+
+        return $time;
     }
 
     /**

--- a/src/EventListener/DatabaseOperations.php
+++ b/src/EventListener/DatabaseOperations.php
@@ -132,6 +132,11 @@ class DatabaseOperations implements ListenerInterface {
             $request->getUser(),
             $request->getImageIdentifier()
         );
+
+        $event->getDatabase()->setLastModifiedNow(
+            $request->getUser(),
+            $request->getImageIdentifier()
+        );
     }
 
     /**
@@ -146,6 +151,11 @@ class DatabaseOperations implements ListenerInterface {
             $request->getUser(),
             $request->getImageIdentifier(),
             $event->getArgument('metadata')
+        );
+
+        $event->getDatabase()->setLastModifiedNow(
+            $request->getUser(),
+            $request->getImageIdentifier()
         );
     }
 

--- a/tests/phpunit/unit/EventListener/DatabaseOperationsTest.php
+++ b/tests/phpunit/unit/EventListener/DatabaseOperationsTest.php
@@ -112,6 +112,7 @@ class DatabaseOperationsTest extends ListenerTests {
      */
     public function testCanDeleteMetadata() {
         $this->database->expects($this->once())->method('deleteMetadata')->with($this->user, $this->imageIdentifier);
+        $this->database->expects($this->once())->method('setLastModifiedNow')->with($this->user, $this->imageIdentifier);
 
         $this->listener->deleteMetadata($this->event);
     }
@@ -122,6 +123,7 @@ class DatabaseOperationsTest extends ListenerTests {
     public function testCanUpdateMetadata() {
         $this->event->expects($this->once())->method('getArgument')->with('metadata')->will($this->returnValue(['key' => 'value']));
         $this->database->expects($this->once())->method('updateMetadata')->with($this->user, $this->imageIdentifier, ['key' => 'value']);
+        $this->database->expects($this->once())->method('setLastModifiedNow')->with($this->user, $this->imageIdentifier);
 
         $this->listener->updateMetadata($this->event);
     }


### PR DESCRIPTION
This moves the responsibility for updating the last-modified timestamp away from the update-metadata functionality,
and makes it into an explicit action performed by the database-operations event-listener

This is in reference to #530, where the behaviour between the Doctrine and Mongo implementation were different.