### PR TITLE
No zoom on smartSize with crop param`full`

### DIFF
--- a/docs/usage/image-transformations.rst
+++ b/docs/usage/image-transformations.rst
@@ -562,6 +562,7 @@ The smart size transformation supports reading the POI from the metadata of the 
     ``close``
     ``medium``
     ``wide``
+    ``full``
 
 **Examples:**
 

--- a/src/Image/Transformation/SmartSize.php
+++ b/src/Image/Transformation/SmartSize.php
@@ -181,6 +181,9 @@ class SmartSize extends Transformation {
             case 'wide':
                 return 0.66;
 
+            case 'full':
+                return 1;
+
             default:
                 return 0.5;
         }
@@ -199,6 +202,9 @@ class SmartSize extends Transformation {
 
             case 'wide':
                 return 1.6;
+
+            case 'full':
+                return 2;
 
             default:
                 return 1.25;
@@ -265,7 +271,7 @@ class SmartSize extends Transformation {
                 throw new TransformationException('Invalid POI format, expected format `<x>,<y>`', 400);
             }
 
-            if (!empty($params['crop']) && in_array($params['crop'], ['close', 'medium', 'wide']) === false) {
+            if (!empty($params['crop']) && in_array($params['crop'], ['close', 'medium', 'wide', 'full']) === false) {
                 throw new TransformationException('Invalid crop value. Valid values are: close,medium,wide', 400);
             }
         }

--- a/src/Image/Transformation/SmartSize.php
+++ b/src/Image/Transformation/SmartSize.php
@@ -272,7 +272,7 @@ class SmartSize extends Transformation {
             }
 
             if (!empty($params['crop']) && in_array($params['crop'], ['close', 'medium', 'wide', 'full']) === false) {
-                throw new TransformationException('Invalid crop value. Valid values are: close,medium,wide', 400);
+                throw new TransformationException('Invalid crop value. Valid values are: close,medium,wide,full', 400);
             }
         }
 

--- a/tests/phpunit/unit/Image/Transformation/SmartSizeTest.php
+++ b/tests/phpunit/unit/Image/Transformation/SmartSizeTest.php
@@ -133,6 +133,42 @@ class SmartSizeTest extends \PHPUnit_Framework_TestCase {
                 ['width' => 800, 'height' => 1800],
                 ['width' => 800, 'height' => 300, 'poi' => '100,700', 'crop' => 'wide'],
                 ['width' => 800, 'height' => 300, 'x' => 0, 'y' => 550]
+            ],
+
+            'Square, full crop, (800,300) poi on landscape image' => [
+                ['width' => 1200, 'height' => 700],
+                ['width' => 400, 'height' => 400, 'poi' => '800,300', 'crop' => 'full'],
+                ['width' => 700, 'height' => 700, 'x' => 450, 'y' => 0]
+            ],
+
+            'Square, full crop, (0,0) poi on portrait image' => [
+                ['width' => 700, 'height' => 1200],
+                ['width' => 400, 'height' => 400, 'poi' => '0,0', 'crop' => 'full'],
+                ['width' => 700, 'height' => 700, 'x' => 0, 'y' => 0]
+            ],
+
+            'Square, full crop, (0,700) poi on portrait image' => [
+                ['width' => 700, 'height' => 1200],
+                ['width' => 400, 'height' => 400, 'poi' => '0,700', 'crop' => 'full'],
+                ['width' => 700, 'height' => 700, 'x' => 0, 'y' => 350]
+            ],
+
+            'Square, full crop, (500,500) poi on square image' => [
+                ['width' => 1200, 'height' => 1200],
+                ['width' => 400, 'height' => 400, 'poi' => '500,500', 'crop' => 'full'],
+                ['width' => 1200, 'height' => 1200, 'x' => 0, 'y' => 0]
+            ],
+
+            'Portrait, full crop, (600,300) poi on landscape image' => [
+                ['width' => 1200, 'height' => 600],
+                ['width' => 400, 'height' => 700, 'poi' => '600,300', 'crop' => 'full'],
+                ['width' => 343, 'height' => 600, 'x' => 429, 'y' => 0]
+            ],
+
+            'Panorama, full crop, (100,700) poi on portrait image' => [
+                ['width' => 800, 'height' => 1800],
+                ['width' => 800, 'height' => 300, 'poi' => '100,700', 'crop' => 'full'],
+                ['width' => 800, 'height' => 300, 'x' => 0, 'y' => 550]
             ]
         ];
     }


### PR DESCRIPTION
Hi :wave: ,

smartSize is a great transformation, but sometimes only the correct crop is needed without zoom.

With the additional crop param `full` zoom is disabled.

## Examples:

### Original
![orig](https://images.unsplash.com/photo-1522679056866-8dbbc8774a9d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&h=600&q=80)

### SmartSize with crop param `wide` 
![wide](https://images.unsplash.com/photo-1522679056866-8dbbc8774a9d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=600&h=600&q=80&fit=crop&crop=focalpoint&fp-x=.825&fp-y=.35&fp-z=1.2)

### SmartSize with crop param `full` 
![full](https://images.unsplash.com/photo-1522679056866-8dbbc8774a9d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=600&h=600&q=80&fit=crop&crop=focalpoint&fp-x=.825&fp-y=.35)