### PR TITLE
Allow compress to be invoked directly

### DIFF
--- a/src/Http/Response/ResponseFormatter.php
+++ b/src/Http/Response/ResponseFormatter.php
@@ -275,6 +275,13 @@ class ResponseFormatter implements ListenerInterface {
                 $outputConverterManager->supportsExtension($this->formatter)
             ) {
                 $outputConverterManager->convert($model, $this->formatter);
+            // for clarity - if we just have a requested compression / quality value, we still have to invoke the
+            // conversion / writer for the existing format
+            } else if (
+                $model->getOutputQualityCompression() &&
+                $outputConverterManager->supportsExtension($this->formatter)
+            ) {
+                $outputConverterManager->convert($model, $this->formatter);
             }
 
             // Finished transforming the image

--- a/src/Image/OutputConverter/Basic.php
+++ b/src/Image/OutputConverter/Basic.php
@@ -39,6 +39,14 @@ class Basic implements OutputConverterInterface {
     public function convert(Imagick $imagick, Image $image, $extension, $mimeType) {
         try {
             $imagick->setImageFormat($extension);
+
+            // Levels from 0 - 100 will work for both JPEG and PNG, although the level has different
+            // meaning for these two image types. For PNG's a high level will mean more compression,
+            // which usually results in a smaller file size, as for JPEG's, a high level means a
+            // higher quality, resulting in a larger file size.
+            if ($image->getOutputQualityCompression() !== null && ($mimeType !== 'image/gif')) {
+                $imagick->setImageCompressionQuality($image->getOutputQualityCompression());
+            }
         } catch (ImagickException $e) {
             throw new OutputConverterException($e->getMessage(), 400, $e);
         }

--- a/src/Image/Transformation/Compress.php
+++ b/src/Image/Transformation/Compress.php
@@ -21,61 +21,11 @@ use Imbo\Exception\TransformationException,
  * @author Christer Edvartsen <cogo@starzinger.net>
  * @package Image\Transformations
  */
-class Compress extends Transformation implements ListenerInterface {
+class Compress extends Transformation {
     /**
      * @var int
      */
     private $level;
-
-    /**
-     * Whether we've been registered as an event listener or not - event listeners are invoked at the end of the
-     * request. If we haven't, we perform the transformation when the transform method is called instead.
-     *
-     * @var boolean
-     */
-    private static $registeredAsEventListener = false;
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function getSubscribedEvents() {
-        self::$registeredAsEventListener = true;
-
-        return [
-            'image.transformed' => 'compress',
-        ];
-    }
-
-    /**
-     * Apply the compression
-     *
-     * @param EventInterface $event The event instance
-     */
-    public function compress(EventInterface $event) {
-        if ($this->level === null) {
-            return;
-        }
-
-        $image = $event->hasArgument('image') ? $event->getArgument('image') : $this->image;
-        $mimeType = $image->getMimeType();
-
-        if ($mimeType === 'image/gif') {
-            // No need to do anything if the image is a GIF
-            return;
-        }
-
-        try {
-            // Levels from 0 - 100 will work for both JPEG and PNG, although the level has different
-            // meaning for these two image types. For PNG's a high level will mean more compression,
-            // which usually results in a smaller file size, as for JPEG's, a high level means a
-            // higher quality, resulting in a larger file size.
-            $this->imagick->setImageCompressionQuality($this->level);
-        } catch (ImagickException $e) {
-            throw new TransformationException($e->getMessage(), 400, $e);
-        }
-
-        $image->hasBeenTransformed(true);
-    }
 
     /**
      * {@inheritdoc}
@@ -91,10 +41,7 @@ class Compress extends Transformation implements ListenerInterface {
             throw new TransformationException('level must be between 0 and 100', 400);
         }
 
-        if (!self::$registeredAsEventListener) {
-            $this->compress($this->event);
-        }
-
+        $this->image->setOutputQualityCompression($this->level);
         return $this;
     }
 }

--- a/src/Model/Image.php
+++ b/src/Model/Image.php
@@ -129,6 +129,11 @@ class Image implements ModelInterface {
     private $hasBeenTransformed = false;
 
     /**
+     * Track requested output quality compression
+     */
+    private $outputQualityCompression;
+
+    /**
      * Get the size of the image data in bytes
      *
      * @return int
@@ -422,6 +427,26 @@ class Image implements ModelInterface {
         $this->hasBeenTransformed = (bool) $flag;
 
         return $this;
+    }
+
+    /**
+     * Get the requested output quality compression or quality value
+     *
+     * @return null|int
+     */
+    public function getOutputQualityCompression() {
+        return $this->outputQualityCompression;
+    }
+
+    /**
+     * Request a specific output quality compression or quality value. The output converter for the file type must still
+     * make use of the value.
+     *
+     * @param int $outputQualityCompression  The requested compression or quality value
+     * @return null
+     */
+    public function setOutputQualityCompression($outputQualityCompression) {
+        $this->outputQualityCompression = $outputQualityCompression;
     }
 
     /**

--- a/tests/phpunit/integration/Image/Transformation/CompressTest.php
+++ b/tests/phpunit/integration/Image/Transformation/CompressTest.php
@@ -28,9 +28,7 @@ class CompressTest extends TransformationTests {
 
     public function testCanTransformTheImage() {
         $image = $this->createMock('Imbo\Model\Image');
-        $image->expects($this->once())->method('hasBeenTransformed')->with(true);
-        $image->expects($this->once())->method('getMimeType')->will($this->returnValue('image/jpeg'));
-
+        $image->expects($this->once())->method('setOutputQualityCompression')->with(50);
         $event = $this->createMock('Imbo\EventManager\Event');
 
         $imagick = new Imagick();
@@ -41,7 +39,6 @@ class CompressTest extends TransformationTests {
             ->setImagick($imagick)
             ->setImage($image)
             ->setEvent($event)
-            ->transform(['level' => 50]) // Set the correct level parameter
-            ->compress($event); // Perform the actual compression
+            ->transform(['level' => 50]);
     }
 }

--- a/tests/phpunit/unit/Image/Transformation/CompressTest.php
+++ b/tests/phpunit/unit/Image/Transformation/CompressTest.php
@@ -46,26 +46,6 @@ class CompressTest extends \PHPUnit_Framework_TestCase {
         $this->transformation->transform([]);
     }
 
-    public function testDoesNotApplyCompressionToGifImages() {
-        $image = $this->createMock('Imbo\Model\Image');
-        $image->expects($this->once())->method('getMimeType')->will($this->returnValue('image/gif'));
-
-        $imagick = $this->createMock('Imagick');
-        $imagick->expects($this->never())->method('setImageCompressionQuality');
-
-        $this->transformation->setImagick($imagick)->setImage($image)->transform(['level' => 40]);
-        $this->transformation->compress($this->createMock('Imbo\EventManager\EventInterface'));
-    }
-
-    public function testDoesNotApplyCompressionWhenLevelIsNotSet() {
-        $imagick = $this->createMock('Imagick');
-        $imagick->expects($this->never())->method('setImageCompressionQuality');
-
-        $this->transformation->setImagick($imagick)->compress(
-            $this->createMock('Imbo\EventManager\Event')
-        );
-    }
-
     /**
      * @expectedException Imbo\Exception\TransformationException
      * @expectedExceptionMessage level must be between 0 and 100


### PR DESCRIPTION
Since the implementation of the Transformation Manager framework, we're not registered as an event listener by default. This allows the compress statement to be executed at the current location in the chain as necessary.