### PR TITLE
fix: Use docs.imbo.io as the URL for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Imbo is an image "server" that can be used to add/get/delete images using a REST interface. There is also support for adding meta data to an image. The main idea behind Imbo is to have a place to store high quality original images and to use the REST interface to fetch variations of those images. Imbo will resize, rotate, crop (amongst other features) on the fly so you won't have to store all the different variations.
 
 ## Installation / Configuration / Documentation
-End-user docs can be found [here](http://docs.imbo-project.org/en/latest/).
+End-user docs can be found [here](https://docs.imbo.io).
 
 ## License
 Licensed under the MIT License.


### PR DESCRIPTION
Since the old imbo-project.org domain has expired, this small PR changes the URL in the readme to the current location.